### PR TITLE
PDI-8962 - Implementing 3 arg version of compare, toByteArray, parseFrom

### DIFF
--- a/hdp20/src/org/pentaho/hbase/shim/hdp20/DeserializedNumericComparator.java
+++ b/hdp20/src/org/pentaho/hbase/shim/hdp20/DeserializedNumericComparator.java
@@ -22,8 +22,12 @@
 
 package org.pentaho.hbase.shim.hdp20;
 
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
 import java.io.DataInput;
+import java.io.DataInputStream;
 import java.io.DataOutput;
+import java.io.DataOutputStream;
 import java.io.IOException;
 
 import org.apache.hadoop.hbase.filter.ByteArrayComparable;
@@ -118,11 +122,41 @@ public class DeserializedNumericComparator extends ByteArrayComparable {
   }
 
   public int compareTo( byte[] value, int offset, int length ) {
-    return compareTo( value );
+    return compareTo( Bytes.copy( value, offset, length ) );
   }
 
   @Override
   public byte[] toByteArray() {
-    return super.getValue();
+    ByteArrayOutputStream byteArrayOutputStream = new ByteArrayOutputStream();
+    DataOutputStream output = new DataOutputStream( byteArrayOutputStream );
+    try {
+      write( output );
+      output.close();
+      byteArrayOutputStream.close();
+      return byteArrayOutputStream.toByteArray();
+    } catch ( IOException e ) {
+      throw new RuntimeException( "Unable to serialize to byte array.", e );
+    }
+  }
+  
+  /**
+   * Needed for hbase-0.95+
+   * @throws IOException 
+   */
+  public static ByteArrayComparable parseFrom(final byte [] pbBytes) {
+    DataInput in = new DataInputStream( new ByteArrayInputStream( pbBytes ) );
+    try {
+      boolean m_isInteger = in.readBoolean();
+      boolean m_isLongOrDouble = in.readBoolean();
+      long m_longValue = in.readLong();
+      double m_doubleValue = in.readDouble();
+      if (m_isInteger) {
+        return new DeserializedNumericComparator( m_isInteger, m_isLongOrDouble, m_longValue );
+      } else {
+        return new DeserializedNumericComparator( m_isInteger, m_isLongOrDouble, m_doubleValue );
+      }
+    } catch ( IOException e ) {
+      throw new RuntimeException( "Unable to deserialize byte array", e );
+    }
   }
 }


### PR DESCRIPTION
Applied fix from PDI-10962 (the cdh50beta shim) to the hdp20 shim, both fixes are needed as both shims use HBase 95+, which changed a LOT of the API and implementation.
