### PR TITLE
BAD-38: Override clean-all target for HDP 1.2 shim

### DIFF
--- a/hdp12/build.xml
+++ b/hdp12/build.xml
@@ -13,7 +13,12 @@
 
   <import file="../common-shims-build.xml"/>
 	
-	<target name="clean-jars" >
-	    <delete dir="${lib.provided.dir}"/>
-	  </target>
+  <target name="clean-jars" >
+	<delete dir="${lib.provided.dir}"/>
+  </target>
+
+  <!-- We need to keep the JARs in lib (they're checked in as they're not available 
+       in a repository for use by Ivy) so a clean-all should just do a clean -->
+  
+  <target name="clean-all" depends="clean" />
 </project>


### PR DESCRIPTION
clean-all targets normally wipe out the lib folder of the project, as the lib folder is normally filled by Ivy resolve tasks.  In the case of the HDP 1.2 shim, the JARs are not available to Ivy and thus we had to check them in, and we don't want to wipe out the lib folder in this case. So I just overrode the clean-all target to call clean instead.
