### PR TITLE
[SP-1498][5.1] oozie client/core should be in /lib folder not /lib/client

### DIFF
--- a/hdp21/ivy.xml
+++ b/hdp21/ivy.xml
@@ -82,8 +82,8 @@
     <dependency conf="pmr->default" org="org.apache.hbase" name="hbase-hadoop-compat" rev="${dependency.apache-hbase.revision}" transitive="false"/>
     <dependency conf="pmr->default" org="org.cloudera.htrace" name="htrace-core" rev="2.04" transitive="false" />
     <dependency conf="pmr->default" org="org.apache.zookeeper" name="zookeeper" rev="${dependency.zookeeper.revision}" transitive="false"/>
-    <dependency conf="client->default" org="org.apache.oozie" name="oozie-core" rev="${dependency.apache-oozie.revision}" changing="true" transitive="false"/>
-    <dependency conf="client->default" org="org.apache.oozie" name="oozie-client" rev="${dependency.apache-oozie.revision}" changing="true" transitive="false"/>
+    <dependency org="org.apache.oozie" name="oozie-core" rev="${dependency.apache-oozie.revision}" changing="true" transitive="false"/>
+    <dependency org="org.apache.oozie" name="oozie-client" rev="${dependency.apache-oozie.revision}" changing="true" transitive="false"/>
     <dependency org="org.apache.hive" name="hive-jdbc" rev="${dependency.hive-jdbc.revision}" changing="false" transitive="false"/>
     <dependency org="org.apache.hive" name="hive-exec" rev="${dependency.hive-jdbc.revision}" changing="false"/>
     <dependency org="org.apache.hive" name="hive-service" rev="${dependency.hive-jdbc.revision}" changing="false"/>


### PR DESCRIPTION
Oozie lib should be in lib no in client (need to be copied to hdfs)
