### PR TITLE
[BACKLOG-350] Prevents the reducer from initializing the Kettle environm...

### DIFF
--- a/common/src-mapred/org/pentaho/hadoop/mapreduce/GenericTransReduce.java
+++ b/common/src-mapred/org/pentaho/hadoop/mapreduce/GenericTransReduce.java
@@ -33,10 +33,8 @@ import org.apache.hadoop.io.WritableComparable;
 import org.apache.hadoop.mapred.OutputCollector;
 import org.apache.hadoop.mapred.Reducer;
 import org.apache.hadoop.mapred.Reporter;
+import org.apache.log4j.Logger;
 import org.pentaho.di.core.exception.KettleException;
-import org.pentaho.di.core.logging.KettleLogStore;
-import org.pentaho.di.core.logging.KettleLoggingEvent;
-import org.pentaho.di.core.logging.LogLevel;
 import org.pentaho.di.core.row.RowMeta;
 import org.pentaho.di.core.row.RowMetaInterface;
 import org.pentaho.di.trans.RowProducer;
@@ -50,9 +48,11 @@ import org.pentaho.hadoop.mapreduce.converter.spi.ITypeConverter;
 /**
  * A reducer class that just emits the sum of the input values.
  */
-@SuppressWarnings("deprecation")
+@SuppressWarnings( "deprecation" )
 public class GenericTransReduce<K extends WritableComparable<?>, V extends Iterator<Writable>, K2, V2> extends PentahoMapReduceBase<K2, V2> implements
     Reducer<K, V, K2, V2> {
+
+  private static Logger logger = Logger.getLogger( GenericTransReduce.class );
 
   protected RowProducer rowProducer;
   protected Object value;
@@ -62,180 +62,127 @@ public class GenericTransReduce<K extends WritableComparable<?>, V extends Itera
   protected ITypeConverter inConverterV = null;
   protected RowMetaInterface injectorRowMeta;
   protected SingleThreadedTransExecutor executor;
-  
+
   public GenericTransReduce() throws KettleException {
-      super();
-      this.setMRType(MROperations.Reduce);
-      typeConverterFactory = new TypeConverterFactory();
-  } 
+    super();
+    this.setMRType( MROperations.Reduce );
+    typeConverterFactory = new TypeConverterFactory();
+  }
 
   public boolean isSingleThreaded() {
     return reduceSingleThreaded;
   }
-  
+
   public String getInputStepName() {
     return reduceInputStepName;
   }
-  
+
   public String getOutputStepName() {
     return reduceOutputStepName;
   }
 
-  public void reduce(final K key, final Iterator<V> values, final OutputCollector<K2, V2> output, final Reporter reporter) throws IOException {
+  public void reduce( final K key, final Iterator<V> values, final OutputCollector<K2, V2> output, final Reporter reporter ) throws IOException {
     try {
-      if (debug) reporter.setStatus("Begin processing record");
+      if ( debug ) {
+        reporter.setStatus( "Begin processing record" );
+      }
 
       // Just to make sure the configuration is not broken...
-      //
-      if (trans == null) {
-        throw new RuntimeException("Error initializing transformation.  See error log."); //$NON-NLS-1$
+      if ( trans == null ) {
+        throw new RuntimeException( "Error initializing transformation. See error log." ); //$NON-NLS-1$
       }
-      
-      // If we're using the single threading engine we're going to keep pushing rows into our construct.
-      // If not, we're going to re-create the Trans engine every time.
-      //
-      if (isSingleThreaded()) {
-        
-        // Only ever initialize once!
-        //
-        if (!trans.isRunning()) {
-          // The transformation needs to be prepared and started...
-          // 
-          shareVariableSpaceWithTrans(reporter);
-          setTransLogLevel(reporter);
-          prepareExecution(reporter);
-          addInjectorAndProducerToTrans(key, values, output, reporter, getInputStepName(), getOutputStepName());
-          
-          // Create the Single Threader executor, sort the steps, and so on...
-          //
-          executor = new SingleThreadedTransExecutor(trans);
-          
+
+      // The transformation needs to be prepared and started...
+      // Only ever initialize once!
+      if ( !trans.isRunning() ) {
+        shareVariableSpaceWithTrans( reporter );
+        setTransLogLevel( reporter );
+        prepareExecution( reporter );
+        addInjectorAndProducerToTrans( key, values, output, reporter, getInputStepName(), getOutputStepName() );
+
+        // If we're using the single threading engine we're going to keep pushing rows into our construct.
+        // If not, we're going to re-create the Trans engine every time.
+        if ( isSingleThreaded() ) {
+          executor = new SingleThreadedTransExecutor( trans );
+
           // This validates whether or not a step is capable of running in Single Threaded mode.
-          //
           boolean ok = executor.init();
-          if (!ok) {
-            throw new KettleException("Unable to initialize the single threaded transformation, check the log for details.");
+          if ( !ok ) {
+            throw new KettleException( "Unable to initialize the single threaded transformation, check the log for details." );
           }
-          
+
           // The transformation is considered in a "running" state now.
-        } 
-        
-        // The following 2 statements are the only things left to do for one set of data coming from Hadoop...
-        //
-        
-        // Inject the values, including the one we probed...
-        //
-        injectValues(key, values, output, reporter);
-        
+        }
+      }
+
+      // The following 2 statements are the only things left to do for one set of data coming from Hadoop...
+
+      // Inject the values, including the one we probed...
+      injectValues( key, values, output, reporter );
+
+      if ( isSingleThreaded() ) {
         // Signal to the executor that we have enough data in the pipeline to do one iteration.
         // All steps are executed in a loop once in sequence, one after the other.
-        //
         executor.oneIteration();
-
-      } else {
-        
-        // Clean up old logging
-        //
-        KettleLogStore.discardLines(trans.getLogChannelId(), true);
-        
-        // Create a copy of trans so we don't continue to add new TransListeners and run into a ConcurrentModificationException
-        // when this reducer is reused "quickly"
-
-        trans = MRUtil.recreateTrans(trans);
-        
-        shareVariableSpaceWithTrans(reporter);
-        setTransLogLevel(reporter);
-        prepareExecution(reporter);
-        addInjectorAndProducerToTrans(key, values, output, reporter, getInputStepName(), getOutputStepName());
-
-        try {
-          // Inject the values, including the one we probed...
-          //
-          injectValues(key, values, output, reporter);
-          trans.waitUntilFinished();
-          setDebugStatus(reporter, "Transformation has finished");
-        } finally {
-          disposeTransformation();
-        }
       }
 
-      if (trans.getErrors() > 0) {
-        setDebugStatus(reporter, "Errors detected in reducer/combiner transformation");
-        
-        List<KettleLoggingEvent> logList = KettleLogStore.getLogBufferFromTo(trans.getLogChannelId(), false, 0, KettleLogStore.getLastBufferLineNr());
-
-        StringBuffer buff = new StringBuffer();
-        for (KettleLoggingEvent le : logList) {
-          if (le.getLevel() == LogLevel.ERROR) {
-            buff.append(le.getMessage().toString()).append("\n");
-          }
-        }
-        throw new Exception("Errors were detected for reducer/combiner transformation:\n\n" 
-            + buff.toString());
-      }
-
-    } catch (Exception e) {
-      printException(reporter, e);
-      setDebugStatus(reporter, "An exception was raised");
-      throw new IOException(e);
+    } catch ( Exception e ) {
+      printException( reporter, e );
+      setDebugStatus( reporter, "An exception was raised" );
+      throw new IOException( e );
     }
-    if (debug) reporter.setStatus("Completed processing record");
   }
 
-  private void printException(Reporter reporter, Exception e) throws IOException {
-    e.printStackTrace(System.err);
-    setDebugStatus(reporter, "An exception was raised");
-    throw new IOException(e);
-
+  private void printException( Reporter reporter, Exception e ) throws IOException {
+    e.printStackTrace( System.err );
+    setDebugStatus( reporter, "An exception was raised" );
+    throw new IOException( e );
   }
 
   private void disposeTransformation() {
     try {
       trans.stopAll();
-    } catch (Exception ex) {
+    } catch ( Exception ex ) {
       ex.printStackTrace();
     }
     try {
       trans.cleanup();
-    } catch (Exception ex) {
+    } catch ( Exception ex ) {
       ex.printStackTrace();
     }
   }
 
-  private void injectValues(final K key, final Iterator<V> values, final OutputCollector<K2, V2> output, final Reporter reporter) throws Exception {
-    if (rowProducer != null) {
+  private void injectValues( final K key, final Iterator<V> values, final OutputCollector<K2, V2> output, final Reporter reporter ) throws Exception {
+    if ( rowProducer != null ) {
       // Execute row injection
       // We loop through the values to do this
 
-      if (value != null) {
-        if(inOrdinals != null) {
-          injectValue(key, inOrdinals.getKeyOrdinal(), inConverterK, value, inOrdinals.getValueOrdinal(), inConverterV, injectorRowMeta, rowProducer, reporter);
+      if ( value != null ) {
+        if ( inOrdinals != null ) {
+          injectValue(key, inOrdinals.getKeyOrdinal(), inConverterK, value, inOrdinals.getValueOrdinal(), inConverterV, injectorRowMeta, rowProducer, reporter );
         } else {
-          injectValue(key, inConverterK, value, inConverterV, injectorRowMeta, rowProducer, reporter);
+          injectValue(key, inConverterK, value, inConverterV, injectorRowMeta, rowProducer, reporter );
         }
       }
 
-      while (values.hasNext()) {
+      while ( values.hasNext() ) {
         value = values.next();
-        
-        if(inOrdinals != null) {
-          injectValue(key, inOrdinals.getKeyOrdinal(), inConverterK, value, inOrdinals.getValueOrdinal(), inConverterV, injectorRowMeta, rowProducer, reporter);
+
+        if ( inOrdinals != null ) {
+          injectValue(key, inOrdinals.getKeyOrdinal(), inConverterK, value, inOrdinals.getValueOrdinal(), inConverterV, injectorRowMeta, rowProducer, reporter );
         } else {
-          injectValue(key, inConverterK, value, inConverterV, injectorRowMeta, rowProducer, reporter);
+          injectValue(key, inConverterK, value, inConverterV, injectorRowMeta, rowProducer, reporter );
         }
       }
-      
+
       // make sure we don't pick up a bogus row next time this method is called without rows.
-      //
-      value = null; 
-      
-      rowProducer.finished();
+      value = null;
     }
   }
 
-  private void prepareExecution(Reporter reporter) throws KettleException {
-    setDebugStatus(reporter, "Preparing transformation for execution");
-    trans.prepareExecution(null);
+  private void prepareExecution( Reporter reporter ) throws KettleException {
+    setDebugStatus( reporter, "Preparing transformation for execution" );
+    trans.prepareExecution( null );
   }
 
 
@@ -243,133 +190,130 @@ public class GenericTransReduce<K extends WritableComparable<?>, V extends Itera
    * set the trans' log level if we have our's set
    * @param reporter
    */
-  private void setTransLogLevel(Reporter reporter) {
-    if (logLevel != null) {
-       setDebugStatus(reporter, "Setting the trans.logLevel to "+logLevel.toString());
-       trans.setLogLevel(logLevel);
-    }
-    else {
-       setDebugStatus(reporter, getClass().getName()+".logLevel is null.  The trans log level will not be set.");
+  private void setTransLogLevel( Reporter reporter ) {
+    if ( logLevel != null ) {
+      setDebugStatus( reporter, "Setting the trans.logLevel to " + logLevel.toString() );
+      trans.setLogLevel( logLevel );
+    } else {
+      setDebugStatus( reporter, getClass().getName() + ".logLevel is null.  The trans log level will not be set." );
     }
   }
 
-  /** 
+  /**
    * share the variables from the PDI job.
-   * we do this here instead of in createTrans() as MRUtil.recreateTrans() will not 
+   * we do this here instead of in createTrans() as MRUtil.recreateTrans() will not
    * copy "execution" trans information.
    */
-  private void shareVariableSpaceWithTrans(Reporter reporter) {
-    if (variableSpace != null) {
-       setDebugStatus(reporter, "Sharing the VariableSpace from the PDI job.");
-       trans.shareVariablesWith(variableSpace);
-    
-       if (debug) {
-          
-          //  list the variables
-          List<String> variables = Arrays.asList(trans.listVariables());
-          Collections.sort(variables);
-      
-          if (variables != null) {
-             setDebugStatus(reporter, "Variables: ");
-             for(String variable: variables) {
-                setDebugStatus(reporter, "     "+variable+" = "+trans.getVariable(variable));
-             }
+  private void shareVariableSpaceWithTrans( Reporter reporter ) {
+    if ( variableSpace != null ) {
+      setDebugStatus( reporter, "Sharing the VariableSpace from the PDI job." );
+      trans.shareVariablesWith( variableSpace );
+
+      if ( debug ) {
+
+        //  list the variables
+        List<String> variables = Arrays.asList( trans.listVariables() );
+        Collections.sort( variables );
+
+        if ( variables != null ) {
+          setDebugStatus( reporter, "Variables: " );
+          for ( String variable : variables ) {
+            setDebugStatus( reporter, "     " + variable + " = " + trans.getVariable( variable ) );
           }
-       }
-    }
-    else {
-       setDebugStatus(reporter, "variableSpace is null.  We are not going to share it with the trans.");
+        }
+      }
+    } else {
+      setDebugStatus( reporter, "variableSpace is null.  We are not going to share it with the trans." );
     }
 
   }
 
-  private void addInjectorAndProducerToTrans(K key, Iterator<V> values, OutputCollector<K2, V2> output, Reporter reporter, String inputStepName, String outputStepName) throws Exception {
-    setDebugStatus(reporter, "Locating output step: " + outputStepName);
-    StepInterface outputStep = trans.findRunThread(outputStepName);
-    if (outputStep != null) {
-      rowCollector = new OutputCollectorRowListener(output, outClassK, outClassV, reporter, debug);
-      outputStep.addRowListener(rowCollector);
+  private void addInjectorAndProducerToTrans( K key, Iterator<V> values, OutputCollector<K2, V2> output, Reporter reporter, String inputStepName, String outputStepName ) throws Exception {
+    setDebugStatus( reporter, "Locating output step: " + outputStepName );
+    StepInterface outputStep = trans.findRunThread( outputStepName );
+    if ( outputStep != null ) {
+      rowCollector = new OutputCollectorRowListener( output, outClassK, outClassV, reporter, debug );
+      outputStep.addRowListener( rowCollector );
 
       injectorRowMeta = new RowMeta();
-      setDebugStatus(reporter, "Locating input step: " + inputStepName);
-      if (inputStepName != null) {
+      setDebugStatus( reporter, "Locating input step: " + inputStepName );
+      if ( inputStepName != null ) {
         // Setup row injection
-        rowProducer = trans.addRowProducer(inputStepName, 0);
+        rowProducer = trans.addRowProducer( inputStepName, 0 );
         StepInterface inputStep = rowProducer.getStepInterface();
         StepMetaInterface inputStepMeta = inputStep.getStepMeta().getStepMetaInterface();
-  
+
         inOrdinals = null;
-        if (inputStepMeta instanceof BaseStepMeta) {
-          setDebugStatus(reporter, "Generating converters from RowMeta for injection into the transformation");
-  
+        if ( inputStepMeta instanceof BaseStepMeta ) {
+          setDebugStatus( reporter, "Generating converters from RowMeta for injection into the transformation" );
+
           // Convert to BaseStepMeta and use getFields(...) to get the row meta and therefore the expected input types
-          ((BaseStepMeta) inputStepMeta).getFields(injectorRowMeta, null, null, null, null);
-  
-          inOrdinals = new InKeyValueOrdinals(injectorRowMeta);
-          
-          if(inOrdinals.getKeyOrdinal() < 0 || inOrdinals.getValueOrdinal() < 0) {
-            throw new KettleException("key or value is not defined in transformation injector step");
+          ( (BaseStepMeta) inputStepMeta ).getFields( injectorRowMeta, null, null, null, null );
+
+          inOrdinals = new InKeyValueOrdinals( injectorRowMeta );
+
+          if ( inOrdinals.getKeyOrdinal() < 0 || inOrdinals.getValueOrdinal() < 0 ) {
+            throw new KettleException( "key or value is not defined in transformation injector step" );
           }
-          
+
           // Get a converter for the Key if the value meta has a concrete Java class we can use.
           // If no converter can be found here we wont do any type conversion.
-          if (injectorRowMeta.getValueMeta(inOrdinals.getKeyOrdinal()) != null) {
-            inConverterK = typeConverterFactory.getConverter(key.getClass(), injectorRowMeta.getValueMeta(inOrdinals.getKeyOrdinal()));
+          if ( injectorRowMeta.getValueMeta( inOrdinals.getKeyOrdinal() ) != null ) {
+            inConverterK = typeConverterFactory.getConverter(key.getClass(), injectorRowMeta.getValueMeta(inOrdinals.getKeyOrdinal() ) );
           }
 
           // we need to peek into the first value to get the class (the combination of Iterator and generic makes this a pain)
-          if (values.hasNext()) {
+          if ( values.hasNext() ) {
             value = values.next();
           }
-          if (value != null) {
+          if ( value != null ) {
             // Get a converter for the Value if the value meta has a concrete Java class we can use.
             // If no converter can be found here we wont do any type conversion.
-            if (injectorRowMeta.getValueMeta(inOrdinals.getValueOrdinal()) != null) {
-              inConverterV = typeConverterFactory.getConverter(value.getClass(), injectorRowMeta.getValueMeta(inOrdinals.getValueOrdinal()));
+            if ( injectorRowMeta.getValueMeta( inOrdinals.getValueOrdinal() ) != null ) {
+              inConverterV = typeConverterFactory.getConverter(value.getClass(), injectorRowMeta.getValueMeta(inOrdinals.getValueOrdinal() ) );
             }
           }
         }
-        
+
         trans.startThreads();
       } else {
-        setDebugStatus(reporter, "No input stepname was defined");
+        setDebugStatus(reporter, "No input stepname was defined" );
       }
 
-      if (getException() != null) {
-        setDebugStatus(reporter, "An exception was generated by the transformation");
+      if ( getException() != null ) {
+        setDebugStatus( reporter, "An exception was generated by the transformation" );
         // Bubble the exception from within Kettle to Hadoop
         throw getException();
       }
 
     } else {
-      if (outputStepName != null) {
-        setDebugStatus(reporter, "Output step [" + outputStepName + "] could not be found");
-        throw new KettleException("Output step not defined in transformation");
+      if ( outputStepName != null ) {
+        setDebugStatus( reporter, "Output step [" + outputStepName + "] could not be found" );
+        throw new KettleException( "Output step not defined in transformation" );
       } else {
-        setDebugStatus(reporter, "Output step name not specified");
+        setDebugStatus( reporter, "Output step name not specified" );
       }
     }
   }
-  
+
   @Override
   public void close() throws IOException {
-    
+    rowProducer.finished();
+
     // Stop the executor if any is defined...
-    if (isSingleThreaded() && executor!=null) {
+    if ( isSingleThreaded() && executor != null ) {
       try {
         executor.dispose();
-      } catch (KettleException e) {
-        e.printStackTrace(System.err);
-        trans.getLogChannel().logError("Error disposing of single threading transformation: ", e);
+      } catch ( KettleException e ) {
+        e.printStackTrace( System.err );
+        trans.getLogChannel().logError( "Error disposing of single threading transformation: ", e );
       }
-      
-      // Clean up old log lines
-      //
-      KettleLogStore.discardLines(trans.getLogChannelId(), true);
-      
+
+    } else if ( !isSingleThreaded() && trans != null ) {
+      trans.waitUntilFinished();
+      disposeTransformation();
     }
-    
+
     super.close();
   }
-  
 }


### PR DESCRIPTION
...ent for each invocation. There are tests for this in pentaho-big-data-plugin. I'll send a second pull request for pentaho-big-data-plugin as well, since the test was not closing the buffers and results in errors. I've tested the change on CDH50 and PDI 5.1.0.0-752. Both the single-threaded and the multi-threaded reducers work perfectly.

The tests for this request are in this other pull request:

https://github.com/pentaho/big-data-plugin/pull/246
