### PR TITLE
Pdi 10643

### DIFF
--- a/api/src/org/pentaho/hbase/shim/api/Mapping.java
+++ b/api/src/org/pentaho/hbase/shim/api/Mapping.java
@@ -514,7 +514,7 @@ public class Mapping {
 
   public boolean readRep(Repository rep, ObjectId id_step)
       throws KettleException {
-    if (Const.isEmpty(rep.getStepAttributeString(id_step, 0, "key"))) {
+    if (Const.isEmpty(rep.getStepAttributeString(id_step, 0, "key_type"))) {
       return false; // No mapping information in the repository
     }
 


### PR DESCRIPTION
PDI-10643 - changing the condition for determining there is no mapping information in the repository. Was using "key" which is always present. "key_type" is only present when the mapping information is available.
