### PR TITLE
[PDI-12639] Hive/Hive2: Unable to pre-load connection to the connection pool.

### DIFF
--- a/common/src/org/pentaho/hadoop/shim/common/DriverProxyInvocationChain.java
+++ b/common/src/org/pentaho/hadoop/shim/common/DriverProxyInvocationChain.java
@@ -255,6 +255,8 @@ public class DriverProxyInvocationChain {
                 o = Boolean.FALSE;
               } else if ( "setReadOnly".equals( methodName ) ) {
                 o = (Void) null;
+              } else if ( "setAutoCommit".equals( methodName ) ) {
+                o = (Void) null;
               } else {
                 throw cause;
               }


### PR DESCRIPTION
Original hIve jdbc driver has a mess-up of the some methods implementations : 
- It always returns getAutoCommit() = true;
- it ignores setAutoCommit(false)
- it throw exception if setAutoCommit(true)

In fact it always works as usual driver with enabled autoCommit so invoke of the setAutoCommit method was overridden for ignoring behavior.
