### PR TITLE
[PDI-12631][5.1] YARN clustering step doesn't work on windows

### DIFF
--- a/hdp21/build.properties
+++ b/hdp21/build.properties
@@ -16,6 +16,7 @@ dependency.commons-httpclient.revision=3.1
 dependency.commons-net.revision=3.1
 
 dependency.hadoop.revision=2.4.0.2.1.1.0-385
+dependency.hadoop2-windows-patch.revision=08072014
 dependency.hive-jdbc.revision=0.13.0.2.1.1.0-385
 dependency.thrift.revision=0.9.0
 dependency.apache-hbase.revision=0.98.0.2.1.1.0-385-hadoop2

--- a/hdp21/ivy.xml
+++ b/hdp21/ivy.xml
@@ -51,7 +51,14 @@
     <dependency conf="client->default" org="org.apache.hadoop" name="hadoop-mapreduce-client-jobclient" rev="${dependency.hadoop.revision}" />
     <dependency conf="client->default" org="org.apache.hadoop" name="hadoop-mapreduce-client-shuffle" rev="${dependency.hadoop.revision}" />
 
-
+    <!-- 
+      This patch gets us around bugs like MAPREDUCE-5665 where MapReduce jobs submitted from a Windows client to YARN
+      fail because of client-side attributes used during cluster-side execution.
+     -->
+    <dependency org="pentaho" name="hadoop2-windows-patch" rev="${dependency.hadoop2-windows-patch.revision}" transitive="false">
+      <artifact name="hadoop2-windows-patch" ext="jar"/>
+    </dependency>
+    
     <!-- Resolving HDP Pig is messy, the core JAR is provided, some other Pig dependencies need to be added or excluded
     <dependency conf="pmr->default" org="org.apache.pig" name="pig" rev="${dependency.pig.revision}" transitive="true">
       <exclude org="com.google.guava" />

--- a/hdp21/package-res/config.properties
+++ b/hdp21/package-res/config.properties
@@ -3,7 +3,7 @@ name=HortonWorks HDP 2.1.x
 
 # Comma-separated list of directories and files to make available to this
 # configuration. Any resources found here will overwrite ones in lib/.
-classpath=
+classpath=lib/hadoop2-windows-patch-08072014.jar
 
 # Comma-separated list of paths that contain native libraries to load. These
 # could be added to LD_LIBRARY_PATH or set with -Djava.library.path instead.


### PR DESCRIPTION
Restore hadoop2-windows-patch.jar which is needed for Yarn cluster steps to work.
