### PR TITLE
[PDI-11959][5.1.1.0] Hadoop Job Executor: Jobs using org.apache.hadoop.mapreduce API don't work

### DIFF
--- a/api/src/org/pentaho/hadoop/shim/api/Configuration.java
+++ b/api/src/org/pentaho/hadoop/shim/api/Configuration.java
@@ -1,156 +1,158 @@
 /*******************************************************************************
-*
-* Pentaho Big Data
-*
-* Copyright (C) 2002-2013 by Pentaho : http://www.pentaho.com
-*
-*******************************************************************************
-*
-* Licensed under the Apache License, Version 2.0 (the "License");
-* you may not use this file except in compliance with
-* the License. You may obtain a copy of the License at
-*
-*    http://www.apache.org/licenses/LICENSE-2.0
-*
-* Unless required by applicable law or agreed to in writing, software
-* distributed under the License is distributed on an "AS IS" BASIS,
-* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-* See the License for the specific language governing permissions and
-* limitations under the License.
-*
-******************************************************************************/
+ *
+ * Pentaho Big Data
+ *
+ * Copyright (C) 2002-2013 by Pentaho : http://www.pentaho.com
+ *
+ *******************************************************************************
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ******************************************************************************/
 
 package org.pentaho.hadoop.shim.api;
 
 import org.pentaho.hadoop.shim.api.fs.Path;
 
 /**
- * A thin abstraction for {@link org.apache.hadoop.mapred.JobConf} (and
- * consequently {@link org.apache.hadoop.conf.Configuration}). Most of the methods
- * here are a direct wrapping for methods found in {@link org.apache.hadoop.mapred.JobConf}
- * and the documentation there should be considered when providing an implementation.
- * 
+ * A thin abstraction for {@link org.apache.hadoop.mapred.JobConf} (and consequently {@link
+ * org.apache.hadoop.conf.Configuration}). Most of the methods here are a direct wrapping for methods found in {@link
+ * org.apache.hadoop.mapred.JobConf} and the documentation there should be considered when providing an implementation.
+ *
  * @author Jordan Ganoff (jganoff@pentaho.com)
  */
 public interface Configuration {
 
   /**
-   * Property for indicating a Pentaho MapReduce combiner should execute in
-   * single threaded mode.
+   * Property for indicating a Pentaho MapReduce combiner should execute in single threaded mode.
    */
   public static final String STRING_COMBINE_SINGLE_THREADED = "transformation-combine-single-threaded";
 
   /**
-   * Property for indicating a Pentaho MapReduce reduce should execute in
-   * single threaded mode.
+   * Property for indicating a Pentaho MapReduce reduce should execute in single threaded mode.
    */
   public static final String STRING_REDUCE_SINGLE_THREADED = "transformation-reduce-single-threaded";
 
   /**
    * Sets the MapReduce job name.
-   * 
+   *
    * @param jobName Name of job
    */
-  void setJobName(String jobName);
+  void setJobName( String jobName );
 
   /**
    * Sets the property {@code name}'s value to {@code value}.
-   * 
-   * @param name Name of property
+   *
+   * @param name  Name of property
    * @param value Value of property
    */
-  void set(String name, String value);
+  void set( String name, String value );
 
   /**
    * Look up the value of a property.
-   * 
+   *
    * @param name Name of property
    * @return Value of the property named {@code name}
    */
-  String get(String name);
+  String get( String name );
 
   /**
-   * Look up the value of a property optionally returning a default value if 
-   * the property is not set.
-   * 
-   * @param name Name of property
+   * Look up the value of a property optionally returning a default value if the property is not set.
+   *
+   * @param name         Name of property
    * @param defaultValue Value to return if the property is not set
    * @return Value of property named {@code name} or {@code defaultValue} if {@code name} is not set
    */
-  String get(String name, String defaultValue);
+  String get( String name, String defaultValue );
 
   /**
    * Set the key class for the map output data.
-   * 
+   *
    * @param c the map output key class
    */
-  void setMapOutputKeyClass(Class<?> c);
+  void setMapOutputKeyClass( Class<?> c );
 
   /**
    * Set the value class for the map output data.
-   * 
+   *
    * @param c the map output value class
    */
-  void setMapOutputValueClass(Class<?> c);
+  void setMapOutputValueClass( Class<?> c );
 
-  void setMapperClass(Class<?> c);
+  void setMapperClass( Class<?> c );
 
-  void setCombinerClass(Class<?> c);
+  void setCombinerClass( Class<?> c );
 
-  void setReducerClass(Class<?> c);
+  void setReducerClass( Class<?> c );
 
-  void setOutputKeyClass(Class<?> c);
+  void setOutputKeyClass( Class<?> c );
 
-  void setOutputValueClass(Class<?> c);
+  void setOutputValueClass( Class<?> c );
 
-  void setMapRunnerClass(Class<?> c);
+  void setMapRunnerClass( Class<?> c );
 
-  void setInputFormat(Class<?> inputFormat);
+  void setInputFormat( Class<?> inputFormat );
 
-  void setOutputFormat(Class<?> outputFormat);
+  void setOutputFormat( Class<?> outputFormat );
 
-  void setInputPaths(Path... paths);
+  void setInputPaths( Path... paths );
 
-  void setOutputPath(Path path);
+  void setOutputPath( Path path );
 
-  void setJarByClass(Class<?> c);
+  void setJarByClass( Class<?> c );
 
-  void setJar(String url);
+  void setJar( String url );
 
   /**
-   * Provide a hint to Hadoop for the number of map tasks to start for the
-   * MapReduce job submitted with this configuration.
-   * 
+   * Provide a hint to Hadoop for the number of map tasks to start for the MapReduce job submitted with this
+   * configuration.
+   *
    * @param n the number of map tasks for this job
    */
-  void setNumMapTasks(int n);
+  void setNumMapTasks( int n );
 
   /**
-   * Sets the requisite number of reduce tasks for the MapReduce job submitted
-   * with this configuration.
-   * 
-   * <p>If {@code n} is {@code zero} there will not be a
-   * reduce (or sort/shuffle) phase and the output of the map tasks will be 
-   * written directly to the distributed file system under the path specified
-   * via {@link #setOutputPath(Path)</p>
-   * 
+   * Sets the requisite number of reduce tasks for the MapReduce job submitted with this configuration.
+   * <p/>
+   * <p>If {@code n} is {@code zero} there will not be a reduce (or sort/shuffle) phase and the output of the map tasks
+   * will be written directly to the distributed file system under the path specified via {@link
+   * #setOutputPath(Path)</p>
+   *
    * @param n the number of reduce tasks required for this job
    */
-  void setNumReduceTasks(int n);
+  void setNumReduceTasks( int n );
 
-  /** 
-   * Set the array of string values for the <code>name</code> property as 
-   * as comma delimited values.  
-   * 
-   * @param name property name.
+  /**
+   * Set the array of string values for the <code>name</code> property as as comma delimited values.
+   *
+   * @param name   property name.
    * @param values The values
    */
-  void setStrings(String name, String... values);
+  void setStrings( String name, String... values );
 
   /**
    * Get the default file system URL as stored in this configuration.
-   * 
+   *
    * @return the default URL if it was set, otherwise empty string
    */
   String getDefaultFileSystemURL();
+
+  /**
+   * Hack
+   * Return this configuration as was asked with provided delegate class (If it is possible).
+   *
+   * @param delegate class of desired return object
+   * @return this configuration delegate object if possible
+   */
+  <T> T getAsDelegateConf( Class<T> delegate );
 }

--- a/common/src/org/pentaho/hadoop/shim/common/ConfigurationProxy.java
+++ b/common/src/org/pentaho/hadoop/shim/common/ConfigurationProxy.java
@@ -1,24 +1,24 @@
 /*******************************************************************************
-*
-* Pentaho Big Data
-*
-* Copyright (C) 2002-2013 by Pentaho : http://www.pentaho.com
-*
-*******************************************************************************
-*
-* Licensed under the Apache License, Version 2.0 (the "License");
-* you may not use this file except in compliance with
-* the License. You may obtain a copy of the License at
-*
-*    http://www.apache.org/licenses/LICENSE-2.0
-*
-* Unless required by applicable law or agreed to in writing, software
-* distributed under the License is distributed on an "AS IS" BASIS,
-* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-* See the License for the specific language governing permissions and
-* limitations under the License.
-*
-******************************************************************************/
+ *
+ * Pentaho Big Data
+ *
+ * Copyright (C) 2002-2013 by Pentaho : http://www.pentaho.com
+ *
+ *******************************************************************************
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ******************************************************************************/
 
 package org.pentaho.hadoop.shim.common;
 
@@ -32,21 +32,17 @@ import org.apache.hadoop.mapred.OutputFormat;
 import org.apache.hadoop.mapred.Reducer;
 
 /**
- * A common configuration object representing org.apache.hadoop.conf.Configuration.
- * <p>
- * This has been un-deprecated in future version of Hadoop
- * and thus the deprecation warning can be safely ignored.
- * </p>
+ * A common configuration object representing org.apache.hadoop.conf.Configuration. <p> This has been un-deprecated in
+ * future version of Hadoop and thus the deprecation warning can be safely ignored. </p>
  */
-@SuppressWarnings({ "unchecked", "rawtypes" })
+@SuppressWarnings( { "unchecked", "rawtypes" } )
 public class ConfigurationProxy extends org.apache.hadoop.mapred.JobConf implements
-    org.pentaho.hadoop.shim.api.Configuration {
-  
+  org.pentaho.hadoop.shim.api.Configuration {
+
   public ConfigurationProxy() {
     super();
-    addResource("hdfs-site.xml");
+    addResource( "hdfs-site.xml" );
   }
-  
   /*
    * Wrap the call to {@link super#setMapperClass(Class)} to avoid generic type
    * mismatches. We do not expose {@link org.apache.hadoop.mapred.*} classes through
@@ -55,54 +51,69 @@ public class ConfigurationProxy extends org.apache.hadoop.mapred.JobConf impleme
    */
 
   @Override
-  public void setMapperClass(Class c) {
-    super.setMapperClass((Class<? extends Mapper>) c);
-  }
-  
-  @Override
-  public void setCombinerClass(Class c) {
-    super.setCombinerClass((Class<? extends Reducer>) c);
+  public void setMapperClass( Class c ) {
+    super.setMapperClass( (Class<? extends Mapper>) c );
   }
 
   @Override
-  public void setReducerClass(Class c) {
-    super.setReducerClass((Class<? extends Reducer>) c);
+  public void setCombinerClass( Class c ) {
+    super.setCombinerClass( (Class<? extends Reducer>) c );
   }
 
   @Override
-  public void setMapRunnerClass(Class c) {
-    super.setMapRunnerClass((Class<? extends MapRunnable>) c);
+  public void setReducerClass( Class c ) {
+    super.setReducerClass( (Class<? extends Reducer>) c );
   }
 
   @Override
-  public void setInputFormat(Class c) {
-    super.setInputFormat((Class<? extends InputFormat>) c);
+  public void setMapRunnerClass( Class c ) {
+    super.setMapRunnerClass( (Class<? extends MapRunnable>) c );
   }
 
   @Override
-  public void setOutputFormat(Class c) {
-    super.setOutputFormat((Class<? extends OutputFormat>) c);
+  public void setInputFormat( Class c ) {
+    super.setInputFormat( (Class<? extends InputFormat>) c );
+  }
+
+  @Override
+  public void setOutputFormat( Class c ) {
+    super.setOutputFormat( (Class<? extends OutputFormat>) c );
   }
 
   @Override
   public String getDefaultFileSystemURL() {
-    return get("fs.default.name", "");
+    return get( "fs.default.name", "" );
   }
-  
+
+  /**
+   * Hack Return this configuration as was asked with provided delegate class (If it is possible).
+   *
+   * @param delegate class of desired return object
+   * @return this configuration delegate object if possible
+   */
   @Override
-  public void setInputPaths(org.pentaho.hadoop.shim.api.fs.Path... paths) {
-    if (paths == null) {
-      return;
+  public <T> T getAsDelegateConf( Class<T> delegate ) {
+    if ( delegate.isAssignableFrom( this.getClass() ) ) {
+      return (T) this;
+    } else {
+      return null;
     }
-    Path[] actualPaths = new Path[paths.length];
-    for (int i = 0; i < paths.length; i ++) {
-      actualPaths[i] = ShimUtils.asPath(paths[i]);
-    }
-    FileInputFormat.setInputPaths(this, actualPaths);
   }
 
   @Override
-  public void setOutputPath(org.pentaho.hadoop.shim.api.fs.Path path) {
-    FileOutputFormat.setOutputPath(this, ShimUtils.asPath(path));
+  public void setInputPaths( org.pentaho.hadoop.shim.api.fs.Path... paths ) {
+    if ( paths == null ) {
+      return;
+    }
+    Path[] actualPaths = new Path[ paths.length ];
+    for ( int i = 0; i < paths.length; i++ ) {
+      actualPaths[ i ] = ShimUtils.asPath( paths[ i ] );
+    }
+    FileInputFormat.setInputPaths( this, actualPaths );
+  }
+
+  @Override
+  public void setOutputPath( org.pentaho.hadoop.shim.api.fs.Path path ) {
+    FileOutputFormat.setOutputPath( this, ShimUtils.asPath( path ) );
   }
 }

--- a/common/src/org/pentaho/hadoop/shim/common/ShimUtils.java
+++ b/common/src/org/pentaho/hadoop/shim/common/ShimUtils.java
@@ -1,24 +1,24 @@
 /*******************************************************************************
-*
-* Pentaho Big Data
-*
-* Copyright (C) 2002-2013 by Pentaho : http://www.pentaho.com
-*
-*******************************************************************************
-*
-* Licensed under the Apache License, Version 2.0 (the "License");
-* you may not use this file except in compliance with
-* the License. You may obtain a copy of the License at
-*
-*    http://www.apache.org/licenses/LICENSE-2.0
-*
-* Unless required by applicable law or agreed to in writing, software
-* distributed under the License is distributed on an "AS IS" BASIS,
-* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-* See the License for the specific language governing permissions and
-* limitations under the License.
-*
-******************************************************************************/
+ *
+ * Pentaho Big Data
+ *
+ * Copyright (C) 2002-2013 by Pentaho : http://www.pentaho.com
+ *
+ *******************************************************************************
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ******************************************************************************/
 
 package org.pentaho.hadoop.shim.common;
 
@@ -28,16 +28,16 @@ import org.pentaho.hadoop.shim.api.fs.Path;
 
 public class ShimUtils {
 
-  public static org.apache.hadoop.fs.FileSystem asFileSystem(FileSystem fs) {
+  public static org.apache.hadoop.fs.FileSystem asFileSystem( FileSystem fs ) {
     return fs == null ? null : (org.apache.hadoop.fs.FileSystem) fs.getDelegate();
   }
 
-  @SuppressWarnings("deprecation")
-  public static org.apache.hadoop.mapred.JobConf asConfiguration(Configuration c) {
-    return (org.apache.hadoop.mapred.JobConf) c;
+  @SuppressWarnings( "deprecation" )
+  public static org.apache.hadoop.mapred.JobConf asConfiguration( Configuration c ) {
+    return c.getAsDelegateConf( org.apache.hadoop.mapred.JobConf.class );
   }
 
-  public static org.apache.hadoop.fs.Path asPath(Path path) {
+  public static org.apache.hadoop.fs.Path asPath( Path path ) {
     return (org.apache.hadoop.fs.Path) path;
   }
 }

--- a/hdp21/src/org/pentaho/hadoop/shim/hdp21/ConfigurationProxyV2.java
+++ b/hdp21/src/org/pentaho/hadoop/shim/hdp21/ConfigurationProxyV2.java
@@ -1,0 +1,296 @@
+/*! ******************************************************************************
+ *
+ * Pentaho Big Data
+ *
+ * Copyright (C) 2002-2014 by Pentaho : http://www.pentaho.com
+ *
+ *******************************************************************************
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ******************************************************************************/
+package org.pentaho.hadoop.shim.hdp21;
+
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.mapred.JobConf;
+import org.apache.hadoop.mapreduce.Job;
+import org.apache.hadoop.mapreduce.lib.input.FileInputFormat;
+import org.apache.hadoop.mapreduce.lib.output.FileOutputFormat;
+import org.pentaho.hadoop.shim.api.Configuration;
+import org.pentaho.hadoop.shim.common.ShimUtils;
+
+import java.io.IOException;
+
+/**
+ * User: Dzmitry Stsiapanau Date: 7/22/14 Time: 11:59 AM
+ */
+public class ConfigurationProxyV2 implements Configuration {
+
+  private Job job;
+
+  public ConfigurationProxyV2() throws IOException {
+    job = Job.getInstance();
+    getJobConf().addResource( "hdfs-site.xml" );
+  }
+
+  public JobConf getJobConf() {
+    return (JobConf) job.getConfiguration();
+  }
+
+  public Job getJob() {
+    return job;
+  }
+
+  /**
+   * Sets the MapReduce job name.
+   *
+   * @param jobName Name of job
+   */
+  @Override
+  public void setJobName( String jobName ) {
+    job.setJobName( jobName );
+  }
+
+  /**
+   * Sets the property {@code name}'s value to {@code value}.
+   *
+   * @param name  Name of property
+   * @param value Value of property
+   */
+  @Override
+  public void set( String name, String value ) {
+    getJobConf().set( name, value );
+  }
+
+  /**
+   * Look up the value of a property.
+   *
+   * @param name Name of property
+   * @return Value of the property named {@code name}
+   */
+  @Override
+  public String get( String name ) {
+    return getJobConf().get( name );
+  }
+
+  /**
+   * Look up the value of a property optionally returning a default value if the property is not set.
+   *
+   * @param name         Name of property
+   * @param defaultValue Value to return if the property is not set
+   * @return Value of property named {@code name} or {@code defaultValue} if {@code name} is not set
+   */
+  @Override
+  public String get( String name, String defaultValue ) {
+    return getJobConf().get( name, defaultValue );
+  }
+
+  /**
+   * Set the key class for the map output data.
+   *
+   * @param c the map output key class
+   */
+  @Override
+  public void setMapOutputKeyClass( Class<?> c ) {
+    job.setMapOutputKeyClass( c );
+  }
+
+  /**
+   * Set the value class for the map output data.
+   *
+   * @param c the map output value class
+   */
+  @Override
+  public void setMapOutputValueClass( Class<?> c ) {
+    job.setMapOutputValueClass( c );
+  }
+
+  @SuppressWarnings( "unchecked" )
+  @Override
+  public void setMapperClass( Class<?> c ) {
+    if ( org.apache.hadoop.mapred.Mapper.class.isAssignableFrom( c ) ) {
+      setUseOldMapApi();
+      getJobConf().setMapperClass( (Class<? extends org.apache.hadoop.mapred.Mapper>) c );
+    } else if ( org.apache.hadoop.mapreduce.Mapper.class.isAssignableFrom( c ) ) {
+      job.setMapperClass( (Class<? extends org.apache.hadoop.mapreduce.Mapper>) c );
+    }
+  }
+
+  private void setUseOldMapApi() {
+    set( "mapred.mapper.new-api", "false" );
+  }
+
+  @SuppressWarnings( "unchecked" )
+  @Override
+  public void setCombinerClass( Class<?> c ) {
+    if ( org.apache.hadoop.mapred.Reducer.class.isAssignableFrom( c ) ) {
+      setUseOldRedApi();
+      getJobConf().setCombinerClass( (Class<? extends org.apache.hadoop.mapred.Reducer>) c );
+    } else if ( org.apache.hadoop.mapreduce.Reducer.class.isAssignableFrom( c ) ) {
+      job.setCombinerClass( (Class<? extends org.apache.hadoop.mapreduce.Reducer>) c );
+    }
+  }
+
+  private void setUseOldRedApi() {
+    set( "mapred.reducer.new-api", "false" );
+  }
+
+  @SuppressWarnings( "unchecked" )
+  @Override
+  public void setReducerClass( Class<?> c ) {
+    if ( org.apache.hadoop.mapred.Reducer.class.isAssignableFrom( c ) ) {
+      setUseOldRedApi();
+      getJobConf().setReducerClass( (Class<? extends org.apache.hadoop.mapred.Reducer>) c );
+    } else if ( org.apache.hadoop.mapreduce.Reducer.class.isAssignableFrom( c ) ) {
+      job.setReducerClass( (Class<? extends org.apache.hadoop.mapreduce.Reducer>) c );
+    }
+  }
+
+  @Override
+  public void setOutputKeyClass( Class<?> c ) {
+    job.setOutputKeyClass( c );
+  }
+
+  @Override
+  public void setOutputValueClass( Class<?> c ) {
+    job.setOutputValueClass( c );
+  }
+
+  @SuppressWarnings( "unchecked" )
+  @Override
+  public void setMapRunnerClass( Class<?> c ) {
+    if ( org.apache.hadoop.mapred.MapRunnable.class.isAssignableFrom( c ) ) {
+      getJobConf().setMapRunnerClass( (Class<? extends org.apache.hadoop.mapred.MapRunnable>) c );
+    }
+  }
+
+  @SuppressWarnings( "unchecked" )
+  @Override
+  public void setInputFormat( Class<?> inputFormat ) {
+    if ( org.apache.hadoop.mapred.InputFormat.class.isAssignableFrom( inputFormat ) ) {
+      setUseOldMapApi();
+      getJobConf().setInputFormat( (Class<? extends org.apache.hadoop.mapred.InputFormat>) inputFormat );
+    } else if ( org.apache.hadoop.mapreduce.InputFormat.class.isAssignableFrom( inputFormat ) ) {
+      job.setInputFormatClass( (Class<? extends org.apache.hadoop.mapreduce.InputFormat>) inputFormat );
+    }
+  }
+
+  @SuppressWarnings( "unchecked" )
+  @Override
+  public void setOutputFormat( Class<?> outputFormat ) {
+    if ( org.apache.hadoop.mapred.OutputFormat.class.isAssignableFrom( outputFormat ) ) {
+      setUseOldRedApi();
+      if ( getJobConf().getNumReduceTasks() == 0 || get( "mapred.partitioner.class" ) != null ) {
+        setUseOldMapApi();
+      }
+      getJobConf().setOutputFormat( (Class<? extends org.apache.hadoop.mapred.OutputFormat>) outputFormat );
+    } else if ( org.apache.hadoop.mapreduce.OutputFormat.class.isAssignableFrom( outputFormat ) ) {
+      job.setOutputFormatClass( (Class<? extends org.apache.hadoop.mapreduce.OutputFormat>) outputFormat );
+    }
+  }
+
+  @Override
+  public void setInputPaths( org.pentaho.hadoop.shim.api.fs.Path... paths ) {
+    if ( paths == null ) {
+      return;
+    }
+    Path[] actualPaths = new Path[ paths.length ];
+    for ( int i = 0; i < paths.length; i++ ) {
+      actualPaths[ i ] = ShimUtils.asPath( paths[ i ] );
+    }
+    try {
+      FileInputFormat.setInputPaths( job, actualPaths );
+    } catch ( IOException e ) {
+      e.printStackTrace();
+    }
+  }
+
+  @Override
+  public void setOutputPath( org.pentaho.hadoop.shim.api.fs.Path path ) {
+    FileOutputFormat.setOutputPath( job, ShimUtils.asPath( path ) );
+  }
+
+  @Override
+  public void setJarByClass( Class<?> c ) {
+    job.setJarByClass( c );
+  }
+
+  @Override
+  public void setJar( String url ) {
+    job.setJar( url );
+  }
+
+  /**
+   * Provide a hint to Hadoop for the number of map tasks to start for the MapReduce job submitted with this
+   * configuration.
+   *
+   * @param n the number of map tasks for this job
+   */
+  @Override
+  public void setNumMapTasks( int n ) {
+    getJobConf().setNumMapTasks( n );
+  }
+
+  /**
+   * Sets the requisite number of reduce tasks for the MapReduce job submitted with this configuration.  <p>If {@code n}
+   * is {@code zero} there will not be a reduce (or sort/shuffle) phase and the output of the map tasks will be written
+   * directly to the distributed file system under the path specified via {@link #setOutputPath(org.pentaho.hadoop
+   * .shim.api.fs.Path)</p>
+   *
+   * @param n the number of reduce tasks required for this job
+   * @param n
+   */
+  @Override
+  public void setNumReduceTasks( int n ) {
+    job.setNumReduceTasks( n );
+  }
+
+  /**
+   * Set the array of string values for the <code>name</code> property as as comma delimited values.
+   *
+   * @param name   property name.
+   * @param values The values
+   */
+  @Override
+  public void setStrings( String name, String... values ) {
+    getJobConf().setStrings( name, values );
+  }
+
+  /**
+   * Get the default file system URL as stored in this configuration.
+   *
+   * @return the default URL if it was set, otherwise empty string
+   */
+  @Override
+  public String getDefaultFileSystemURL() {
+    return get( "fs.default.name", "" );
+  }
+
+  /**
+   * Hack
+   * Return this configuration as was asked with provided delegate class (If it is possible).
+   *
+   * @param delegate class of desired return object
+   * @return this configuration delegate object if possible
+   */
+  @Override
+  public <T> T getAsDelegateConf( Class<T> delegate ) {
+    if ( delegate.isAssignableFrom( this.getClass() ) ) {
+      return (T) this;
+    } else if ( delegate.isAssignableFrom( JobConf.class ) ) {
+      return (T) getJobConf();
+    } else {
+      return null;
+    }
+  }
+}

--- a/hdp21/src/org/pentaho/hadoop/shim/hdp21/HadoopShim.java
+++ b/hdp21/src/org/pentaho/hadoop/shim/hdp21/HadoopShim.java
@@ -1,76 +1,109 @@
 /*******************************************************************************
-*
-* Pentaho Big Data
-*
-* Copyright (C) 2002-2013 by Pentaho : http://www.pentaho.com
-*
-*******************************************************************************
-*
-* Licensed under the Apache License, Version 2.0 (the "License");
-* you may not use this file except in compliance with
-* the License. You may obtain a copy of the License at
-*
-*    http://www.apache.org/licenses/LICENSE-2.0
-*
-* Unless required by applicable law or agreed to in writing, software
-* distributed under the License is distributed on an "AS IS" BASIS,
-* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-* See the License for the specific language governing permissions and
-* limitations under the License.
-*
-******************************************************************************/
+ *
+ * Pentaho Big Data
+ *
+ * Copyright (C) 2002-2013 by Pentaho : http://www.pentaho.com
+ *
+ *******************************************************************************
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ******************************************************************************/
 
 package org.pentaho.hadoop.shim.hdp21;
 
-import java.io.IOException;
-import java.net.URI;
-
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.filecache.DistributedCache;
-import org.apache.hadoop.fs.FileStatus;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
-import org.apache.hadoop.util.Shell;
-import org.apache.hive.jdbc.HiveDriver;
+import org.apache.hadoop.mapreduce.Job;
 import org.pentaho.hadoop.shim.HadoopConfiguration;
 import org.pentaho.hadoop.shim.HadoopConfigurationFileSystemManager;
+import org.pentaho.hadoop.shim.api.mapred.RunningJob;
 import org.pentaho.hadoop.shim.common.CommonHadoopShim;
 import org.pentaho.hadoop.shim.common.DistributedCacheUtilImpl;
 import org.pentaho.hdfs.vfs.HDFSFileProvider;
 
+import java.io.IOException;
+import java.net.URI;
+
 public class HadoopShim extends CommonHadoopShim {
-  
+
   static {
-    JDBC_DRIVER_MAP.put("hive2",org.apache.hive.jdbc.HiveDriver.class); 
+    JDBC_DRIVER_MAP.put( "hive2", org.apache.hive.jdbc.HiveDriver.class );
   }
-  
+
   @Override
   protected String getDefaultNamenodePort() {
     return "8020";
   }
-  
+
   @Override
   protected String getDefaultJobtrackerPort() {
     return "50300";
   }
-  
+
   @Override
   public void onLoad( HadoopConfiguration config, HadoopConfigurationFileSystemManager fsm ) throws Exception {
     fsm.addProvider( config, "hdfs", config.getIdentifier(), new HDFSFileProvider() );
     setDistributedCacheUtil( new DistributedCacheUtilImpl( config ) {
-      
-      public void addFileToClassPath(Path file, Configuration conf) throws IOException {
-        String classpath = conf.get("mapred.job.classpath.files");
-        conf.set("mapred.job.classpath.files", classpath == null ? file.toString() : classpath + getClusterPathSeparator() + file.toString());
-        FileSystem fs = FileSystem.get(conf);
-        URI uri = fs.makeQualified(file).toUri();
 
-        DistributedCache.addCacheFile(uri, conf);
+      public void addFileToClassPath( Path file, Configuration conf ) throws IOException {
+        String classpath = conf.get( "mapred.job.classpath.files" );
+        conf.set( "mapred.job.classpath.files",
+          classpath == null ? file.toString() : classpath + getClusterPathSeparator() + file.toString() );
+        FileSystem fs = FileSystem.get( conf );
+        URI uri = fs.makeQualified( file ).toUri();
+
+        DistributedCache.addCacheFile( uri, conf );
       }
-      
+
       public String getClusterPathSeparator() {
-        return System.getProperty("hadoop.cluster.path.separator", ",");
+        return System.getProperty( "hadoop.cluster.path.separator", "," );
       }
-    });
+    } );
   }
+
+  @Override
+  public RunningJob submitJob( org.pentaho.hadoop.shim.api.Configuration c ) throws IOException {
+    ClassLoader cl = Thread.currentThread().getContextClassLoader();
+    Thread.currentThread().setContextClassLoader( getClass().getClassLoader() );
+    try {
+      Job job = ( (org.pentaho.hadoop.shim.hdp21.ConfigurationProxyV2) c ).getJob();
+      job.submit();
+      return new RunningJobProxyV2( job );
+    } catch ( InterruptedException e ) {
+      throw new RuntimeException( e );
+    } catch ( ClassNotFoundException e ) {
+      throw new RuntimeException( e );
+    } finally {
+      Thread.currentThread().setContextClassLoader( cl );
+    }
+  }
+
+  @Override
+  public org.pentaho.hadoop.shim.api.Configuration createConfiguration() {
+    // Set the context class loader when instantiating the configuration
+    // since org.apache.hadoop.conf.Configuration uses it to load resources
+    ClassLoader cl = Thread.currentThread().getContextClassLoader();
+    Thread.currentThread().setContextClassLoader( getClass().getClassLoader() );
+    try {
+      return new org.pentaho.hadoop.shim.hdp21.ConfigurationProxyV2();
+    } catch ( IOException e ) {
+      throw new RuntimeException( "Unable to create configuration for new mapreduce api: ", e );
+    } finally {
+      Thread.currentThread().setContextClassLoader( cl );
+    }
+  }
+
 }

--- a/hdp21/src/org/pentaho/hadoop/shim/hdp21/RunningJobProxyV2.java
+++ b/hdp21/src/org/pentaho/hadoop/shim/hdp21/RunningJobProxyV2.java
@@ -1,0 +1,140 @@
+/*! ******************************************************************************
+ *
+ * Pentaho Big Data
+ *
+ * Copyright (C) 2002-2014 by Pentaho : http://www.pentaho.com
+ *
+ *******************************************************************************
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ******************************************************************************/
+package org.pentaho.hadoop.shim.hdp21;
+
+
+import org.apache.hadoop.mapred.TaskAttemptID;
+import org.apache.hadoop.mapreduce.Job;
+import org.pentaho.hadoop.shim.api.mapred.RunningJob;
+import org.pentaho.hadoop.shim.common.mapred.TaskCompletionEventProxy;
+
+import java.io.IOException;
+
+/**
+ * User: Dzmitry Stsiapanau Date: 7/22/14 Time: 3:50 PM
+ */
+public class RunningJobProxyV2 implements RunningJob {
+  private Job delegateJob;
+
+  public RunningJobProxyV2( Job job ) {
+    delegateJob = job;
+  }
+
+
+  /**
+   * Check if the job is completed.
+   *
+   * @return {@code true} if the job has completed
+   * @throws java.io.IOException
+   */
+  @Override
+  public boolean isComplete() throws IOException {
+    return delegateJob.isComplete();
+  }
+
+  /**
+   * Kill a running job. This blocks until all tasks of the job have been killed as well.
+   *
+   * @throws java.io.IOException
+   */
+  @Override
+  public void killJob() throws IOException {
+    delegateJob.killJob();
+  }
+
+  /**
+   * Check if a job completed successfully.
+   *
+   * @return {@code true} if the job succeeded.
+   * @throws java.io.IOException
+   */
+  @Override
+  public boolean isSuccessful() throws IOException {
+    return delegateJob.isSuccessful();
+  }
+
+  /**
+   * Get a list of events indicating success/failure of underlying tasks.
+   *
+   * @param startIndex offset/index to start fetching events from
+   * @return an array of events
+   * @throws java.io.IOException
+   */
+  @Override public org.pentaho.hadoop.shim.api.mapred.TaskCompletionEvent[] getTaskCompletionEvents( int startIndex )
+    throws IOException {
+    org.apache.hadoop.mapred.TaskCompletionEvent[] events = delegateJob.getTaskCompletionEvents( startIndex );
+    org.pentaho.hadoop.shim.api.mapred.TaskCompletionEvent[] wrapped =
+      new org.pentaho.hadoop.shim.api.mapred.TaskCompletionEvent[ events.length ];
+
+    for ( int i = 0; i < wrapped.length; i++ ) {
+      wrapped[ i ] = new TaskCompletionEventProxy( events[ i ] );
+    }
+
+    return wrapped;
+  }
+
+  /**
+   * Retrieve the diagnostic messages for a given task attempt.
+   *
+   * @param taskAttemptId Identifier of the task
+   * @return an array of diagnostic messages for the task attempt with the id provided.
+   * @throws java.io.IOException
+   */
+  @Override public String[] getTaskDiagnostics( Object taskAttemptId ) throws IOException {
+    TaskAttemptID id = (TaskAttemptID) taskAttemptId;
+    try {
+      return delegateJob.getTaskDiagnostics( id );
+    } catch ( InterruptedException e ) {
+      throw new RuntimeException( e );
+    }
+  }
+
+  /**
+   * The progress of the job's setup tasks.
+   *
+   * @return progress percentage
+   * @throws java.io.IOException
+   */
+  @Override public float setupProgress() throws IOException {
+    return delegateJob.setupProgress();
+  }
+
+  /**
+   * The progress of the job's map tasks.
+   *
+   * @return progress percentage
+   * @throws java.io.IOException
+   */
+  @Override public float mapProgress() throws IOException {
+    return delegateJob.mapProgress();
+  }
+
+  /**
+   * The progress of the job's reduce tasks.
+   *
+   * @return progress percentage
+   * @throws java.io.IOException
+   */
+  @Override public float reduceProgress() throws IOException {
+    return delegateJob.reduceProgress();
+  }
+}


### PR DESCRIPTION
Backport from 5.1.

Add ability to use mapreduce V2 api.
Changed Connection interface in shims.api to have ability to change ShimUtils in common project and to not lose backward compatibility.
Also fixed regression related to MapReduce job entry.
