### PR TITLE
[PDI-11959] Hadoop Job Executor: Jobs using org.apache.hadoop.mapreduce API don't work

### DIFF
--- a/api/src/org/pentaho/hadoop/shim/api/Configuration.java
+++ b/api/src/org/pentaho/hadoop/shim/api/Configuration.java
@@ -1,156 +1,158 @@
 /*******************************************************************************
-*
-* Pentaho Big Data
-*
-* Copyright (C) 2002-2013 by Pentaho : http://www.pentaho.com
-*
-*******************************************************************************
-*
-* Licensed under the Apache License, Version 2.0 (the "License");
-* you may not use this file except in compliance with
-* the License. You may obtain a copy of the License at
-*
-*    http://www.apache.org/licenses/LICENSE-2.0
-*
-* Unless required by applicable law or agreed to in writing, software
-* distributed under the License is distributed on an "AS IS" BASIS,
-* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-* See the License for the specific language governing permissions and
-* limitations under the License.
-*
-******************************************************************************/
+ *
+ * Pentaho Big Data
+ *
+ * Copyright (C) 2002-2013 by Pentaho : http://www.pentaho.com
+ *
+ *******************************************************************************
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ******************************************************************************/
 
 package org.pentaho.hadoop.shim.api;
 
 import org.pentaho.hadoop.shim.api.fs.Path;
 
 /**
- * A thin abstraction for {@link org.apache.hadoop.mapred.JobConf} (and
- * consequently {@link org.apache.hadoop.conf.Configuration}). Most of the methods
- * here are a direct wrapping for methods found in {@link org.apache.hadoop.mapred.JobConf}
- * and the documentation there should be considered when providing an implementation.
- * 
+ * A thin abstraction for {@link org.apache.hadoop.mapred.JobConf} (and consequently {@link
+ * org.apache.hadoop.conf.Configuration}). Most of the methods here are a direct wrapping for methods found in {@link
+ * org.apache.hadoop.mapred.JobConf} and the documentation there should be considered when providing an implementation.
+ *
  * @author Jordan Ganoff (jganoff@pentaho.com)
  */
 public interface Configuration {
 
   /**
-   * Property for indicating a Pentaho MapReduce combiner should execute in
-   * single threaded mode.
+   * Property for indicating a Pentaho MapReduce combiner should execute in single threaded mode.
    */
   public static final String STRING_COMBINE_SINGLE_THREADED = "transformation-combine-single-threaded";
 
   /**
-   * Property for indicating a Pentaho MapReduce reduce should execute in
-   * single threaded mode.
+   * Property for indicating a Pentaho MapReduce reduce should execute in single threaded mode.
    */
   public static final String STRING_REDUCE_SINGLE_THREADED = "transformation-reduce-single-threaded";
 
   /**
    * Sets the MapReduce job name.
-   * 
+   *
    * @param jobName Name of job
    */
-  void setJobName(String jobName);
+  void setJobName( String jobName );
 
   /**
    * Sets the property {@code name}'s value to {@code value}.
-   * 
-   * @param name Name of property
+   *
+   * @param name  Name of property
    * @param value Value of property
    */
-  void set(String name, String value);
+  void set( String name, String value );
 
   /**
    * Look up the value of a property.
-   * 
+   *
    * @param name Name of property
    * @return Value of the property named {@code name}
    */
-  String get(String name);
+  String get( String name );
 
   /**
-   * Look up the value of a property optionally returning a default value if 
-   * the property is not set.
-   * 
-   * @param name Name of property
+   * Look up the value of a property optionally returning a default value if the property is not set.
+   *
+   * @param name         Name of property
    * @param defaultValue Value to return if the property is not set
    * @return Value of property named {@code name} or {@code defaultValue} if {@code name} is not set
    */
-  String get(String name, String defaultValue);
+  String get( String name, String defaultValue );
 
   /**
    * Set the key class for the map output data.
-   * 
+   *
    * @param c the map output key class
    */
-  void setMapOutputKeyClass(Class<?> c);
+  void setMapOutputKeyClass( Class<?> c );
 
   /**
    * Set the value class for the map output data.
-   * 
+   *
    * @param c the map output value class
    */
-  void setMapOutputValueClass(Class<?> c);
+  void setMapOutputValueClass( Class<?> c );
 
-  void setMapperClass(Class<?> c);
+  void setMapperClass( Class<?> c );
 
-  void setCombinerClass(Class<?> c);
+  void setCombinerClass( Class<?> c );
 
-  void setReducerClass(Class<?> c);
+  void setReducerClass( Class<?> c );
 
-  void setOutputKeyClass(Class<?> c);
+  void setOutputKeyClass( Class<?> c );
 
-  void setOutputValueClass(Class<?> c);
+  void setOutputValueClass( Class<?> c );
 
-  void setMapRunnerClass(Class<?> c);
+  void setMapRunnerClass( Class<?> c );
 
-  void setInputFormat(Class<?> inputFormat);
+  void setInputFormat( Class<?> inputFormat );
 
-  void setOutputFormat(Class<?> outputFormat);
+  void setOutputFormat( Class<?> outputFormat );
 
-  void setInputPaths(Path... paths);
+  void setInputPaths( Path... paths );
 
-  void setOutputPath(Path path);
+  void setOutputPath( Path path );
 
-  void setJarByClass(Class<?> c);
+  void setJarByClass( Class<?> c );
 
-  void setJar(String url);
+  void setJar( String url );
 
   /**
-   * Provide a hint to Hadoop for the number of map tasks to start for the
-   * MapReduce job submitted with this configuration.
-   * 
+   * Provide a hint to Hadoop for the number of map tasks to start for the MapReduce job submitted with this
+   * configuration.
+   *
    * @param n the number of map tasks for this job
    */
-  void setNumMapTasks(int n);
+  void setNumMapTasks( int n );
 
   /**
-   * Sets the requisite number of reduce tasks for the MapReduce job submitted
-   * with this configuration.
-   * 
-   * <p>If {@code n} is {@code zero} there will not be a
-   * reduce (or sort/shuffle) phase and the output of the map tasks will be 
-   * written directly to the distributed file system under the path specified
-   * via {@link #setOutputPath(Path)</p>
-   * 
+   * Sets the requisite number of reduce tasks for the MapReduce job submitted with this configuration.
+   * <p/>
+   * <p>If {@code n} is {@code zero} there will not be a reduce (or sort/shuffle) phase and the output of the map tasks
+   * will be written directly to the distributed file system under the path specified via {@link
+   * #setOutputPath(Path)</p>
+   *
    * @param n the number of reduce tasks required for this job
    */
-  void setNumReduceTasks(int n);
+  void setNumReduceTasks( int n );
 
-  /** 
-   * Set the array of string values for the <code>name</code> property as 
-   * as comma delimited values.  
-   * 
-   * @param name property name.
+  /**
+   * Set the array of string values for the <code>name</code> property as as comma delimited values.
+   *
+   * @param name   property name.
    * @param values The values
    */
-  void setStrings(String name, String... values);
+  void setStrings( String name, String... values );
 
   /**
    * Get the default file system URL as stored in this configuration.
-   * 
+   *
    * @return the default URL if it was set, otherwise empty string
    */
   String getDefaultFileSystemURL();
+
+  /**
+   * Hack
+   * Return this configuration as was asked with provided delegate class (If it is possible).
+   *
+   * @param delegate class of desired return object
+   * @return this configuration delegate object if possible
+   */
+  <T> T getAsDelegateConf( Class<T> delegate );
 }

--- a/common/src/org/pentaho/hadoop/shim/common/ConfigurationProxy.java
+++ b/common/src/org/pentaho/hadoop/shim/common/ConfigurationProxy.java
@@ -1,24 +1,24 @@
 /*******************************************************************************
-*
-* Pentaho Big Data
-*
-* Copyright (C) 2002-2013 by Pentaho : http://www.pentaho.com
-*
-*******************************************************************************
-*
-* Licensed under the Apache License, Version 2.0 (the "License");
-* you may not use this file except in compliance with
-* the License. You may obtain a copy of the License at
-*
-*    http://www.apache.org/licenses/LICENSE-2.0
-*
-* Unless required by applicable law or agreed to in writing, software
-* distributed under the License is distributed on an "AS IS" BASIS,
-* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-* See the License for the specific language governing permissions and
-* limitations under the License.
-*
-******************************************************************************/
+ *
+ * Pentaho Big Data
+ *
+ * Copyright (C) 2002-2013 by Pentaho : http://www.pentaho.com
+ *
+ *******************************************************************************
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ******************************************************************************/
 
 package org.pentaho.hadoop.shim.common;
 
@@ -32,21 +32,17 @@ import org.apache.hadoop.mapred.OutputFormat;
 import org.apache.hadoop.mapred.Reducer;
 
 /**
- * A common configuration object representing org.apache.hadoop.conf.Configuration.
- * <p>
- * This has been un-deprecated in future version of Hadoop
- * and thus the deprecation warning can be safely ignored.
- * </p>
+ * A common configuration object representing org.apache.hadoop.conf.Configuration. <p> This has been un-deprecated in
+ * future version of Hadoop and thus the deprecation warning can be safely ignored. </p>
  */
-@SuppressWarnings({ "unchecked", "rawtypes" })
+@SuppressWarnings( { "unchecked", "rawtypes" } )
 public class ConfigurationProxy extends org.apache.hadoop.mapred.JobConf implements
-    org.pentaho.hadoop.shim.api.Configuration {
-  
+  org.pentaho.hadoop.shim.api.Configuration {
+
   public ConfigurationProxy() {
     super();
-    addResource("hdfs-site.xml");
+    addResource( "hdfs-site.xml" );
   }
-  
   /*
    * Wrap the call to {@link super#setMapperClass(Class)} to avoid generic type
    * mismatches. We do not expose {@link org.apache.hadoop.mapred.*} classes through
@@ -55,54 +51,69 @@ public class ConfigurationProxy extends org.apache.hadoop.mapred.JobConf impleme
    */
 
   @Override
-  public void setMapperClass(Class c) {
-    super.setMapperClass((Class<? extends Mapper>) c);
-  }
-  
-  @Override
-  public void setCombinerClass(Class c) {
-    super.setCombinerClass((Class<? extends Reducer>) c);
+  public void setMapperClass( Class c ) {
+    super.setMapperClass( (Class<? extends Mapper>) c );
   }
 
   @Override
-  public void setReducerClass(Class c) {
-    super.setReducerClass((Class<? extends Reducer>) c);
+  public void setCombinerClass( Class c ) {
+    super.setCombinerClass( (Class<? extends Reducer>) c );
   }
 
   @Override
-  public void setMapRunnerClass(Class c) {
-    super.setMapRunnerClass((Class<? extends MapRunnable>) c);
+  public void setReducerClass( Class c ) {
+    super.setReducerClass( (Class<? extends Reducer>) c );
   }
 
   @Override
-  public void setInputFormat(Class c) {
-    super.setInputFormat((Class<? extends InputFormat>) c);
+  public void setMapRunnerClass( Class c ) {
+    super.setMapRunnerClass( (Class<? extends MapRunnable>) c );
   }
 
   @Override
-  public void setOutputFormat(Class c) {
-    super.setOutputFormat((Class<? extends OutputFormat>) c);
+  public void setInputFormat( Class c ) {
+    super.setInputFormat( (Class<? extends InputFormat>) c );
+  }
+
+  @Override
+  public void setOutputFormat( Class c ) {
+    super.setOutputFormat( (Class<? extends OutputFormat>) c );
   }
 
   @Override
   public String getDefaultFileSystemURL() {
-    return get("fs.default.name", "");
+    return get( "fs.default.name", "" );
   }
-  
+
+  /**
+   * Hack Return this configuration as was asked with provided delegate class (If it is possible).
+   *
+   * @param delegate class of desired return object
+   * @return this configuration delegate object if possible
+   */
   @Override
-  public void setInputPaths(org.pentaho.hadoop.shim.api.fs.Path... paths) {
-    if (paths == null) {
-      return;
+  public <T> T getAsDelegateConf( Class<T> delegate ) {
+    if ( delegate.isAssignableFrom( this.getClass() ) ) {
+      return (T) this;
+    } else {
+      return null;
     }
-    Path[] actualPaths = new Path[paths.length];
-    for (int i = 0; i < paths.length; i ++) {
-      actualPaths[i] = ShimUtils.asPath(paths[i]);
-    }
-    FileInputFormat.setInputPaths(this, actualPaths);
   }
 
   @Override
-  public void setOutputPath(org.pentaho.hadoop.shim.api.fs.Path path) {
-    FileOutputFormat.setOutputPath(this, ShimUtils.asPath(path));
+  public void setInputPaths( org.pentaho.hadoop.shim.api.fs.Path... paths ) {
+    if ( paths == null ) {
+      return;
+    }
+    Path[] actualPaths = new Path[ paths.length ];
+    for ( int i = 0; i < paths.length; i++ ) {
+      actualPaths[ i ] = ShimUtils.asPath( paths[ i ] );
+    }
+    FileInputFormat.setInputPaths( this, actualPaths );
+  }
+
+  @Override
+  public void setOutputPath( org.pentaho.hadoop.shim.api.fs.Path path ) {
+    FileOutputFormat.setOutputPath( this, ShimUtils.asPath( path ) );
   }
 }

--- a/common/src/org/pentaho/hadoop/shim/common/ShimUtils.java
+++ b/common/src/org/pentaho/hadoop/shim/common/ShimUtils.java
@@ -1,24 +1,24 @@
 /*******************************************************************************
-*
-* Pentaho Big Data
-*
-* Copyright (C) 2002-2013 by Pentaho : http://www.pentaho.com
-*
-*******************************************************************************
-*
-* Licensed under the Apache License, Version 2.0 (the "License");
-* you may not use this file except in compliance with
-* the License. You may obtain a copy of the License at
-*
-*    http://www.apache.org/licenses/LICENSE-2.0
-*
-* Unless required by applicable law or agreed to in writing, software
-* distributed under the License is distributed on an "AS IS" BASIS,
-* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-* See the License for the specific language governing permissions and
-* limitations under the License.
-*
-******************************************************************************/
+ *
+ * Pentaho Big Data
+ *
+ * Copyright (C) 2002-2013 by Pentaho : http://www.pentaho.com
+ *
+ *******************************************************************************
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ******************************************************************************/
 
 package org.pentaho.hadoop.shim.common;
 
@@ -28,16 +28,16 @@ import org.pentaho.hadoop.shim.api.fs.Path;
 
 public class ShimUtils {
 
-  public static org.apache.hadoop.fs.FileSystem asFileSystem(FileSystem fs) {
+  public static org.apache.hadoop.fs.FileSystem asFileSystem( FileSystem fs ) {
     return fs == null ? null : (org.apache.hadoop.fs.FileSystem) fs.getDelegate();
   }
 
-  @SuppressWarnings("deprecation")
-  public static org.apache.hadoop.mapred.JobConf asConfiguration(Configuration c) {
-    return (org.apache.hadoop.mapred.JobConf) c;
+  @SuppressWarnings( "deprecation" )
+  public static org.apache.hadoop.mapred.JobConf asConfiguration( Configuration c ) {
+    return c.getAsDelegateConf( org.apache.hadoop.mapred.JobConf.class );
   }
 
-  public static org.apache.hadoop.fs.Path asPath(Path path) {
+  public static org.apache.hadoop.fs.Path asPath( Path path ) {
     return (org.apache.hadoop.fs.Path) path;
   }
 }

--- a/hdp21/src/org/pentaho/hadoop/shim/hdp21/HadoopShim.java
+++ b/hdp21/src/org/pentaho/hadoop/shim/hdp21/HadoopShim.java
@@ -32,7 +32,6 @@ import org.pentaho.hadoop.shim.HadoopConfigurationFileSystemManager;
 import org.pentaho.hadoop.shim.api.mapred.RunningJob;
 import org.pentaho.hadoop.shim.common.CommonHadoopShim;
 import org.pentaho.hadoop.shim.common.DistributedCacheUtilImpl;
-import org.pentaho.hadoop.shim.common.fs.FileSystemProxy;
 import org.pentaho.hdfs.vfs.HDFSFileProvider;
 
 import java.io.IOException;
@@ -107,31 +106,4 @@ public class HadoopShim extends CommonHadoopShim {
     }
   }
 
-  @Override
-  public org.pentaho.hadoop.shim.api.fs.FileSystem getFileSystem( org.pentaho.hadoop.shim.api.Configuration conf )
-    throws IOException {
-    // Set the context class loader when instantiating the configuration
-    // since org.apache.hadoop.conf.Configuration uses it to load resources
-    ClassLoader cl = Thread.currentThread().getContextClassLoader();
-    Thread.currentThread().setContextClassLoader( getClass().getClassLoader() );
-    try {
-      return new FileSystemProxy(
-        org.apache.hadoop.fs.FileSystem.get( ( (ConfigurationProxyV2) conf ).getJob().getConfiguration() ) );
-    } finally {
-      Thread.currentThread().setContextClassLoader( cl );
-    }
-  }
-
-  @Override public String[] getNamenodeConnectionInfo( org.pentaho.hadoop.shim.api.Configuration c ) {
-    URI namenode = org.apache.hadoop.fs.FileSystem.getDefaultUri(
-      ( (ConfigurationProxyV2) c ).getJob().getConfiguration() );
-    String[] result = new String[ 2 ];
-    if ( namenode != null ) {
-      result[ 0 ] = namenode.getHost();
-      if ( namenode.getPort() != -1 ) {
-        result[ 1 ] = String.valueOf( namenode.getPort() );
-      }
-    }
-    return result;
-  }
 }


### PR DESCRIPTION
Changed Connection interface in shims.api to have ability to change ShimUtils in common project and to not lose backward compatibility 
To verify fix also need to replace pentaho-shims-api.jar in big data lib folder. 
Also fixed regression related to MapReduce job entry introduced by previous commit (https://github.com/stepanovdg/pentaho-hadoop-shims/commit/7e9ad7de8c134ad7e87bcf6f18e21ba185bf30ed).
