### PR TITLE
[BACKLOG-365] CLONE - Unable to create a database table data source against Apache Hadoop

### DIFF
--- a/hive-jdbc/src/org/apache/hadoop/hive/jdbc/HiveDriver.java
+++ b/hive-jdbc/src/org/apache/hadoop/hive/jdbc/HiveDriver.java
@@ -53,7 +53,7 @@ import org.pentaho.hadoop.hive.jdbc.JDBCDriverCallable;
  * JDBC driver via HadoopConfiguration#getHiveJdbcDriver.
  * </p>
  * <p>
- * All calls to the loaded HiveDriver will have the current Thread's context 
+ * All calls to the loaded HiveDriver will have the current Thread's context
  * class loader set to the class that loaded the driver so subsequent resource
  * lookups are successful.
  * </p>
@@ -63,7 +63,7 @@ public class HiveDriver implements java.sql.Driver {
    * Method name of {@link org.pentaho.hadoop.shim.spi.HadoopShim#getJdbcDriver()}
    */
   private static final String METHOD_GET_JDBC_DRIVER = "getJdbcDriver";
-  
+
   /**
    * Driver type = "hive"
    */
@@ -108,7 +108,7 @@ public class HiveDriver implements java.sql.Driver {
       throw new SQLException("Unable to load Hive JDBC driver for the currently active Hadoop configuration", ex);
     }
 
-    // Check if the Shim contains a Hive driver. It may return this driver if it 
+    // Check if the Shim contains a Hive driver. It may return this driver if it
     // doesn't contain one since it'll be found in one of the parent class loaders
     // so we also need to make sure we didn't return ourself... :)
     if (driver == null || driver.getClass() == this.getClass()) {
@@ -133,7 +133,7 @@ public class HiveDriver implements java.sql.Driver {
     return callWithActiveDriver(new JDBCDriverCallable<Connection>() {
       @Override
       public Connection call() throws Exception {
-        return driver.connect(url, info);
+        return driver.acceptsURL( url ) ? driver.connect( url, info ) : null;
       }
     });
   }
@@ -203,7 +203,7 @@ public class HiveDriver implements java.sql.Driver {
       return false;
     }
   }
-  
+
   public Logger getParentLogger() throws SQLFeatureNotSupportedException {
     return null;
   }

--- a/hive-jdbc/test-src/org/apache/hadoop/hive/jdbc/HiveDriverTest.java
+++ b/hive-jdbc/test-src/org/apache/hadoop/hive/jdbc/HiveDriverTest.java
@@ -66,7 +66,7 @@ public class HiveDriverTest {
   public void getActiveDriver() throws SQLException {
     final AtomicBoolean called = new AtomicBoolean(false);
     HadoopShim shim = new MockHadoopShim() {
-      
+
       public java.sql.Driver getJdbcDriver(String scheme) {
         if(scheme.equalsIgnoreCase("hive")) {
           called.set(true);
@@ -86,7 +86,7 @@ public class HiveDriverTest {
       public java.sql.Driver getJdbcDriver(String scheme) {
         if(scheme.equalsIgnoreCase("hive")) {
           throw new RuntimeException();
-        } 
+        }
         else {
           return null;
         }
@@ -143,18 +143,25 @@ public class HiveDriverTest {
 
   @Test
   public void connect() throws SQLException {
-    final AtomicBoolean called = new AtomicBoolean(false);
+    final AtomicBoolean connectCalled = new AtomicBoolean(false);
+    final AtomicBoolean acceptsUrlCalled = new AtomicBoolean(false);
     Driver driver = new MockDriver() {
       @Override
       public Connection connect(String url, Properties info) throws SQLException {
-        called.set(true);
+        connectCalled.set( true );
         return null;
+      }
+
+      @Override
+      public boolean acceptsURL( String url ) throws SQLException {
+        acceptsUrlCalled.set( true );
+        return true;
       }
     };
     HiveDriver d = new HiveDriver(getMockUtil(getMockShimWithDriver(driver)));
 
     d.connect(null, null);
-    assertTrue(called.get());
+    assertTrue( connectCalled.get() && acceptsUrlCalled.get() );
   }
 
   @Test
@@ -264,7 +271,7 @@ public class HiveDriverTest {
     d.jdbcCompliant();
     assertTrue(called.get());
   }
-  
+
   @Test
   public void jdbcCompliant_exception() throws SQLException {
     Driver driver = new MockDriver() {
@@ -274,7 +281,7 @@ public class HiveDriverTest {
       }
     };
     HiveDriver d = new HiveDriver(getMockUtil(getMockShimWithDriver(driver)));
-    
+
     // should return false if there is an exception
     assertFalse(d.jdbcCompliant());
   }


### PR DESCRIPTION
<b>This PR is not complete fix for BACKLOG-365 and needs https://github.com/pentaho/pentaho-hadoop-shims/pull/126 for it to work.</b>
Hive1 driver violates JDBC contract by throwing SQLException in case it doesn't accept url passed to it's connect method, call acceptsUrl before actual driver's connect method.
Add check for acceptsUrl method invocation to test.
