### PR TITLE
[SP-1499][5.1.2.0] The following unexpected error has occurred during adding fields to the IR: "The generated SQL-query did not execute successfully".

### DIFF
--- a/common/src/org/pentaho/hadoop/shim/common/DriverProxyInvocationChain.java
+++ b/common/src/org/pentaho/hadoop/shim/common/DriverProxyInvocationChain.java
@@ -788,7 +788,8 @@ public class DriverProxyInvocationChain {
    * this file is specifically for handling Hive JDBC calls, and therefore should not be used to proxy any other JDBC
    * objects besides those provided by Hive.
    */
-  private static class ResultSetMetaDataInvocationHandler implements InvocationHandler {
+  //@VisibleForTesting has not guava in all class pathes so that`s why package access modificator was used
+  static class ResultSetMetaDataInvocationHandler implements InvocationHandler {
 
     /**
      * The "real" ResultSetMetaData object.
@@ -845,6 +846,11 @@ public class DriverProxyInvocationChain {
     private String getColumnName( Integer column ) throws SQLException {
       String columnName = null;
       columnName = this.rsmd.getColumnName( column );
+      return cutDoubledTableNameFromColumnName( columnName );
+    }
+
+    //@VisibleForTesting has not guava in all class pathes so that`s why package access modificator was used
+    static String cutDoubledTableNameFromColumnName( String columnName ) {
       if ( columnName != null ) {
         int dotIndex = columnName.indexOf( '.' );
         if ( dotIndex != -1 ) {

--- a/common/test-src/org/pentaho/hadoop/shim/common/DriverProxyInvocationChainTest.java
+++ b/common/test-src/org/pentaho/hadoop/shim/common/DriverProxyInvocationChainTest.java
@@ -129,4 +129,15 @@ public class DriverProxyInvocationChainTest {
     }
   }
 
+  @Test
+  public void testCutDoubledTableNameFromColumnName() throws Exception {
+    assertEquals( null,
+      DriverProxyInvocationChain.ResultSetMetaDataInvocationHandler.cutDoubledTableNameFromColumnName( null ) );
+    assertEquals( "columnName", DriverProxyInvocationChain.ResultSetMetaDataInvocationHandler
+      .cutDoubledTableNameFromColumnName( "tableName.columnName" ) );
+    assertEquals( "tableName.columnName", DriverProxyInvocationChain.ResultSetMetaDataInvocationHandler
+      .cutDoubledTableNameFromColumnName( "tableName.tableName.columnName" ) );
+    assertEquals( "tableName_tableName_columnName", DriverProxyInvocationChain.ResultSetMetaDataInvocationHandler
+      .cutDoubledTableNameFromColumnName( "tableName_tableName_columnName" ) );
+  }
 }


### PR DESCRIPTION
- Added handlers for getColumnName and getColumnLabel methods.
  Backport from master https://github.com/pentaho/pentaho-hadoop-shims/pull/117

(cherry picked from commit 92b529e)
