### PR TITLE
[PDI-10807][SP-1096][SP-1099]: Fix PMR on Windows

### DIFF
--- a/common/src/org/pentaho/hadoop/shim/common/DistributedCacheUtilImpl.java
+++ b/common/src/org/pentaho/hadoop/shim/common/DistributedCacheUtilImpl.java
@@ -329,17 +329,13 @@ public class DistributedCacheUtilImpl implements org.pentaho.hadoop.shim.api.Dis
     // Restore the original classloader
     Thread.currentThread().setContextClassLoader( cl);
     
-    if (!version.contains("0.20")) {
-      DistributedCache.addFileToClassPath(file, conf);
-    } else {
-      String classpath = conf.get("mapred.job.classpath.files");
-      conf.set("mapred.job.classpath.files", classpath == null ? file.toString()
-          : classpath + getClusterPathSeparator() + file.toString());
-      FileSystem fs = FileSystem.get(conf);
-      URI uri = fs.makeQualified(file).toUri();
+    String classpath = conf.get("mapred.job.classpath.files");
+    conf.set("mapred.job.classpath.files", classpath == null ? file.toString()
+        : classpath + getClusterPathSeparator() + file.toString());
+    FileSystem fs = FileSystem.get(conf);
+    URI uri = fs.makeQualified(file).toUri();
 
-      DistributedCache.addCacheFile(uri, conf);
-    }
+    DistributedCache.addCacheFile(uri, conf);
   }
 
   /**


### PR DESCRIPTION
Removed conditional logic based on version number as it is fragile and incorrect for vendors' distributions. Instead default to a Linux path separator (colon). This is now overridable via the config.properties file for things like Windows clusters, or if the distro is using a version of Hadoop for which the Distributed Cache classpath separator was changed to be a comma. The latter has (so far) already been done for the appropriate shims.
