### PR TITLE
[BACKLOG-115] Certify support for Kerberos for CDH 5.1

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -14,7 +14,7 @@
   <import file="build-res/subfloor-pkg.xml"/>
 
   <!-- Every non-api shim module. These will be compiled/resolved after api. -->
-  <property name="shim-non-api-modules" value="hive-jdbc,hadoop-20,cdh42,cdh50,hdp13,hdp20,hdp21,mapr21,mapr30,mapr31" />
+  <property name="shim-non-api-modules" value="hive-jdbc,hadoop-20,cdh42,cdh50,cdh51,hdp13,hdp20,hdp21,mapr21,mapr30,mapr31" />
   <!-- These are the modules this script should build -->
   <property name="modules" value="api,${shim-non-api-modules}" />
 	  

--- a/cdh51/.project
+++ b/cdh51/.project
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectDescription>
+	<name>pentaho-hadoop-shims-cdh51</name>
+	<comment></comment>
+	<projects>
+	</projects>
+	<buildSpec>
+		<buildCommand>
+			<name>org.eclipse.jdt.core.javabuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+	</buildSpec>
+	<natures>
+		<nature>org.eclipse.jdt.core.javanature</nature>
+		<nature>org.apache.ivyde.eclipse.ivynature</nature>
+	</natures>
+	<linkedResources>
+		<link>
+			<name>src-common</name>
+			<type>2</type>
+			<locationURI>PARENT-1-PROJECT_LOC/common/src</locationURI>
+		</link>
+		<link>
+			<name>src-mapred</name>
+			<type>2</type>
+			<locationURI>PARENT-1-PROJECT_LOC/common/src-mapred</locationURI>
+		</link>
+		<link>
+			<name>test-src-common</name>
+			<type>2</type>
+			<locationURI>PARENT-1-PROJECT_LOC/common/test-src</locationURI>
+		</link>
+	</linkedResources>
+</projectDescription>

--- a/cdh51/build.properties
+++ b/cdh51/build.properties
@@ -1,0 +1,23 @@
+impl.title=Pentaho Hadoop CDH 5.1 Shim
+impl.productID=pentaho-hadoop-shims-cdh51
+ivy.artifact.id=pentaho-hadoop-shims-cdh51
+ivy.artifact.group=pentaho
+project.revision=TRUNK-SNAPSHOT
+package.id=pentaho-hadoop-shims-cdh51-package
+package.root.dir=cdh51
+
+dependency.kettle.revision=TRUNK-SNAPSHOT
+dependency.pentaho-hdfs-vfs.revision=TRUNK-SNAPSHOT
+
+dependency.xstream.revision=1.4.2
+dependency.commons-lang.revision=2.5
+
+dependency.hadoop.revision=2.3.0-cdh5.1.0
+dependency.hadoop.mr1.revision=2.3.0-mr1-cdh5.1.0
+dependency.hadoop2-windows-patch.revision=08072014
+dependency.hive-jdbc.revision=0.12.0-cdh5.1.0
+dependency.cloudera-hive-jdbc.revision=0.12.0-cdh5.1.0
+dependency.apache-hbase.revision=0.98.1-cdh5.1.0
+dependency.apache-oozie.revision=4.0.0-cdh5.1.0
+dependency.apache-sqoop.revision=1.4.4-cdh5.1.0
+dependency.pig.revision=0.12.0-cdh5.1.0

--- a/cdh51/build.xml
+++ b/cdh51/build.xml
@@ -1,0 +1,31 @@
+<!--===========================================================================
+  This is the build file for the CDH4 Shim modules.
+
+  See ../build-res/subfloor.xml for more details
+============================================================================-->
+<project name="pentaho-hadoop-shims-cdh51" basedir="." default="dist"
+  xmlns:ivy="antlib:org.apache.ivy.ant" >
+
+  <description>
+    This build file is used to create the CDH5.1 Shim module for the Big Data plugin
+    and is based off Subfloor (../build-res/subfloor.xml)
+  </description>
+
+  <import file="../common-shims-build.xml"/>
+
+  <target name="resolve" depends="subfloor.resolve">
+    <mkdir dir="lib/client/mr1"/>
+    <move todir="lib/client/mr1">
+      <fileset dir="lib/client">
+        <include name="**/hadoop*mr1*.jar"/>
+      </fileset>
+    </move>
+    <mkdir dir="lib/client/mr2"/>
+    <move todir="lib/client/mr2">
+      <fileset dir="lib/client">
+        <include name="**/hadoop-mapreduce-client-*.jar"/>
+        <include name="**/hadoop-yarn-*.jar"/>
+      </fileset>
+    </move>
+  </target>
+</project>

--- a/cdh51/ivy.xml
+++ b/cdh51/ivy.xml
@@ -1,0 +1,85 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ivy-module version="2.0" xmlns:m="http://ant.apache.org/ivy/maven">
+  <info organisation="${ivy.artifact.group}" module="${ivy.artifact.id}" revision="${project.revision}" />
+
+  <configurations>
+    <conf name="default" />
+    <conf name="zip" />
+    <conf name="test" visibility="private" />
+    <conf name="provided" />
+    <conf name="client" />
+    <conf name="pmr" />
+  </configurations>
+
+  <publications>
+    <artifact name="${ivy.artifact.id}" type="jar" conf="default" />
+    <artifact name="${package.id}" type="zip" conf="zip" />
+  </publications>
+
+  <dependencies defaultconf="default->default">
+    <dependency conf="provided->default" org="pentaho" name="pentaho-hadoop-shims-api" rev="${project.revision}" changing="true"/>
+    <dependency conf="provided->default" org="pentaho-kettle" name="kettle-core" rev="${dependency.kettle.revision}" changing="true"/>
+    <dependency conf="provided->default" org="pentaho-kettle" name="kettle-engine" rev="${dependency.kettle.revision}" changing="true"/>
+
+    <dependency conf="provided->default" org="com.thoughtworks.xstream" name="xstream" rev="${dependency.xstream.revision}" transitive="false"/>
+    <dependency conf="provided->default" org="log4j" name="log4j" rev="1.2.14" />
+    <dependency conf="provided->default" org="commons-lang" name="commons-lang" rev="${dependency.commons-lang.revision}" transitive="false"/>
+
+    <dependency conf="client->default" org="org.apache.hadoop" name="hadoop-client" rev="${dependency.hadoop.revision}" changing="true"/>
+    <dependency conf="client->default" org="org.apache.hadoop" name="hadoop-core" rev="${dependency.hadoop.mr1.revision}" transitive="false" changing="true"/>
+
+    <!--
+      This patch gets us around bugs like MAPREDUCE-5665 where MapReduce jobs submitted from a Windows client to YARN
+      fail because of client-side attributes used during cluster-side execution.
+     -->
+    <dependency org="pentaho" name="hadoop2-windows-patch" rev="${dependency.hadoop2-windows-patch.revision}" transitive="false">
+      <artifact name="hadoop2-windows-patch" ext="jar"/>
+    </dependency>
+
+    <dependency conf="pmr->default" org="org.apache.hbase" name="hbase-client" rev="${dependency.apache-hbase.revision}" transitive="false" changing="true"/>
+    <dependency conf="pmr->default" org="org.apache.hbase" name="hbase-hadoop-compat" rev="${dependency.apache-hbase.revision}" transitive="false" changing="true"/>
+    <dependency conf="pmr->default" org="org.apache.hbase" name="hbase-common" rev="${dependency.apache-hbase.revision}" transitive="false" changing="true"/>
+    <dependency conf="pmr->default" org="org.apache.hbase" name="hbase-examples" rev="${dependency.apache-hbase.revision}" transitive="false" changing="true"/>
+    <dependency conf="pmr->default" org="org.apache.hbase" name="hbase-protocol" rev="${dependency.apache-hbase.revision}" transitive="false" changing="true"/>
+    <dependency conf="pmr->default" org="org.apache.hbase" name="hbase-server" rev="${dependency.apache-hbase.revision}" transitive="false" changing="true"/>
+    <dependency conf="pmr->default" org="org.apache.hbase" name="hbase-thrift" rev="${dependency.apache-hbase.revision}" transitive="false" changing="true"/>
+    <dependency conf="pmr->default" org="org.cloudera.htrace" name="htrace-core" rev="2.01" transitive="false" changing="true"/>
+
+    <dependency org="pentaho" name="pentaho-hdfs-vfs" rev="${dependency.pentaho-hdfs-vfs.revision}" transitive="false" changing="true"/>
+
+    <!-- Our modified Hive driver (need to include it until changes are accepted into main Hive project) -->
+    <dependency org="org.apache.hive" name="hive-jdbc" rev="${dependency.hive-jdbc.revision}" changing="true" transitive="false"/>
+    <!-- The rest of the Hive dependencies -->
+    <dependency org="org.apache.hive" name="hive-common" rev="${dependency.cloudera-hive-jdbc.revision}" changing="true"/>
+    <!--<dependency org="org.apache.hive" name="hive-builtins" rev="${dependency.cloudera-hive-jdbc.revision}" changing="true"/>-->
+    <dependency org="org.apache.hive" name="hive-exec" rev="${dependency.cloudera-hive-jdbc.revision}" changing="true">
+        <exclude module="datanucleus-core"/>
+        <!-- <exclude module="derby"/> -->
+    </dependency>
+    <dependency org="org.apache.hive" name="hive-service" rev="${dependency.cloudera-hive-jdbc.revision}" changing="true"/>
+    <dependency org="org.apache.hive" name="hive-serde" rev="${dependency.cloudera-hive-jdbc.revision}" changing="true"/>
+    <dependency org="org.apache.hive" name="hive-metastore" rev="${dependency.cloudera-hive-jdbc.revision}" changing="true">
+        <!-- <exclude module="derby"/> -->
+      <!-- <exclude module="datanucleus-core" /> -->
+    </dependency>
+    <dependency org="org.apache.oozie" name="oozie-core" rev="${dependency.apache-oozie.revision}" changing="true" transitive="false"/>
+    <dependency org="org.apache.oozie" name="oozie-client" rev="${dependency.apache-oozie.revision}" changing="true" transitive="false"/>
+    <!--  explicit dependency on datanucleus-core as it is newer than the one brought in by Hive -->
+    <!-- <dependency org="org.datanucleus" name="datanucleus-core" rev="2.0.3-ZD5977-CDH5293" transitive="false" />-->
+
+    <dependency org="org.apache.sqoop" name="sqoop" rev="${dependency.apache-sqoop.revision}" changing="true" transitive="false"/>
+    <dependency org="org.apache.pig" name="pig" rev="${dependency.pig.revision}" transitive="false" changing="true"/>
+    <dependency org="dk.brics.automaton" name="automaton" rev="1.11-8" />
+
+    <dependency conf="test->default" org="junit" name="junit" rev="4.5"/>
+    <dependency conf="test->default" org="org.safehaus.jug" name="jug-lgpl" rev="2.0.0" />
+    <dependency conf="test->default" org="pentaho" name="pentaho-hadoop-shims-api-test" rev="${project.revision}" changing="true"/>
+    <dependency conf="test->default" org="org.mockito" name="mockito-all" rev="1.9.5" transitive="false" />
+
+    <!-- Exclude log4j from default libraries - it's brought in transitively through many of the Hadoop dependencies and should not be included -->
+    <exclude org="log4j" module="log4j" conf="default" />
+    <!-- Exclude antlr. Hive brings in a version that's not compatible with Pig. -->
+    <exclude org="org.antlr" conf="default" />
+    <exclude org="junit" conf="default,zip,client,provided,pmr"/>
+  </dependencies>
+</ivy-module>

--- a/cdh51/ivysettings.xml
+++ b/cdh51/ivysettings.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ivysettings>
+  <properties environment="env" />
+  <property name="ivy.local.default.root" value="${ivy.default.ivy.user.dir}/local" override="true" />
+  <property name="ivy.local.default.artifact.pattern" value="[organisation]/[module]/[revision]/[type]s/[artifact]-[revision].[ext]"
+    override="false" />
+    
+  <!-- Repository for Pentaho-hosted artifacts -->  
+  <property name="pentaho.resolve.repo" value="http://repo.pentaho.org/artifactory/repo" override="false" />
+  <!-- Repository for External-hosted artifacts (Optional. Defaults to Pentaho-hosted.) -->
+  <property name="public.resolve.repo" value="${pentaho.resolve.repo}" override="false" />
+
+  <settings defaultResolver="pentaho-chained-resolver" />
+  <include url="${ivy.default.settings.dir}/ivysettings-public.xml" />
+  <include url="${ivy.default.settings.dir}/ivysettings-local.xml" />
+  <resolvers>
+    <chain name="pentaho-chained-resolver">
+      <resolver ref="local" />
+      <dual name="pentaho">
+        <url name="pentaho-ivy">
+          <ivy pattern="${pentaho.resolve.repo}/[organisation]/[module]/[revision]/[module]-[revision].ivy.xml" />
+        </url>
+        <ibiblio name="pentaho-mvn" m2compatible="true" root="${pentaho.resolve.repo}" />
+      </dual>
+      <ibiblio name="public-maven" root="${public.resolve.repo}" m2compatible="true" />
+    </chain>
+  </resolvers>
+  <caches lockStrategy="artifact-lock" resolutionCacheDir="${ivy.default.ivy.user.dir}/resol-cache${env.EXECUTOR_NUMBER}" />
+</ivysettings>

--- a/cdh51/package-ivy.xml
+++ b/cdh51/package-ivy.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ivy-module version="2.0" xmlns:m="http://ant.apache.org/ivy/maven">
+  <info organisation="${ivy.artifact.group}" module="${package.id}" revision="${project.revision}" />
+  <configurations>
+    <conf name="default" />
+  </configurations>
+
+  <publications>
+    <artifact name="${package.id}" type="zip" />
+  </publications>
+
+  <dependencies defaultconf="default->default">
+  </dependencies>
+</ivy-module>

--- a/cdh51/package-res/config.properties
+++ b/cdh51/package-res/config.properties
@@ -1,0 +1,24 @@
+# Friendly name for this configuration
+name=Cloudera CDH 5.1
+
+# Comma-separated list of directories and files to make available to this
+# configuration. Any resources found here will overwrite ones in lib/.
+classpath=lib/hadoop2-windows-patch-08072014.jar
+
+# Comma-separated list of paths that contain native libraries to load. These
+# could be added to LD_LIBRARY_PATH or set with -Djava.library.path instead.
+library.path=
+
+# Comma-separated list of classes or package names to explicitly ignore when
+# loading classes from the resources within this Hadoop configuration directory
+# or the classpath property
+# e.g.: org.apache.commons.log,org.apache.log4j
+# Note, the two packages above are automatically included for all configurations
+ignore.classes=org.apache.derby.iapi.services
+
+shim.current.config=mr2
+
+mr1.classpath.ignore=lib/client/mr2
+mr2.classpath.ignore=lib/client/mr1
+
+mr1.java.system.hadoop.cluster.path.separator=:

--- a/cdh51/package-res/core-site.xml
+++ b/cdh51/package-res/core-site.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<configuration>
+</configuration>

--- a/cdh51/package-res/hive-site.xml
+++ b/cdh51/package-res/hive-site.xml
@@ -1,0 +1,19 @@
+<configuration>
+  <property>
+    <name>hive.metastore.local</name>
+    <value>false</value>
+  </property>
+  <property>
+    <name>hive.metastore.uris</name>
+    <value>thrift://clouderamanager.cdh5.test:9083</value>
+  </property>
+  <property>
+    <name>hive.exec.reducers.bytes.per.reducer</name>
+    <value>1073741824</value>
+  </property>
+  <property>
+    <name>hive.support.concurrency</name>
+    <value>true</value>
+  </property>
+</configuration>
+

--- a/cdh51/package-res/mapred-site.xml
+++ b/cdh51/package-res/mapred-site.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<configuration>
+  <property>
+    <name>mapreduce.framework.name</name>
+    <value>yarn</value>
+  </property>
+  <property>
+    <name>mapreduce.application.classpath</name>
+    <value>$HADOOP_MAPRED_HOME/*,$HADOOP_MAPRED_HOME/lib/*</value>
+  </property>
+  <property>
+    <name>mapreduce.jobhistory.address</name>
+    <value>clouderamanager.cdh5.test:10020</value>
+    <description>MapReduce JobHistory Server IPC host:port</description>
+  </property>
+</configuration>

--- a/cdh51/package-res/yarn-site.xml
+++ b/cdh51/package-res/yarn-site.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<configuration>
+  <property>
+    <name>yarn.resourcemanager.hostname</name>
+    <value>clouderamanager.cdh5.test</value>
+  </property>
+  <property>
+    <name>yarn.application.classpath</name>
+    <value>$HADOOP_CONF_DIR,$HADOOP_COMMON_HOME/*,$HADOOP_COMMON_HOME/lib/*,$HADOOP_HDFS_HOME/*,$HADOOP_HDFS_HOME/lib/*,$HADOOP_YARN_HOME/*,$HADOOP_YARN_HOME/lib/*</value>
+  </property>
+</configuration>

--- a/cdh51/src/META-INF/services/org.pentaho.hadoop.shim.spi.HadoopShim
+++ b/cdh51/src/META-INF/services/org.pentaho.hadoop.shim.spi.HadoopShim
@@ -1,0 +1,1 @@
+org.pentaho.hadoop.shim.cdh51.authorization.AuthenticatingHadoopShim

--- a/cdh51/src/META-INF/services/org.pentaho.hadoop.shim.spi.PigShim
+++ b/cdh51/src/META-INF/services/org.pentaho.hadoop.shim.spi.PigShim
@@ -1,0 +1,1 @@
+org.pentaho.hadoop.shim.cdh51.delegating.DelegatingPigShim

--- a/cdh51/src/META-INF/services/org.pentaho.hadoop.shim.spi.SnappyShim
+++ b/cdh51/src/META-INF/services/org.pentaho.hadoop.shim.spi.SnappyShim
@@ -1,0 +1,1 @@
+org.pentaho.hadoop.shim.cdh51.delegating.DelegatingSnappyShim

--- a/cdh51/src/META-INF/services/org.pentaho.hadoop.shim.spi.SqoopShim
+++ b/cdh51/src/META-INF/services/org.pentaho.hadoop.shim.spi.SqoopShim
@@ -1,0 +1,1 @@
+org.pentaho.hadoop.shim.cdh51.delegating.DelegatingSqoopShim

--- a/cdh51/src/META-INF/services/org.pentaho.hbase.shim.spi.HBaseShim
+++ b/cdh51/src/META-INF/services/org.pentaho.hbase.shim.spi.HBaseShim
@@ -1,0 +1,1 @@
+org.pentaho.hadoop.shim.cdh51.delegating.DelegatingHBaseShim

--- a/cdh51/src/META-INF/services/org.pentaho.oozie.shim.api.OozieClientFactory
+++ b/cdh51/src/META-INF/services/org.pentaho.oozie.shim.api.OozieClientFactory
@@ -1,0 +1,1 @@
+org.pentaho.hadoop.shim.cdh51.delegating.DelegatingOozieClientFactory

--- a/cdh51/src/org/pentaho/hadoop/shim/cdh51/ClassPathModifyingSqoopShim.java
+++ b/cdh51/src/org/pentaho/hadoop/shim/cdh51/ClassPathModifyingSqoopShim.java
@@ -1,0 +1,96 @@
+/*******************************************************************************
+*
+* Pentaho Big Data
+*
+* Copyright (C) 2002-2013 by Pentaho : http://www.pentaho.com
+*
+*******************************************************************************
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License. You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*
+******************************************************************************/
+
+package org.pentaho.hadoop.shim.cdh51;
+
+import java.util.concurrent.Callable;
+
+import org.pentaho.hadoop.shim.HadoopConfigurationClassLoader;
+import org.pentaho.hadoop.shim.api.Configuration;
+import org.pentaho.hadoop.shim.common.CommonSqoopShim;
+
+/**
+ * Sqoop shim to handle working around Sqoop's ConfigurationManager
+ * and how it builds up the class path when compiling temporary files.
+ *
+ * <p>
+ * This applies to any version of Hadoop that bundles classes in separate
+ * jars instead of the conglomerate "core" jar.
+ * </p>
+ *
+ */
+public class ClassPathModifyingSqoopShim extends CommonSqoopShim {
+  private static final String PROPERTY_JAVA_CLASS_PATH = "java.class.path";
+
+  /**
+   * Run a given {@link Callable} within a code block that sets the
+   * {@code "java.class.path"} property to the path defined for the {@link HadoopConfigurationClassLoader}
+   * used to load this class, if it was used. If not, this is the same as calling {@code callable.call()}.
+   * @param callable Callable to execute with a modified class path set.
+   * @return
+   */
+  public int runWithModifiedClassPathProperty(Callable<Integer> callable) {
+    /**
+     * WARNING: This is non-thread safe. This is only to work around the
+     * deficiencies of the Sqoop CompilationManager (as of 1.4.1) as it will
+     * only look for the Hadoop "core" jar. For CDH4 the necessary classes are contained within a
+     * "common" jar.
+     */
+    String newClassPath = getClassPathString();
+    String originalClassPath = System.getProperty(PROPERTY_JAVA_CLASS_PATH);
+    if (newClassPath != null) {
+      System.setProperty(PROPERTY_JAVA_CLASS_PATH, newClassPath);
+    }
+    try {
+      Integer returnVal = callable.call();
+      return returnVal == null ? Integer.MIN_VALUE : returnVal.intValue();
+    } catch (Exception ex) {
+      throw new RuntimeException(ex);
+    } finally {
+      if (originalClassPath != null) {
+        System.setProperty(PROPERTY_JAVA_CLASS_PATH, originalClassPath);
+      }
+    }
+  }
+
+  @Override
+  public int runTool(final String[] args, final Configuration c) {
+    return runWithModifiedClassPathProperty(new Callable<Integer>() {
+      @Override
+      public Integer call() throws Exception {
+        return ClassPathModifyingSqoopShim.super.runTool(args, c);
+      }
+    });
+  }
+
+  /**
+   * @return the class path to set for each run of {@link #runWithModifiedClassPathProperty(Callable)}.
+   */
+  protected String getClassPathString() {
+    ClassLoader cl = getClass().getClassLoader();
+    if (HadoopConfigurationClassLoader.class.isAssignableFrom(cl.getClass())) {
+      HadoopConfigurationClassLoader hccl = (HadoopConfigurationClassLoader) cl;
+      return hccl.generateClassPathString();
+    }
+    return null;
+  }
+}

--- a/cdh51/src/org/pentaho/hadoop/shim/cdh51/HadoopShim.java
+++ b/cdh51/src/org/pentaho/hadoop/shim/cdh51/HadoopShim.java
@@ -1,0 +1,78 @@
+/*******************************************************************************
+*
+* Pentaho Big Data
+*
+* Copyright (C) 2002-2013 by Pentaho : http://www.pentaho.com
+*
+*******************************************************************************
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License. You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*
+******************************************************************************/
+
+package org.pentaho.hadoop.shim.cdh51;
+
+
+import java.io.IOException;
+import java.net.URI;
+
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.filecache.DistributedCache;
+import org.apache.hadoop.fs.FileStatus;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.util.Shell;
+import org.apache.hive.jdbc.HiveDriver;
+import org.pentaho.hadoop.shim.HadoopConfiguration;
+import org.pentaho.hadoop.shim.HadoopConfigurationFileSystemManager;
+import org.pentaho.hadoop.shim.common.CommonHadoopShim;
+import org.pentaho.hadoop.shim.common.DistributedCacheUtilImpl;
+import org.pentaho.hdfs.vfs.HDFSFileProvider;
+
+public class HadoopShim extends CommonHadoopShim {
+
+  static {
+    JDBC_DRIVER_MAP.put("hive2",org.apache.hive.jdbc.HiveDriver.class);
+  }
+
+  @Override
+  protected String getDefaultNamenodePort() {
+    return "8020";
+  }
+
+  @Override
+  protected String getDefaultJobtrackerPort() {
+    return "8021";
+  }
+
+  @Override
+  public void onLoad( HadoopConfiguration config, HadoopConfigurationFileSystemManager fsm ) throws Exception {
+    fsm.addProvider( config, "hdfs", config.getIdentifier(), new HDFSFileProvider() );
+    setDistributedCacheUtil( new DistributedCacheUtilImpl( config ) {
+
+      public void addFileToClassPath(Path file, Configuration conf) throws IOException {
+        String classpath = conf.get("mapred.job.classpath.files");
+        conf.set("mapred.job.classpath.files", classpath == null ? file.toString() : classpath + getClusterPathSeparator() + file.toString());
+        FileSystem fs = FileSystem.get(conf);
+        URI uri = fs.makeQualified(file).toUri();
+
+        DistributedCache.addCacheFile(uri, conf);
+      }
+
+      public String getClusterPathSeparator() {
+        // Use a comma rather than an OS-specific separator (see https://issues.apache.org/jira/browse/HADOOP-4864)
+        return System.getProperty("hadoop.cluster.path.separator", ",");
+      }
+    });
+  }
+}

--- a/cdh51/src/org/pentaho/hadoop/shim/cdh51/SnappyShim.java
+++ b/cdh51/src/org/pentaho/hadoop/shim/cdh51/SnappyShim.java
@@ -1,0 +1,47 @@
+/*******************************************************************************
+*
+* Pentaho Big Data
+*
+* Copyright (C) 2002-2013 by Pentaho : http://www.pentaho.com
+*
+*******************************************************************************
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License. You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*
+******************************************************************************/
+
+package org.pentaho.hadoop.shim.cdh51;
+
+import org.apache.hadoop.io.compress.SnappyCodec;
+import org.pentaho.hadoop.shim.common.CommonSnappyShim;
+
+public class SnappyShim extends CommonSnappyShim {
+  /**
+   * Tests whether hadoop-snappy (not to be confused with other java-based
+   * snappy implementations such as jsnappy or snappy-java) plus the
+   * native snappy libraries are available.
+   *
+   * @return true if hadoop-snappy is available on the classpath
+   */
+  public boolean isHadoopSnappyAvailable() {
+    ClassLoader cl = Thread.currentThread().getContextClassLoader();
+    Thread.currentThread().setContextClassLoader(getClass().getClassLoader());
+    try {
+      return SnappyCodec.isNativeCodeLoaded();
+    } catch (Throwable t) {
+      return false;
+    } finally {
+      Thread.currentThread().setContextClassLoader(cl);
+    }
+  }
+}

--- a/cdh51/src/org/pentaho/hadoop/shim/cdh51/authentication/HadoopNoAuthConsumer.java
+++ b/cdh51/src/org/pentaho/hadoop/shim/cdh51/authentication/HadoopNoAuthConsumer.java
@@ -1,0 +1,60 @@
+/*******************************************************************************
+*
+* Pentaho Big Data
+*
+* Copyright (C) 2002-2014 by Pentaho : http://www.pentaho.com
+*
+*******************************************************************************
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License. You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*
+******************************************************************************/
+
+package org.pentaho.hadoop.shim.cdh51.authentication;
+
+import org.pentaho.di.core.auth.AuthenticationConsumerPlugin;
+import org.pentaho.di.core.auth.AuthenticationConsumerType;
+import org.pentaho.di.core.auth.NoAuthenticationAuthenticationProvider;
+import org.pentaho.di.core.auth.core.AuthenticationConsumer;
+import org.pentaho.di.core.auth.core.AuthenticationConsumptionException;
+import org.pentaho.hadoop.shim.cdh51.authorization.HadoopAuthorizationService;
+import org.pentaho.hadoop.shim.cdh51.authorization.NoOpHadoopAuthorizationService;
+
+import java.util.Properties;
+
+public class HadoopNoAuthConsumer implements
+    AuthenticationConsumer<HadoopAuthorizationService, NoAuthenticationAuthenticationProvider> {
+  @AuthenticationConsumerPlugin( id = "HadoopNoAuthConsumer", name = "HadoopNoAuthConsumer" )
+  public static class HadoopNoAuthConsumerType implements AuthenticationConsumerType {
+
+    @Override
+    public String getDisplayName() {
+      return "HadoopNoAuthConsumer";
+    }
+
+    @Override
+    public Class<? extends AuthenticationConsumer<?, ?>> getConsumerClass() {
+      return HadoopNoAuthConsumer.class;
+    }
+  }
+
+  public HadoopNoAuthConsumer( Properties props ) {
+    // Noop
+  }
+
+  @Override
+  public HadoopAuthorizationService consume( NoAuthenticationAuthenticationProvider authenticationProvider )
+    throws AuthenticationConsumptionException {
+    return new NoOpHadoopAuthorizationService();
+  }
+}

--- a/cdh51/src/org/pentaho/hadoop/shim/cdh51/authentication/PropertyAuthenticationProviderParser.java
+++ b/cdh51/src/org/pentaho/hadoop/shim/cdh51/authentication/PropertyAuthenticationProviderParser.java
@@ -1,0 +1,146 @@
+/*******************************************************************************
+*
+* Pentaho Big Data
+*
+* Copyright (C) 2002-2014 by Pentaho : http://www.pentaho.com
+*
+*******************************************************************************
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License. You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*
+******************************************************************************/
+
+package org.pentaho.hadoop.shim.cdh51.authentication;
+
+import org.apache.commons.lang.ClassUtils;
+import org.apache.log4j.Logger;
+import org.pentaho.di.core.auth.core.AuthenticationManager;
+import org.pentaho.di.core.auth.core.AuthenticationProvider;
+import org.pentaho.di.core.encryption.Encr;
+
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.lang.reflect.Modifier;
+import java.util.Properties;
+
+public class PropertyAuthenticationProviderParser {
+  public static interface AuthenticationProviderInstantiator {
+    public AuthenticationProvider instantiate( String canonicalName );
+  }
+
+  private static final Logger logger = Logger.getLogger( PropertyAuthenticationProviderParser.class );
+  private final Properties properties;
+  private final AuthenticationManager manager;
+  private final AuthenticationProviderInstantiator authenticationProviderInstantiator;
+
+  public PropertyAuthenticationProviderParser( Properties properties, AuthenticationManager manager ) {
+    this( properties, manager, new AuthenticationProviderInstantiator() {
+
+      @Override
+      public AuthenticationProvider instantiate( String canonicalName ) {
+        Class<?> clazz = null;
+        try {
+          clazz = Class.forName( canonicalName );
+        } catch ( ClassNotFoundException e ) {
+          logger.warn( "Cannot locate class " + canonicalName + ", provider will not be processed.", e );
+        }
+        if ( clazz != null ) {
+          try {
+            return (AuthenticationProvider) clazz.newInstance();
+          } catch ( Exception e ) {
+            logger.warn( "Cannot instantiate class " + canonicalName + ", provider will not be processed.", e );
+          }
+        }
+        return null;
+      }
+    } );
+  }
+
+  public PropertyAuthenticationProviderParser( Properties properties, AuthenticationManager manager,
+      AuthenticationProviderInstantiator authenticationProviderInstantiator ) {
+    this.properties = properties;
+    this.manager = manager;
+    this.authenticationProviderInstantiator = authenticationProviderInstantiator;
+  }
+
+  public void process( String providerListProperty ) {
+    if ( properties.containsKey( providerListProperty ) ) {
+      for ( String prefix : properties.getProperty( providerListProperty ).split( "," ) ) {
+        prefix = prefix.trim();
+        if ( prefix.length() > 0 ) {
+          processPrefix( prefix );
+        }
+      }
+    }
+  }
+
+  private void processPrefix( String prefix ) {
+    AuthenticationProvider provider =
+        authenticationProviderInstantiator.instantiate( properties.getProperty( prefix + ".class" ) );
+    if ( provider != null ) {
+      for ( Method method : provider.getClass().getMethods() ) {
+        if ( method.getName().startsWith( "set" ) && method.getName().length() >= 4
+            && method.getParameterTypes().length == 1 ) {
+          String propName = prefix + "." + method.getName().substring( 3, 4 ).toLowerCase();
+          if ( method.getName().length() > 4 ) {
+            propName += method.getName().substring( 4 );
+          }
+          if ( properties.containsKey( propName ) ) {
+            String strValue = Encr.decryptPasswordOptionallyEncrypted( properties.getProperty( propName ) );
+            Object actualValue = null;
+            Class<?> argType = method.getParameterTypes()[0];
+            if ( argType.isPrimitive() ) {
+              argType = ClassUtils.primitiveToWrapper( argType );
+            }
+            if ( argType == String.class ) {
+              actualValue = strValue;
+            } else {
+              Method valueOf = null;
+              try {
+                valueOf = argType.getMethod( "valueOf", String.class );
+              } catch ( NoSuchMethodException e1 ) {
+                logger.warn( "Unable to find valueOf method on " + argType.getClass().getCanonicalName() );
+              }
+              if ( valueOf != null && Modifier.isStatic( valueOf.getModifiers() ) ) {
+                try {
+                  actualValue = valueOf.invoke( null, strValue );
+                } catch ( Exception e ) {
+                  logger.warn( "Unable to convert string property " + propName + "(" + strValue + ") to "
+                      + argType.getClass().getCanonicalName() + " to invoke setter " + method.getName(), e );
+                }
+              } else {
+                logger.warn( "Could not find method to convert " + propName + "(" + strValue + ") to "
+                    + argType.getClass().getCanonicalName()
+                    + " (currently only primitives and their wrappers are supported)" );
+              }
+            }
+            if ( actualValue != null ) {
+              try {
+                method.invoke( provider, actualValue );
+              } catch ( Exception e ) {
+                Throwable cause = e;
+                if ( e instanceof InvocationTargetException ) {
+                  cause = e.getCause();
+                }
+                logger.warn( "Error invoking setter " + method.toString() + " with property " + propName + "("
+                    + strValue + ")", cause );
+              }
+            }
+          }
+
+        }
+      }
+      manager.registerAuthenticationProvider( provider );
+    }
+  }
+}

--- a/cdh51/src/org/pentaho/hadoop/shim/cdh51/authorization/AuthenticatingHadoopShim.java
+++ b/cdh51/src/org/pentaho/hadoop/shim/cdh51/authorization/AuthenticatingHadoopShim.java
@@ -1,0 +1,89 @@
+/*******************************************************************************
+ *
+ * Pentaho Big Data
+ *
+ * Copyright (C) 2002-2014 by Pentaho : http://www.pentaho.com
+ *
+ *******************************************************************************
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ******************************************************************************/
+
+package org.pentaho.hadoop.shim.cdh51.authorization;
+
+import org.pentaho.di.core.auth.AuthenticationConsumerPluginType;
+import org.pentaho.di.core.auth.AuthenticationPersistenceManager;
+import org.pentaho.di.core.auth.NoAuthenticationAuthenticationProvider;
+import org.pentaho.di.core.auth.core.AuthenticationManager;
+import org.pentaho.di.core.auth.core.AuthenticationPerformer;
+
+import org.pentaho.di.core.logging.LogChannel;
+import org.pentaho.hadoop.shim.HadoopConfiguration;
+import org.pentaho.hadoop.shim.HadoopConfigurationFileSystemManager;
+import org.pentaho.hadoop.shim.cdh51.authentication.HadoopNoAuthConsumer;
+import org.pentaho.hadoop.shim.cdh51.authentication.PropertyAuthenticationProviderParser;
+import org.pentaho.hadoop.shim.cdh51.delegating.DelegatingHadoopShim;
+import org.pentaho.hadoop.shim.spi.PentahoHadoopShim;
+
+import java.net.URLClassLoader;
+import java.util.Properties;
+
+public class AuthenticatingHadoopShim extends DelegatingHadoopShim {
+  @Override
+  public void onLoad( HadoopConfiguration config, HadoopConfigurationFileSystemManager fsm ) throws Exception {
+    AuthenticationConsumerPluginType.getInstance().registerPlugin( (URLClassLoader) getClass().getClassLoader(),
+      HadoopNoAuthConsumer.HadoopNoAuthConsumerType.class );
+    String activators = config.getConfigProperties().getProperty( "activator.classes" );
+    if ( activators != null ) {
+      activators = activators.trim();
+      for ( String className : activators.split( "," ) ) {
+        className = className.trim();
+        if ( className.length() > 0 ) {
+          try {
+            Class.forName( className ).newInstance();
+          } catch ( Exception e ) {
+            LogChannel.GENERAL.logError( e.getMessage(), e );
+          }
+        }
+      }
+    }
+    String provider = NoAuthenticationAuthenticationProvider.NO_AUTH_ID;
+    if ( config.getConfigProperties().containsKey( SUPER_USER ) ) {
+      provider = config.getConfigProperties().getProperty( SUPER_USER );
+    }
+    AuthenticationManager manager = AuthenticationPersistenceManager.getAuthenticationManager();
+    new PropertyAuthenticationProviderParser( config.getConfigProperties(), manager ).process( PROVIDER_LIST );
+    AuthenticationPerformer<HadoopAuthorizationService, Properties> performer =
+      manager.getAuthenticationPerformer( HadoopAuthorizationService.class, Properties.class, provider );
+    if ( performer == null ) {
+      throw new RuntimeException( "Unable to find relevant provider for chosen authentication method (id of "
+        + config.getConfigProperties().getProperty( SUPER_USER ) );
+    } else {
+      HadoopAuthorizationService hadoopAuthorizationService = performer.perform( config.getConfigProperties() );
+      if ( hadoopAuthorizationService == null ) {
+        throw new RuntimeException( "Unable to get HadoopAuthorizationService for provider "
+          + config.getConfigProperties().getProperty( SUPER_USER ) );
+      }
+      for ( PentahoHadoopShim shim : config.getAvailableShims() ) {
+        if ( HasHadoopAuthorizationService.class.isInstance( shim ) ) {
+          ( (HasHadoopAuthorizationService) shim ).setHadoopAuthorizationService( hadoopAuthorizationService );
+        } else {
+          throw new Exception( "Found shim: " + shim + " that didn't implement "
+            + HasHadoopAuthorizationService.class.getCanonicalName() );
+        }
+      }
+    }
+    super.onLoad( config, fsm );
+  }
+}

--- a/cdh51/src/org/pentaho/hadoop/shim/cdh51/authorization/HadoopAuthorizationService.java
+++ b/cdh51/src/org/pentaho/hadoop/shim/cdh51/authorization/HadoopAuthorizationService.java
@@ -1,0 +1,30 @@
+/*******************************************************************************
+*
+* Pentaho Big Data
+*
+* Copyright (C) 2002-2014 by Pentaho : http://www.pentaho.com
+*
+*******************************************************************************
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License. You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*
+******************************************************************************/
+
+package org.pentaho.hadoop.shim.cdh51.authorization;
+
+import org.pentaho.hadoop.shim.spi.PentahoHadoopShim;
+
+public interface HadoopAuthorizationService {
+
+  public <T extends PentahoHadoopShim> T getShim( Class<T> clazz );
+}

--- a/cdh51/src/org/pentaho/hadoop/shim/cdh51/authorization/HasHadoopAuthorizationService.java
+++ b/cdh51/src/org/pentaho/hadoop/shim/cdh51/authorization/HasHadoopAuthorizationService.java
@@ -1,0 +1,27 @@
+/*******************************************************************************
+*
+* Pentaho Big Data
+*
+* Copyright (C) 2002-2014 by Pentaho : http://www.pentaho.com
+*
+*******************************************************************************
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License. You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*
+******************************************************************************/
+
+package org.pentaho.hadoop.shim.cdh51.authorization;
+
+public interface HasHadoopAuthorizationService {
+  public void setHadoopAuthorizationService( HadoopAuthorizationService hadoopAuthorizationService ) throws Exception;
+}

--- a/cdh51/src/org/pentaho/hadoop/shim/cdh51/authorization/NoOpHadoopAuthorizationService.java
+++ b/cdh51/src/org/pentaho/hadoop/shim/cdh51/authorization/NoOpHadoopAuthorizationService.java
@@ -1,0 +1,59 @@
+/*******************************************************************************
+*
+* Pentaho Big Data
+*
+* Copyright (C) 2002-2014 by Pentaho : http://www.pentaho.com
+*
+*******************************************************************************
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License. You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*
+******************************************************************************/
+
+package org.pentaho.hadoop.shim.cdh51.authorization;
+
+import org.pentaho.hadoop.shim.spi.HadoopShim;
+import org.pentaho.hadoop.shim.spi.PentahoHadoopShim;
+import org.pentaho.hadoop.shim.spi.PigShim;
+import org.pentaho.hadoop.shim.spi.SnappyShim;
+import org.pentaho.hadoop.shim.spi.SqoopShim;
+import org.pentaho.hbase.shim.cdh51.wrapper.HBaseShimInterface;
+import org.pentaho.oozie.shim.api.OozieClientFactory;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class NoOpHadoopAuthorizationService implements HadoopAuthorizationService {
+  private final Map<Class<?>, PentahoHadoopShim> shimMap;
+
+  public NoOpHadoopAuthorizationService() {
+    shimMap = new HashMap<Class<?>, PentahoHadoopShim>();
+    shimMap.put( HadoopShim.class, new org.pentaho.hadoop.shim.cdh51.HadoopShim() );
+    shimMap.put( PigShim.class, new org.pentaho.hadoop.shim.common.CommonPigShim() );
+    shimMap.put( SnappyShim.class, new org.pentaho.hadoop.shim.cdh51.SnappyShim() );
+    shimMap.put( SqoopShim.class, new org.pentaho.hadoop.shim.cdh51.ClassPathModifyingSqoopShim() );
+    shimMap.put( HBaseShimInterface.class, new org.pentaho.hbase.shim.cdh51.HBaseShimImpl() );
+    try {
+      shimMap.put( OozieClientFactory.class, (PentahoHadoopShim) Class.forName(
+          "org.pentaho.di.job.entries.oozie.OozieClientFactoryImpl" ).newInstance() );
+    } catch ( Exception e ) {
+      throw new RuntimeException( "Unable to create oozie client factory", e );
+    }
+  }
+
+  @SuppressWarnings( "unchecked" )
+  @Override
+  public synchronized <T extends PentahoHadoopShim> T getShim( Class<T> clazz ) {
+    return (T) shimMap.get( clazz );
+  }
+}

--- a/cdh51/src/org/pentaho/hadoop/shim/cdh51/delegating/DelegatingHBaseConnection.java
+++ b/cdh51/src/org/pentaho/hadoop/shim/cdh51/delegating/DelegatingHBaseConnection.java
@@ -1,0 +1,532 @@
+/*******************************************************************************
+*
+* Pentaho Big Data
+*
+* Copyright (C) 2002-2014 by Pentaho : http://www.pentaho.com
+*
+*******************************************************************************
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License. You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*
+******************************************************************************/
+
+package org.pentaho.hadoop.shim.cdh51.delegating;
+
+import org.pentaho.di.core.variables.VariableSpace;
+import org.pentaho.hbase.shim.api.ColumnFilter;
+import org.pentaho.hbase.shim.api.HBaseValueMeta;
+import org.pentaho.hbase.shim.cdh51.wrapper.HBaseConnectionInterface;
+import org.pentaho.hbase.shim.spi.HBaseBytesUtilShim;
+import org.pentaho.hbase.shim.spi.HBaseConnection;
+
+import java.util.List;
+import java.util.NavigableMap;
+import java.util.Properties;
+
+public class DelegatingHBaseConnection extends HBaseConnection implements HBaseConnectionInterface {
+  private final HBaseConnectionInterface delegate;
+
+  public DelegatingHBaseConnection( HBaseConnectionInterface delegate ) {
+    this.delegate = delegate;
+  }
+
+  /*
+   * (non-Javadoc)
+   *
+   * @see
+   * org.pentaho.hadoop.shim.mapr31.delegatingShims.HBaseConnectionInterface#addColumnFilterToScan(org.pentaho.hbase
+   * .shim.api.ColumnFilter, org.pentaho.hbase.shim.api.HBaseValueMeta, org.pentaho.di.core.variables.VariableSpace,
+   * boolean)
+   */
+  @Override
+  public void addColumnFilterToScan( ColumnFilter cf, HBaseValueMeta columnMeta, VariableSpace vars, boolean matchAny )
+    throws Exception {
+    delegate.addColumnFilterToScan( cf, columnMeta, vars, matchAny );
+  }
+
+  /*
+   * (non-Javadoc)
+   *
+   * @see org.pentaho.hadoop.shim.mapr31.delegatingShims.HBaseConnectionInterface#addColumnToScan(java.lang.String,
+   * java.lang.String, boolean)
+   */
+  @Override
+  public void addColumnToScan( String colFamilyName, String colName, boolean colNameIsBinary ) throws Exception {
+    delegate.addColumnToScan( colFamilyName, colName, colNameIsBinary );
+  }
+
+  /*
+   * (non-Javadoc)
+   *
+   * @see org.pentaho.hadoop.shim.mapr31.delegatingShims.HBaseConnectionInterface#addColumnToTargetPut(java.lang.String,
+   * java.lang.String, boolean, byte[])
+   */
+  @Override
+  public void addColumnToTargetPut( String columnFamily, String columnName, boolean colNameIsBinary, byte[] colValue )
+    throws Exception {
+    delegate.addColumnToTargetPut( columnFamily, columnName, colNameIsBinary, colValue );
+  }
+
+  /*
+   * (non-Javadoc)
+   *
+   * @see org.pentaho.hadoop.shim.mapr31.delegatingShims.HBaseConnectionInterface#checkForHBaseRow(java.lang.Object)
+   */
+  @Override
+  public boolean checkForHBaseRow( Object rowToCheck ) {
+    return delegate.checkForHBaseRow( rowToCheck );
+  }
+
+  /*
+   * (non-Javadoc)
+   *
+   * @see org.pentaho.hadoop.shim.mapr31.delegatingShims.HBaseConnectionInterface#checkHBaseAvailable()
+   */
+  @Override
+  public void checkHBaseAvailable() throws Exception {
+    delegate.checkHBaseAvailable();
+  }
+
+  /*
+   * (non-Javadoc)
+   *
+   * @see org.pentaho.hadoop.shim.mapr31.delegatingShims.HBaseConnectionInterface#closeSourceResultSet()
+   */
+  @Override
+  public void closeSourceResultSet() throws Exception {
+    delegate.closeSourceResultSet();
+  }
+
+  /*
+   * (non-Javadoc)
+   *
+   * @see org.pentaho.hadoop.shim.mapr31.delegatingShims.HBaseConnectionInterface#closeSourceTable()
+   */
+  @Override
+  public void closeSourceTable() throws Exception {
+    delegate.closeSourceTable();
+  }
+
+  /*
+   * (non-Javadoc)
+   *
+   * @see org.pentaho.hadoop.shim.mapr31.delegatingShims.HBaseConnectionInterface#closeTargetTable()
+   */
+  @Override
+  public void closeTargetTable() throws Exception {
+    delegate.closeTargetTable();
+  }
+
+  /*
+   * (non-Javadoc)
+   *
+   * @see
+   * org.pentaho.hadoop.shim.mapr31.delegatingShims.HBaseConnectionInterface#configureConnection(java.util.Properties,
+   * java.util.List)
+   */
+  @Override
+  public void configureConnection( Properties connProps, List<String> logMessages ) throws Exception {
+    delegate.configureConnection( connProps, logMessages );
+  }
+
+  /*
+   * (non-Javadoc)
+   *
+   * @see org.pentaho.hadoop.shim.mapr31.delegatingShims.HBaseConnectionInterface#createTable(java.lang.String,
+   * java.util.List, java.util.Properties)
+   */
+  @Override
+  public void createTable( String tableName, List<String> colFamilyNames, Properties creationProps ) throws Exception {
+    delegate.createTable( tableName, colFamilyNames, creationProps );
+  }
+
+  /*
+   * (non-Javadoc)
+   *
+   * @see org.pentaho.hadoop.shim.mapr31.delegatingShims.HBaseConnectionInterface#deleteTable(java.lang.String)
+   */
+  @Override
+  public void deleteTable( String tableName ) throws Exception {
+    delegate.deleteTable( tableName );
+  }
+
+  /*
+   * (non-Javadoc)
+   *
+   * @see org.pentaho.hadoop.shim.mapr31.delegatingShims.HBaseConnectionInterface#disableTable(java.lang.String)
+   */
+  @Override
+  public void disableTable( String tableName ) throws Exception {
+    delegate.disableTable( tableName );
+  }
+
+  /*
+   * (non-Javadoc)
+   *
+   * @see org.pentaho.hadoop.shim.mapr31.delegatingShims.HBaseConnectionInterface#enableTable(java.lang.String)
+   */
+  @Override
+  public void enableTable( String tableName ) throws Exception {
+    delegate.enableTable( tableName );
+  }
+
+  /*
+   * (non-Javadoc)
+   *
+   * @see org.pentaho.hadoop.shim.mapr31.delegatingShims.HBaseConnectionInterface#equals(java.lang.Object)
+   */
+  @Override
+  public boolean equals( Object obj ) {
+    return delegate.equals( obj );
+  }
+
+  /*
+   * (non-Javadoc)
+   *
+   * @see org.pentaho.hadoop.shim.mapr31.delegatingShims.HBaseConnectionInterface#executeSourceTableScan()
+   */
+  @Override
+  public void executeSourceTableScan() throws Exception {
+    delegate.executeSourceTableScan();
+  }
+
+  /*
+   * (non-Javadoc)
+   *
+   * @see org.pentaho.hadoop.shim.mapr31.delegatingShims.HBaseConnectionInterface#executeTargetTableDelete(byte[])
+   */
+  @Override
+  public void executeTargetTableDelete( byte[] rowKey ) throws Exception {
+    delegate.executeTargetTableDelete( rowKey );
+  }
+
+  /*
+   * (non-Javadoc)
+   *
+   * @see org.pentaho.hadoop.shim.mapr31.delegatingShims.HBaseConnectionInterface#executeTargetTablePut()
+   */
+  @Override
+  public void executeTargetTablePut() throws Exception {
+    delegate.executeTargetTablePut();
+  }
+
+  /*
+   * (non-Javadoc)
+   *
+   * @see org.pentaho.hadoop.shim.mapr31.delegatingShims.HBaseConnectionInterface#flushCommitsTargetTable()
+   */
+  @Override
+  public void flushCommitsTargetTable() throws Exception {
+    delegate.flushCommitsTargetTable();
+  }
+
+  /*
+   * (non-Javadoc)
+   *
+   * @see org.pentaho.hadoop.shim.mapr31.delegatingShims.HBaseConnectionInterface#getBloomTypeClass()
+   */
+  @Override
+  public Class<?> getBloomTypeClass() throws ClassNotFoundException {
+    return delegate.getBloomTypeClass();
+  }
+
+  /*
+   * (non-Javadoc)
+   *
+   * @see org.pentaho.hadoop.shim.mapr31.delegatingShims.HBaseConnectionInterface#getByteArrayComparableClass()
+   */
+  @Override
+  public Class<?> getByteArrayComparableClass() throws ClassNotFoundException {
+    return delegate.getByteArrayComparableClass();
+  }
+
+  /*
+   * (non-Javadoc)
+   *
+   * @see org.pentaho.hadoop.shim.mapr31.delegatingShims.HBaseConnectionInterface#getBytesUtil()
+   */
+  @Override
+  public HBaseBytesUtilShim getBytesUtil() throws Exception {
+    return delegate.getBytesUtil();
+  }
+
+  /*
+   * (non-Javadoc)
+   *
+   * @see org.pentaho.hadoop.shim.mapr31.delegatingShims.HBaseConnectionInterface#getCompressionAlgorithmClass()
+   */
+  @Override
+  public Class<?> getCompressionAlgorithmClass() throws ClassNotFoundException {
+    return delegate.getCompressionAlgorithmClass();
+  }
+
+  /*
+   * (non-Javadoc)
+   *
+   * @see
+   * org.pentaho.hadoop.shim.mapr31.delegatingShims.HBaseConnectionInterface#getDeserializedBooleanComparatorClass()
+   */
+  @Override
+  public Class<?> getDeserializedBooleanComparatorClass() throws ClassNotFoundException {
+    return delegate.getDeserializedBooleanComparatorClass();
+  }
+
+  /*
+   * (non-Javadoc)
+   *
+   * @see
+   * org.pentaho.hadoop.shim.mapr31.delegatingShims.HBaseConnectionInterface#getDeserializedNumericComparatorClass()
+   */
+  @Override
+  public Class<?> getDeserializedNumericComparatorClass() throws ClassNotFoundException {
+    return delegate.getDeserializedNumericComparatorClass();
+  }
+
+  /*
+   * (non-Javadoc)
+   *
+   * @see
+   * org.pentaho.hadoop.shim.mapr31.delegatingShims.HBaseConnectionInterface#getResultSetCurrentRowColumnLatest(java
+   * .lang.String, java.lang.String, boolean)
+   */
+  @Override
+  public byte[] getResultSetCurrentRowColumnLatest( String colFamilyName, String colName, boolean colNameIsBinary )
+    throws Exception {
+    return delegate.getResultSetCurrentRowColumnLatest( colFamilyName, colName, colNameIsBinary );
+  }
+
+  /*
+   * (non-Javadoc)
+   *
+   * @see
+   * org.pentaho.hadoop.shim.mapr31.delegatingShims.HBaseConnectionInterface#getResultSetCurrentRowFamilyMap(java.lang
+   * .String)
+   */
+  @Override
+  public NavigableMap<byte[], byte[]> getResultSetCurrentRowFamilyMap( String familyName ) throws Exception {
+    return delegate.getResultSetCurrentRowFamilyMap( familyName );
+  }
+
+  /*
+   * (non-Javadoc)
+   *
+   * @see org.pentaho.hadoop.shim.mapr31.delegatingShims.HBaseConnectionInterface#getResultSetCurrentRowKey()
+   */
+  @Override
+  public byte[] getResultSetCurrentRowKey() throws Exception {
+    return delegate.getResultSetCurrentRowKey();
+  }
+
+  /*
+   * (non-Javadoc)
+   *
+   * @see org.pentaho.hadoop.shim.mapr31.delegatingShims.HBaseConnectionInterface#getResultSetCurrentRowMap()
+   */
+  @Override
+  public NavigableMap<byte[], NavigableMap<byte[], NavigableMap<Long, byte[]>>> getResultSetCurrentRowMap()
+    throws Exception {
+    return delegate.getResultSetCurrentRowMap();
+  }
+
+  /*
+   * (non-Javadoc)
+   *
+   * @see org.pentaho.hadoop.shim.mapr31.delegatingShims.HBaseConnectionInterface#getRowColumnLatest(java.lang.Object,
+   * java.lang.String, java.lang.String, boolean)
+   */
+  @Override
+  public byte[] getRowColumnLatest( Object aRow, String colFamilyName, String colName, boolean colNameIsBinary )
+    throws Exception {
+    return delegate.getRowColumnLatest( aRow, colFamilyName, colName, colNameIsBinary );
+  }
+
+  /*
+   * (non-Javadoc)
+   *
+   * @see org.pentaho.hadoop.shim.mapr31.delegatingShims.HBaseConnectionInterface#getRowFamilyMap(java.lang.Object,
+   * java.lang.String)
+   */
+  @Override
+  public NavigableMap<byte[], byte[]> getRowFamilyMap( Object aRow, String familyName ) throws Exception {
+    return delegate.getRowFamilyMap( aRow, familyName );
+  }
+
+  /*
+   * (non-Javadoc)
+   *
+   * @see org.pentaho.hadoop.shim.mapr31.delegatingShims.HBaseConnectionInterface#getRowKey(java.lang.Object)
+   */
+  @Override
+  public byte[] getRowKey( Object aRow ) throws Exception {
+    return delegate.getRowKey( aRow );
+  }
+
+  /*
+   * (non-Javadoc)
+   *
+   * @see org.pentaho.hadoop.shim.mapr31.delegatingShims.HBaseConnectionInterface#getRowMap(java.lang.Object)
+   */
+  @Override
+  public NavigableMap<byte[], NavigableMap<byte[], NavigableMap<Long, byte[]>>> getRowMap( Object aRow )
+    throws Exception {
+    return delegate.getRowMap( aRow );
+  }
+
+  /*
+   * (non-Javadoc)
+   *
+   * @see org.pentaho.hadoop.shim.mapr31.delegatingShims.HBaseConnectionInterface#getTableFamiles(java.lang.String)
+   */
+  @Override
+  public List<String> getTableFamiles( String tableName ) throws Exception {
+    return delegate.getTableFamiles( tableName );
+  }
+
+  /*
+   * (non-Javadoc)
+   *
+   * @see org.pentaho.hadoop.shim.mapr31.delegatingShims.HBaseConnectionInterface#hashCode()
+   */
+  @Override
+  public int hashCode() {
+    return delegate.hashCode();
+  }
+
+  /*
+   * (non-Javadoc)
+   *
+   * @see
+   * org.pentaho.hadoop.shim.mapr31.delegatingShims.HBaseConnectionInterface#isImmutableBytesWritable(java.lang.Object)
+   */
+  @Override
+  public boolean isImmutableBytesWritable( Object o ) {
+    return delegate.isImmutableBytesWritable( o );
+  }
+
+  /*
+   * (non-Javadoc)
+   *
+   * @see org.pentaho.hadoop.shim.mapr31.delegatingShims.HBaseConnectionInterface#isTableAvailable(java.lang.String)
+   */
+  @Override
+  public boolean isTableAvailable( String tableName ) throws Exception {
+    return delegate.isTableAvailable( tableName );
+  }
+
+  /*
+   * (non-Javadoc)
+   *
+   * @see org.pentaho.hadoop.shim.mapr31.delegatingShims.HBaseConnectionInterface#isTableDisabled(java.lang.String)
+   */
+  @Override
+  public boolean isTableDisabled( String tableName ) throws Exception {
+    return delegate.isTableDisabled( tableName );
+  }
+
+  /*
+   * (non-Javadoc)
+   *
+   * @see org.pentaho.hadoop.shim.mapr31.delegatingShims.HBaseConnectionInterface#listTableNames()
+   */
+  @Override
+  public List<String> listTableNames() throws Exception {
+    return delegate.listTableNames();
+  }
+
+  /*
+   * (non-Javadoc)
+   *
+   * @see org.pentaho.hadoop.shim.mapr31.delegatingShims.HBaseConnectionInterface#newSourceTable(java.lang.String)
+   */
+  @Override
+  public void newSourceTable( String tableName ) throws Exception {
+    delegate.newSourceTable( tableName );
+  }
+
+  /*
+   * (non-Javadoc)
+   *
+   * @see org.pentaho.hadoop.shim.mapr31.delegatingShims.HBaseConnectionInterface#newSourceTableScan(byte[], byte[],
+   * int)
+   */
+  @Override
+  public void newSourceTableScan( byte[] keyLowerBound, byte[] keyUpperBound, int cacheSize ) throws Exception {
+    delegate.newSourceTableScan( keyLowerBound, keyUpperBound, cacheSize );
+  }
+
+  /*
+   * (non-Javadoc)
+   *
+   * @see org.pentaho.hadoop.shim.mapr31.delegatingShims.HBaseConnectionInterface#newTargetTable(java.lang.String,
+   * java.util.Properties)
+   */
+  @Override
+  public void newTargetTable( String tableName, Properties props ) throws Exception {
+    delegate.newTargetTable( tableName, props );
+  }
+
+  /*
+   * (non-Javadoc)
+   *
+   * @see org.pentaho.hadoop.shim.mapr31.delegatingShims.HBaseConnectionInterface#newTargetTablePut(byte[], boolean)
+   */
+  @Override
+  public void newTargetTablePut( byte[] key, boolean writeToWAL ) throws Exception {
+    delegate.newTargetTablePut( key, writeToWAL );
+  }
+
+  /*
+   * (non-Javadoc)
+   *
+   * @see org.pentaho.hadoop.shim.mapr31.delegatingShims.HBaseConnectionInterface#resultSetNextRow()
+   */
+  @Override
+  public boolean resultSetNextRow() throws Exception {
+    return delegate.resultSetNextRow();
+  }
+
+  /*
+   * (non-Javadoc)
+   *
+   * @see org.pentaho.hadoop.shim.mapr31.delegatingShims.HBaseConnectionInterface#sourceTableRowExists(byte[])
+   */
+  @Override
+  public boolean sourceTableRowExists( byte[] rowKey ) throws Exception {
+    return delegate.sourceTableRowExists( rowKey );
+  }
+
+  /*
+   * (non-Javadoc)
+   *
+   * @see org.pentaho.hadoop.shim.mapr31.delegatingShims.HBaseConnectionInterface#tableExists(java.lang.String)
+   */
+  @Override
+  public boolean tableExists( String tableName ) throws Exception {
+    return delegate.tableExists( tableName );
+  }
+
+  /*
+   * (non-Javadoc)
+   *
+   * @see org.pentaho.hadoop.shim.mapr31.delegatingShims.HBaseConnectionInterface#targetTableIsAutoFlush()
+   */
+  @Override
+  public boolean targetTableIsAutoFlush() throws Exception {
+    return delegate.targetTableIsAutoFlush();
+  }
+
+  @Override
+  public String toString() {
+    return delegate.toString();
+  }
+}

--- a/cdh51/src/org/pentaho/hadoop/shim/cdh51/delegating/DelegatingHBaseShim.java
+++ b/cdh51/src/org/pentaho/hadoop/shim/cdh51/delegating/DelegatingHBaseShim.java
@@ -1,0 +1,55 @@
+/*******************************************************************************
+*
+* Pentaho Big Data
+*
+* Copyright (C) 2002-2014 by Pentaho : http://www.pentaho.com
+*
+*******************************************************************************
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License. You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*
+******************************************************************************/
+
+package org.pentaho.hadoop.shim.cdh51.delegating;
+
+import org.apache.hadoop.conf.Configuration;
+import org.pentaho.hadoop.shim.ShimVersion;
+import org.pentaho.hadoop.shim.cdh51.authorization.HadoopAuthorizationService;
+import org.pentaho.hadoop.shim.cdh51.authorization.HasHadoopAuthorizationService;
+import org.pentaho.hbase.shim.cdh51.wrapper.HBaseShimInterface;
+import org.pentaho.hbase.shim.spi.HBaseConnection;
+import org.pentaho.hbase.shim.spi.HBaseShim;
+
+public class DelegatingHBaseShim extends HBaseShim implements HasHadoopAuthorizationService, HBaseShimInterface {
+  private HBaseShimInterface delegate;
+
+  @Override
+  public ShimVersion getVersion() {
+    return delegate.getVersion();
+  }
+
+  @Override
+  public void setHadoopAuthorizationService( HadoopAuthorizationService hadoopAuthorizationService ) {
+    delegate = hadoopAuthorizationService.getShim( HBaseShimInterface.class );
+  }
+
+  @Override
+  public HBaseConnection getHBaseConnection() {
+    return delegate.getHBaseConnection();
+  }
+
+  @Override
+  public void setInfo( Configuration configuration ) {
+    delegate.setInfo( configuration );
+  }
+}

--- a/cdh51/src/org/pentaho/hadoop/shim/cdh51/delegating/DelegatingHadoopShim.java
+++ b/cdh51/src/org/pentaho/hadoop/shim/cdh51/delegating/DelegatingHadoopShim.java
@@ -1,0 +1,138 @@
+/*******************************************************************************
+*
+* Pentaho Big Data
+*
+* Copyright (C) 2002-2014 by Pentaho : http://www.pentaho.com
+*
+*******************************************************************************
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License. You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*
+******************************************************************************/
+
+package org.pentaho.hadoop.shim.cdh51.delegating;
+
+import org.pentaho.di.core.row.ValueMetaInterface;
+import org.pentaho.hadoop.shim.ConfigurationException;
+import org.pentaho.hadoop.shim.HadoopConfiguration;
+import org.pentaho.hadoop.shim.HadoopConfigurationFileSystemManager;
+import org.pentaho.hadoop.shim.ShimVersion;
+import org.pentaho.hadoop.shim.api.Configuration;
+import org.pentaho.hadoop.shim.api.DistributedCacheUtil;
+import org.pentaho.hadoop.shim.api.fs.FileSystem;
+import org.pentaho.hadoop.shim.api.mapred.RunningJob;
+import org.pentaho.hadoop.shim.cdh51.authorization.HadoopAuthorizationService;
+import org.pentaho.hadoop.shim.cdh51.authorization.HasHadoopAuthorizationService;
+import org.pentaho.hadoop.shim.spi.HadoopShim;
+
+import java.io.IOException;
+import java.sql.Driver;
+import java.util.List;
+
+public class DelegatingHadoopShim implements HadoopShim, HasHadoopAuthorizationService {
+  public static final String SUPER_USER = "authentication.superuser.provider";
+  public static final String PROVIDER_LIST = "authentication.provider.list";
+  private HadoopShim delegate = null;
+
+  @Override
+  public void onLoad( HadoopConfiguration config, HadoopConfigurationFileSystemManager fsm ) throws Exception {
+    delegate.onLoad( config, fsm );
+  }
+
+  @Override
+  public void setHadoopAuthorizationService( HadoopAuthorizationService hadoopAuthorizationService ) throws Exception {
+    delegate = hadoopAuthorizationService.getShim( HadoopShim.class );
+  }
+
+  @Override
+  public ShimVersion getVersion() {
+    return delegate.getVersion();
+  }
+
+  @SuppressWarnings( "deprecation" )
+  @Override
+  public Driver getHiveJdbcDriver() {
+    return delegate.getHiveJdbcDriver();
+  }
+
+  @Override
+  public Driver getJdbcDriver( String driverType ) {
+    return delegate.getJdbcDriver( driverType );
+  }
+
+  @Override
+  public String[] getNamenodeConnectionInfo( Configuration c ) {
+    return delegate.getNamenodeConnectionInfo( c );
+  }
+
+  @Override
+  public String[] getJobtrackerConnectionInfo( Configuration c ) {
+    return delegate.getJobtrackerConnectionInfo( c );
+  }
+
+  @Override
+  public String getHadoopVersion() {
+    return delegate.getHadoopVersion();
+  }
+
+  @Override
+  public Configuration createConfiguration() {
+    return delegate.createConfiguration();
+  }
+
+  @Override
+  public FileSystem getFileSystem( Configuration conf ) throws IOException {
+    return delegate.getFileSystem( conf );
+  }
+
+  @Override
+  public void configureConnectionInformation( String namenodeHost, String namenodePort, String jobtrackerHost,
+      String jobtrackerPort, Configuration conf, List<String> logMessages ) throws Exception {
+    delegate.configureConnectionInformation( namenodeHost, namenodePort, jobtrackerHost, jobtrackerPort, conf,
+        logMessages );
+  }
+
+  @Override
+  public DistributedCacheUtil getDistributedCacheUtil() throws ConfigurationException {
+    return delegate.getDistributedCacheUtil();
+  }
+
+  @Override
+  public RunningJob submitJob( Configuration c ) throws IOException {
+    return delegate.submitJob( c );
+  }
+
+  @SuppressWarnings( "deprecation" )
+  @Override
+  public Class<?> getHadoopWritableCompatibleClass( ValueMetaInterface kettleType ) {
+    return delegate.getHadoopWritableCompatibleClass( kettleType );
+  }
+
+  @SuppressWarnings( "deprecation" )
+  @Override
+  public Class<?> getPentahoMapReduceCombinerClass() {
+    return delegate.getPentahoMapReduceCombinerClass();
+  }
+
+  @SuppressWarnings( "deprecation" )
+  @Override
+  public Class<?> getPentahoMapReduceReducerClass() {
+    return delegate.getPentahoMapReduceReducerClass();
+  }
+
+  @SuppressWarnings( "deprecation" )
+  @Override
+  public Class<?> getPentahoMapReduceMapRunnerClass() {
+    return delegate.getPentahoMapReduceMapRunnerClass();
+  }
+}

--- a/cdh51/src/org/pentaho/hadoop/shim/cdh51/delegating/DelegatingOozieClientFactory.java
+++ b/cdh51/src/org/pentaho/hadoop/shim/cdh51/delegating/DelegatingOozieClientFactory.java
@@ -1,0 +1,49 @@
+/*******************************************************************************
+*
+* Pentaho Big Data
+*
+* Copyright (C) 2002-2014 by Pentaho : http://www.pentaho.com
+*
+*******************************************************************************
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License. You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*
+******************************************************************************/
+
+package org.pentaho.hadoop.shim.cdh51.delegating;
+
+import org.pentaho.hadoop.shim.ShimVersion;
+import org.pentaho.hadoop.shim.cdh51.authorization.HadoopAuthorizationService;
+import org.pentaho.hadoop.shim.cdh51.authorization.HasHadoopAuthorizationService;
+import org.pentaho.oozie.shim.api.OozieClient;
+import org.pentaho.oozie.shim.api.OozieClientFactory;
+
+public class DelegatingOozieClientFactory implements OozieClientFactory, HasHadoopAuthorizationService {
+  private OozieClientFactory delegate;
+
+  @Override
+  public ShimVersion getVersion() {
+    return delegate.getVersion();
+  }
+
+  @Override
+  public OozieClient create( String oozieUrl ) {
+    return delegate.create( oozieUrl );
+  }
+
+  @Override
+  public void setHadoopAuthorizationService( HadoopAuthorizationService hadoopAuthorizationService ) throws Exception {
+    delegate = hadoopAuthorizationService.getShim( OozieClientFactory.class );
+  }
+
+}

--- a/cdh51/src/org/pentaho/hadoop/shim/cdh51/delegating/DelegatingPigShim.java
+++ b/cdh51/src/org/pentaho/hadoop/shim/cdh51/delegating/DelegatingPigShim.java
@@ -1,0 +1,69 @@
+/*******************************************************************************
+*
+* Pentaho Big Data
+*
+* Copyright (C) 2002-2014 by Pentaho : http://www.pentaho.com
+*
+*******************************************************************************
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License. You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*
+******************************************************************************/
+
+package org.pentaho.hadoop.shim.cdh51.delegating;
+
+import org.pentaho.hadoop.shim.ShimVersion;
+import org.pentaho.hadoop.shim.api.Configuration;
+import org.pentaho.hadoop.shim.cdh51.authorization.HadoopAuthorizationService;
+import org.pentaho.hadoop.shim.cdh51.authorization.HasHadoopAuthorizationService;
+import org.pentaho.hadoop.shim.spi.PigShim;
+
+import java.net.URL;
+import java.util.List;
+import java.util.Properties;
+
+public class DelegatingPigShim implements PigShim, HasHadoopAuthorizationService {
+  private PigShim delegate;
+
+  @Override
+  public void setHadoopAuthorizationService( HadoopAuthorizationService hadoopAuthorizationService ) {
+    delegate = hadoopAuthorizationService.getShim( PigShim.class );
+  }
+
+  @Override
+  public ShimVersion getVersion() {
+    return delegate.getVersion();
+  }
+
+  @Override
+  public boolean isLocalExecutionSupported() {
+    return delegate.isLocalExecutionSupported();
+  }
+
+  @Override
+  public void configure( Properties properties, Configuration configuration ) {
+    delegate.configure( properties, configuration );
+  }
+
+  @Override
+  public String substituteParameters( URL pigScript, List<String> paramList ) throws Exception {
+    return delegate.substituteParameters( pigScript, paramList );
+  }
+
+  @Override
+  public int[] executeScript( String pigScript, ExecutionMode mode, Properties properties ) throws Exception {
+    return delegate.executeScript( pigScript, mode, properties );
+  }
+
+
+}

--- a/cdh51/src/org/pentaho/hadoop/shim/cdh51/delegating/DelegatingSnappyShim.java
+++ b/cdh51/src/org/pentaho/hadoop/shim/cdh51/delegating/DelegatingSnappyShim.java
@@ -1,0 +1,70 @@
+/*******************************************************************************
+*
+* Pentaho Big Data
+*
+* Copyright (C) 2002-2014 by Pentaho : http://www.pentaho.com
+*
+*******************************************************************************
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License. You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*
+******************************************************************************/
+
+package org.pentaho.hadoop.shim.cdh51.delegating;
+
+import org.pentaho.hadoop.shim.ShimVersion;
+import org.pentaho.hadoop.shim.cdh51.authorization.HadoopAuthorizationService;
+import org.pentaho.hadoop.shim.cdh51.authorization.HasHadoopAuthorizationService;
+import org.pentaho.hadoop.shim.spi.SnappyShim;
+
+import java.io.InputStream;
+import java.io.OutputStream;
+
+public class DelegatingSnappyShim implements SnappyShim, HasHadoopAuthorizationService {
+  private SnappyShim delegate;
+
+  @Override
+  public void setHadoopAuthorizationService( HadoopAuthorizationService hadoopAuthorizationService ) {
+    delegate = hadoopAuthorizationService.getShim( SnappyShim.class );
+  }
+
+  @Override
+  public boolean isHadoopSnappyAvailable() {
+    return delegate.isHadoopSnappyAvailable();
+  }
+
+  @Override
+  public ShimVersion getVersion() {
+    return delegate.getVersion();
+  }
+
+  @Override
+  public InputStream getSnappyInputStream( InputStream in ) throws Exception {
+    return delegate.getSnappyInputStream( in );
+  }
+
+  @Override
+  public InputStream getSnappyInputStream( int bufferSize, InputStream in ) throws Exception {
+    return delegate.getSnappyInputStream( bufferSize, in );
+  }
+
+  @Override
+  public OutputStream getSnappyOutputStream( OutputStream out ) throws Exception {
+    return delegate.getSnappyOutputStream( out );
+  }
+
+  @Override
+  public OutputStream getSnappyOutputStream( int bufferSize, OutputStream out ) throws Exception {
+    return delegate.getSnappyOutputStream( bufferSize, out );
+  }
+}

--- a/cdh51/src/org/pentaho/hadoop/shim/cdh51/delegating/DelegatingSqoopShim.java
+++ b/cdh51/src/org/pentaho/hadoop/shim/cdh51/delegating/DelegatingSqoopShim.java
@@ -1,0 +1,48 @@
+/*******************************************************************************
+*
+* Pentaho Big Data
+*
+* Copyright (C) 2002-2014 by Pentaho : http://www.pentaho.com
+*
+*******************************************************************************
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License. You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*
+******************************************************************************/
+
+package org.pentaho.hadoop.shim.cdh51.delegating;
+
+import org.pentaho.hadoop.shim.ShimVersion;
+import org.pentaho.hadoop.shim.api.Configuration;
+import org.pentaho.hadoop.shim.cdh51.authorization.HadoopAuthorizationService;
+import org.pentaho.hadoop.shim.cdh51.authorization.HasHadoopAuthorizationService;
+import org.pentaho.hadoop.shim.spi.SqoopShim;
+
+public class DelegatingSqoopShim implements SqoopShim, HasHadoopAuthorizationService {
+  private SqoopShim delegate;
+
+  @Override
+  public void setHadoopAuthorizationService( HadoopAuthorizationService hadoopAuthorizationService ) {
+    delegate = hadoopAuthorizationService.getShim( SqoopShim.class );
+  }
+
+  @Override
+  public int runTool( String[] args, Configuration c ) {
+    return delegate.runTool( args, c );
+  }
+
+  @Override
+  public ShimVersion getVersion() {
+    return delegate.getVersion();
+  }
+}

--- a/cdh51/src/org/pentaho/hbase/shim/cdh51/DeserializedBooleanComparator.java
+++ b/cdh51/src/org/pentaho/hbase/shim/cdh51/DeserializedBooleanComparator.java
@@ -1,0 +1,191 @@
+/*******************************************************************************
+ *
+ * Pentaho Big Data
+ *
+ * Copyright (C) 2002-2013 by Pentaho : http://www.pentaho.com
+ *
+ *******************************************************************************
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ******************************************************************************/
+
+package org.pentaho.hbase.shim.cdh51;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.DataInput;
+import java.io.DataInputStream;
+import java.io.DataOutput;
+import java.io.DataOutputStream;
+import java.io.IOException;
+
+import org.apache.hadoop.hbase.filter.ByteArrayComparable;
+import org.apache.hadoop.hbase.util.Bytes;
+
+/**
+ * Comparator for use in HBase column filtering that deserializes a boolean column value before performing a comparison.
+ * Various string and numeric deserializations are tried. All representations of "false" (for a given encoding type)
+ * sort before "true" - e.g. "false" < "true"; 0 < 1; "F" < "T"; "N" < "Y" etc. Thus < or > comparisons (excluding <
+ * false and > true) are equivalent to !=.
+ *
+ *
+ * @author Mark Hall (mhall{[at]}pentaho{[dot]}com)
+ * @version $Revision$
+ *
+ */
+public class DeserializedBooleanComparator extends ByteArrayComparable {
+
+  protected Boolean m_value;
+
+  // Use the HBaseBytesUtilShim to convert your boolean to bytes
+  public DeserializedBooleanComparator( byte[] raw ) {
+    super( raw );
+    m_value = Bytes.toBoolean( raw );
+  }
+
+  public DeserializedBooleanComparator( boolean value ) {
+    this( Bytes.toBytes( value ) );
+  }
+
+  public byte[] getValue() {
+    return Bytes.toBytes( m_value.booleanValue() );
+  }
+
+  public void readFields( DataInput in ) throws IOException {
+    m_value = new Boolean( in.readBoolean() );
+  }
+
+  public void write( DataOutput out ) throws IOException {
+    out.writeBoolean( m_value.booleanValue() );
+  }
+
+  public int compareTo( byte[] value ) {
+
+    Boolean decodedValue = decodeBoolFromString( value );
+
+    // if null then try as a number
+    if ( decodedValue == null ) {
+      decodedValue = decodeBoolFromNumber( value );
+    }
+
+    if ( decodedValue != null ) {
+      if ( m_value.equals( decodedValue ) ) {
+        return 0;
+      }
+
+      if ( m_value.booleanValue() == false && decodedValue.booleanValue() == true ) {
+        return -1;
+      }
+
+      return 1;
+    }
+
+    // doesn't matter what we return here because the step wont be able to
+    // decode this value either so an Exception will be raised
+    return 0;
+  }
+
+  public int compareTo( byte[] value, int offset, int length ) {
+    return compareTo( Bytes.copy( value, offset, length ) );
+  }
+
+  public static Boolean decodeBoolFromString( byte[] rawEncoded ) {
+    String tempString = Bytes.toString( rawEncoded );
+    if ( tempString.equalsIgnoreCase( "Y" ) || tempString.equalsIgnoreCase( "N" )
+        || tempString.equalsIgnoreCase( "YES" ) || tempString.equalsIgnoreCase( "NO" )
+        || tempString.equalsIgnoreCase( "TRUE" ) || tempString.equalsIgnoreCase( "FALSE" )
+        || tempString.equalsIgnoreCase( "T" ) || tempString.equalsIgnoreCase( "F" )
+        || tempString.equalsIgnoreCase( "1" ) || tempString.equalsIgnoreCase( "0" ) ) {
+
+      return Boolean.valueOf( tempString.equalsIgnoreCase( "Y" ) || tempString.equalsIgnoreCase( "YES" )
+          || tempString.equalsIgnoreCase( "TRUE" ) || tempString.equalsIgnoreCase( "T" )
+          || tempString.equalsIgnoreCase( "1" ) );
+    }
+
+    // not identifiable from a string
+    return null;
+  }
+
+  public static Boolean decodeBoolFromNumber( byte[] rawEncoded ) {
+    if ( rawEncoded.length == Bytes.SIZEOF_BYTE ) {
+      byte val = rawEncoded[0];
+      if ( val == 0 || val == 1 ) {
+        return new Boolean( val == 1 );
+      }
+    }
+
+    if ( rawEncoded.length == Bytes.SIZEOF_SHORT ) {
+      short tempShort = Bytes.toShort( rawEncoded );
+
+      if ( tempShort == 0 || tempShort == 1 ) {
+        return new Boolean( tempShort == 1 );
+      }
+    }
+
+    if ( rawEncoded.length == Bytes.SIZEOF_INT || rawEncoded.length == Bytes.SIZEOF_FLOAT ) {
+      int tempInt = Bytes.toInt( rawEncoded );
+      if ( tempInt == 1 || tempInt == 0 ) {
+        return new Boolean( tempInt == 1 );
+      }
+
+      float tempFloat = Bytes.toFloat( rawEncoded );
+      if ( tempFloat == 0.0f || tempFloat == 1.0f ) {
+        return new Boolean( tempFloat == 1.0f );
+      }
+    }
+
+    if ( rawEncoded.length == Bytes.SIZEOF_LONG || rawEncoded.length == Bytes.SIZEOF_DOUBLE ) {
+      long tempLong = Bytes.toLong( rawEncoded );
+      if ( tempLong == 0L || tempLong == 1L ) {
+        return new Boolean( tempLong == 1L );
+      }
+
+      double tempDouble = Bytes.toDouble( rawEncoded );
+      if ( tempDouble == 0.0 || tempDouble == 1.0 ) {
+        return new Boolean( tempDouble == 1.0 );
+      }
+    }
+
+    // not identifiable from a number
+    return null;
+  }
+
+  @Override
+  public byte[] toByteArray() {
+    ByteArrayOutputStream byteArrayOutputStream = new ByteArrayOutputStream();
+    DataOutputStream output = new DataOutputStream( byteArrayOutputStream );
+    try {
+      write( output );
+      output.close();
+      byteArrayOutputStream.close();
+      return byteArrayOutputStream.toByteArray();
+    } catch ( IOException e ) {
+      throw new RuntimeException( "Unable to serialize to byte array.", e );
+    }
+  }
+
+  /**
+   * Needed for hbase-0.95+
+   * @throws IOException
+   */
+  public static ByteArrayComparable parseFrom(final byte [] pbBytes) {
+    DataInput in = new DataInputStream( new ByteArrayInputStream( pbBytes ) );
+    try {
+      boolean m_value = new Boolean( in.readBoolean() );
+      return new DeserializedBooleanComparator( m_value );
+    } catch ( IOException e ) {
+      throw new RuntimeException( "Unable to deserialize byte array", e );
+    }
+  }
+}

--- a/cdh51/src/org/pentaho/hbase/shim/cdh51/DeserializedNumericComparator.java
+++ b/cdh51/src/org/pentaho/hbase/shim/cdh51/DeserializedNumericComparator.java
@@ -1,0 +1,162 @@
+/*******************************************************************************
+ *
+ * Pentaho Big Data
+ *
+ * Copyright (C) 2002-2013 by Pentaho : http://www.pentaho.com
+ *
+ *******************************************************************************
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ******************************************************************************/
+
+package org.pentaho.hbase.shim.cdh51;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.DataInput;
+import java.io.DataInputStream;
+import java.io.DataOutput;
+import java.io.DataOutputStream;
+import java.io.IOException;
+
+import org.apache.hadoop.hbase.filter.ByteArrayComparable;
+import org.apache.hadoop.hbase.util.Bytes;
+
+/**
+ * Comparator for use in HBase column filtering that deserializes a numeric column value before performing a comparison.
+ * Comparators built-in to HBase only perform comparisons based on the lexicographical ordering of the bytes in values.
+ * This works ok for positive numbers but does not work when there are negative numbers involved in the comparison.
+ *
+ * @author Mark Hall (mhall{[at]}pentaho{[dot]}com)
+ * @version $Revision$
+ *
+ */
+public class DeserializedNumericComparator extends ByteArrayComparable {
+
+  protected long m_longValue;
+
+  protected double m_doubleValue;
+
+  protected boolean m_isInteger;
+  protected boolean m_isLongOrDouble;
+
+  public DeserializedNumericComparator( byte[] raw ) {
+    super( raw );
+  }
+
+  public DeserializedNumericComparator( boolean isInteger, boolean isLongOrDouble, long value ) {
+    this( Bytes.toBytes( value ) );
+    m_isInteger = isInteger;
+    m_isLongOrDouble = isLongOrDouble;
+    m_longValue = value;
+  }
+
+  public DeserializedNumericComparator( boolean isInteger, boolean isLongOrDouble, double value ) {
+    this( Bytes.toBytes( value ) );
+    m_isInteger = isInteger;
+    m_isLongOrDouble = isLongOrDouble;
+
+    m_doubleValue = value;
+  }
+
+  public byte[] getValue() {
+    if ( m_isInteger ) {
+      return Bytes.toBytes( m_longValue );
+    }
+
+    return Bytes.toBytes( m_doubleValue );
+  }
+
+  // TODO - remove?
+  public void readFields( DataInput in ) throws IOException {
+    m_isInteger = in.readBoolean();
+    m_isLongOrDouble = in.readBoolean();
+    m_longValue = in.readLong();
+    m_doubleValue = in.readDouble();
+  }
+
+  // TODO - remove?
+  public void write( DataOutput out ) throws IOException {
+    out.writeBoolean( m_isInteger );
+    out.writeBoolean( m_isLongOrDouble );
+    out.writeLong( m_longValue );
+    out.writeDouble( m_doubleValue );
+  }
+
+  @Override
+  public int compareTo( byte[] value ) {
+    if ( m_isInteger ) {
+      long compV;
+      if ( value.length == Bytes.SIZEOF_LONG ) {
+        compV = Bytes.toLong( value );
+      } else if ( value.length == Bytes.SIZEOF_INT ) {
+        compV = Bytes.toInt( value );
+      } else {
+        compV = Bytes.toShort( value );
+      }
+
+      Long l = new Long( m_longValue );
+      return l.compareTo( compV );
+    }
+
+    double compV;
+    if ( value.length == Bytes.SIZEOF_DOUBLE ) {
+      compV = Bytes.toDouble( value );
+    } else {
+      compV = Bytes.toFloat( value );
+    }
+
+    Double d = new Double( m_doubleValue );
+    return d.compareTo( compV );
+  }
+
+  public int compareTo( byte[] value, int offset, int length ) {
+    return compareTo( Bytes.copy( value, offset, length ) );
+  }
+
+  @Override
+  public byte[] toByteArray() {
+    ByteArrayOutputStream byteArrayOutputStream = new ByteArrayOutputStream();
+    DataOutputStream output = new DataOutputStream( byteArrayOutputStream );
+    try {
+      write( output );
+      output.close();
+      byteArrayOutputStream.close();
+      return byteArrayOutputStream.toByteArray();
+    } catch ( IOException e ) {
+      throw new RuntimeException( "Unable to serialize to byte array.", e );
+    }
+  }
+
+  /**
+   * Needed for hbase-0.95+
+   * @throws IOException
+   */
+  public static ByteArrayComparable parseFrom(final byte [] pbBytes) {
+    DataInput in = new DataInputStream( new ByteArrayInputStream( pbBytes ) );
+    try {
+      boolean m_isInteger = in.readBoolean();
+      boolean m_isLongOrDouble = in.readBoolean();
+      long m_longValue = in.readLong();
+      double m_doubleValue = in.readDouble();
+      if (m_isInteger) {
+        return new DeserializedNumericComparator( m_isInteger, m_isLongOrDouble, m_longValue );
+      } else {
+        return new DeserializedNumericComparator( m_isInteger, m_isLongOrDouble, m_doubleValue );
+      }
+    } catch ( IOException e ) {
+      throw new RuntimeException( "Unable to deserialize byte array", e );
+    }
+  }
+}

--- a/cdh51/src/org/pentaho/hbase/shim/cdh51/HBaseConnectionImpl.java
+++ b/cdh51/src/org/pentaho/hbase/shim/cdh51/HBaseConnectionImpl.java
@@ -1,0 +1,32 @@
+package org.pentaho.hbase.shim.cdh51;
+
+import org.pentaho.hbase.shim.common.CommonHBaseConnection;
+import org.pentaho.hbase.shim.cdh51.wrapper.HBaseConnectionInterface;
+
+public class HBaseConnectionImpl extends CommonHBaseConnection implements HBaseConnectionInterface {
+
+  @Override
+  public Class<?> getByteArrayComparableClass() throws ClassNotFoundException {
+    return Class.forName( "org.apache.hadoop.hbase.filter.ByteArrayComparable" );
+  }
+
+  @Override
+  public Class<?> getCompressionAlgorithmClass() throws ClassNotFoundException {
+    return Class.forName( "org.apache.hadoop.hbase.io.compress.Compression.Algorithm" );
+  }
+
+  @Override
+  public Class<?> getBloomTypeClass() throws ClassNotFoundException {
+    return Class.forName( "org.apache.hadoop.hbase.regionserver.BloomType" );
+  }
+
+  @Override
+  public Class<?> getDeserializedNumericComparatorClass() throws ClassNotFoundException {
+    return Class.forName( "org.pentaho.hbase.shim.cdh51.DeserializedNumericComparator" );
+  }
+
+  @Override
+  public Class<?> getDeserializedBooleanComparatorClass() throws ClassNotFoundException {
+    return Class.forName( "org.pentaho.hbase.shim.cdh51.DeserializedBooleanComparator" );
+  }
+}

--- a/cdh51/src/org/pentaho/hbase/shim/cdh51/HBaseShimImpl.java
+++ b/cdh51/src/org/pentaho/hbase/shim/cdh51/HBaseShimImpl.java
@@ -1,0 +1,25 @@
+package org.pentaho.hbase.shim.cdh51;
+
+import org.apache.hadoop.conf.Configuration;
+import org.pentaho.hadoop.shim.ShimVersion;
+import org.pentaho.hbase.shim.cdh51.wrapper.HBaseShimInterface;
+import org.pentaho.hbase.shim.spi.HBaseConnection;
+import org.pentaho.hbase.shim.spi.HBaseShim;
+
+public class HBaseShimImpl extends HBaseShim implements HBaseShimInterface {
+
+  @Override
+  public ShimVersion getVersion() {
+    return new ShimVersion( 1, 0 );
+  }
+
+  public HBaseConnection getHBaseConnection() {
+    return new HBaseConnectionImpl();
+  }
+
+  @Override
+  public void setInfo( Configuration configuration ) {
+    // noop
+  }
+
+}

--- a/cdh51/src/org/pentaho/hbase/shim/cdh51/wrapper/HBaseConnectionInterface.java
+++ b/cdh51/src/org/pentaho/hbase/shim/cdh51/wrapper/HBaseConnectionInterface.java
@@ -1,0 +1,132 @@
+/*******************************************************************************
+ *
+ * Pentaho Big Data
+ *
+ * Copyright (C) 2002-2014 by Pentaho : http://www.pentaho.com
+ *
+ *******************************************************************************
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ******************************************************************************/
+
+package org.pentaho.hbase.shim.cdh51.wrapper;
+
+import org.pentaho.di.core.variables.VariableSpace;
+import org.pentaho.hbase.shim.api.ColumnFilter;
+import org.pentaho.hbase.shim.api.HBaseValueMeta;
+import org.pentaho.hbase.shim.spi.HBaseBytesUtilShim;
+
+import java.util.List;
+import java.util.NavigableMap;
+import java.util.Properties;
+
+public interface HBaseConnectionInterface {
+
+  public abstract void addColumnFilterToScan( ColumnFilter cf, HBaseValueMeta columnMeta, VariableSpace vars,
+                                              boolean matchAny ) throws Exception;
+
+  public abstract void addColumnToScan( String colFamilyName, String colName, boolean colNameIsBinary )
+    throws Exception;
+
+  public abstract void addColumnToTargetPut( String columnFamily, String columnName, boolean colNameIsBinary,
+                                             byte[] colValue ) throws Exception;
+
+  public abstract boolean checkForHBaseRow( Object rowToCheck );
+
+  public abstract void checkHBaseAvailable() throws Exception;
+
+  public abstract void closeSourceResultSet() throws Exception;
+
+  public abstract void closeSourceTable() throws Exception;
+
+  public abstract void closeTargetTable() throws Exception;
+
+  public abstract void configureConnection( Properties connProps, List<String> logMessages ) throws Exception;
+
+  public abstract void createTable( String tableName, List<String> colFamilyNames, Properties creationProps )
+    throws Exception;
+
+  public abstract void deleteTable( String tableName ) throws Exception;
+
+  public abstract void disableTable( String tableName ) throws Exception;
+
+  public abstract void enableTable( String tableName ) throws Exception;
+
+  public abstract void executeSourceTableScan() throws Exception;
+
+  public abstract void executeTargetTableDelete( byte[] rowKey ) throws Exception;
+
+  public abstract void executeTargetTablePut() throws Exception;
+
+  public abstract void flushCommitsTargetTable() throws Exception;
+
+  public abstract Class<?> getBloomTypeClass() throws ClassNotFoundException;
+
+  public abstract Class<?> getByteArrayComparableClass() throws ClassNotFoundException;
+
+  public abstract HBaseBytesUtilShim getBytesUtil() throws Exception;
+
+  public abstract Class<?> getCompressionAlgorithmClass() throws ClassNotFoundException;
+
+  public abstract Class<?> getDeserializedBooleanComparatorClass() throws ClassNotFoundException;
+
+  public abstract Class<?> getDeserializedNumericComparatorClass() throws ClassNotFoundException;
+
+  public abstract byte[] getResultSetCurrentRowColumnLatest( String colFamilyName, String colName,
+                                                             boolean colNameIsBinary ) throws Exception;
+
+  public abstract NavigableMap<byte[], byte[]> getResultSetCurrentRowFamilyMap( String familyName ) throws Exception;
+
+  public abstract byte[] getResultSetCurrentRowKey() throws Exception;
+
+  public abstract NavigableMap<byte[], NavigableMap<byte[], NavigableMap<Long, byte[]>>> getResultSetCurrentRowMap()
+    throws Exception;
+
+  public abstract byte[]
+  getRowColumnLatest( Object aRow, String colFamilyName, String colName, boolean colNameIsBinary ) throws Exception;
+
+  public abstract NavigableMap<byte[], byte[]> getRowFamilyMap( Object aRow, String familyName ) throws Exception;
+
+  public abstract byte[] getRowKey( Object aRow ) throws Exception;
+
+  public abstract NavigableMap<byte[], NavigableMap<byte[], NavigableMap<Long, byte[]>>> getRowMap( Object aRow )
+    throws Exception;
+
+  public abstract List<String> getTableFamiles( String tableName ) throws Exception;
+
+  public abstract boolean isImmutableBytesWritable( Object o );
+
+  public abstract boolean isTableAvailable( String tableName ) throws Exception;
+
+  public abstract boolean isTableDisabled( String tableName ) throws Exception;
+
+  public abstract List<String> listTableNames() throws Exception;
+
+  public abstract void newSourceTable( String tableName ) throws Exception;
+
+  public abstract void newSourceTableScan( byte[] keyLowerBound, byte[] keyUpperBound, int cacheSize ) throws Exception;
+
+  public abstract void newTargetTable( String tableName, Properties props ) throws Exception;
+
+  public abstract void newTargetTablePut( byte[] key, boolean writeToWAL ) throws Exception;
+
+  public abstract boolean resultSetNextRow() throws Exception;
+
+  public abstract boolean sourceTableRowExists( byte[] rowKey ) throws Exception;
+
+  public abstract boolean tableExists( String tableName ) throws Exception;
+
+  public abstract boolean targetTableIsAutoFlush() throws Exception;
+
+}

--- a/cdh51/src/org/pentaho/hbase/shim/cdh51/wrapper/HBaseShimInterface.java
+++ b/cdh51/src/org/pentaho/hbase/shim/cdh51/wrapper/HBaseShimInterface.java
@@ -1,0 +1,33 @@
+/*******************************************************************************
+*
+* Pentaho Big Data
+*
+* Copyright (C) 2002-2014 by Pentaho : http://www.pentaho.com
+*
+*******************************************************************************
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License. You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*
+******************************************************************************/
+
+package org.pentaho.hbase.shim.cdh51.wrapper;
+
+import org.apache.hadoop.conf.Configuration;
+import org.pentaho.hadoop.shim.spi.PentahoHadoopShim;
+import org.pentaho.hbase.shim.spi.HBaseConnection;
+
+public interface HBaseShimInterface extends PentahoHadoopShim {
+  public HBaseConnection getHBaseConnection();
+
+  public void setInfo( Configuration configuration );
+}

--- a/cdh51/test-src/org/pentaho/hadoop/shim/cdh51/ClassPathModifyingSqoopShimTest.java
+++ b/cdh51/test-src/org/pentaho/hadoop/shim/cdh51/ClassPathModifyingSqoopShimTest.java
@@ -1,0 +1,79 @@
+/*******************************************************************************
+*
+* Pentaho Big Data
+*
+* Copyright (C) 2002-2013 by Pentaho : http://www.pentaho.com
+*
+*******************************************************************************
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License. You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*
+******************************************************************************/
+
+package org.pentaho.hadoop.shim.cdh51;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import java.util.concurrent.Callable;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import org.junit.Test;
+
+public class ClassPathModifyingSqoopShimTest {
+  private static final String TEST_CLASS_PATH = "testing";
+
+  @Test
+  public void runWithModifiedClassPathProperty_not_null() {
+    ClassPathModifyingSqoopShim shim = new ClassPathModifyingSqoopShim() {
+      protected String getClassPathString() {
+        return TEST_CLASS_PATH;
+      };
+    };
+    final AtomicBoolean isSet = new AtomicBoolean();
+    int returnVal = shim.runWithModifiedClassPathProperty(new Callable<Integer>() {
+      @Override
+      public Integer call() throws Exception {
+        if (TEST_CLASS_PATH.equals(System.getProperty("java.class.path"))) {
+          isSet.set(true);
+        }
+        return null;
+      }
+    });
+    assertTrue("Class path not modified when it should have been", isSet.get());
+    assertEquals("Invalid return code when callable returns null", Integer.MIN_VALUE, returnVal);
+  }
+
+  @Test
+  public void runWithModifiedClassPathProperty_null() {
+    ClassPathModifyingSqoopShim shim = new ClassPathModifyingSqoopShim() {
+      protected String getClassPathString() {
+        return null;
+      };
+    };
+    final AtomicBoolean isSet = new AtomicBoolean();
+    int returnVal = shim.runWithModifiedClassPathProperty(new Callable<Integer>() {
+      @Override
+      public Integer call() throws Exception {
+        if (TEST_CLASS_PATH.equals(System.getProperty("java.class.path"))) {
+          isSet.set(true);
+        }
+        return null;
+      }
+    });
+    assertFalse("Class path modified when it should not have been", isSet.get());
+    assertEquals("Invalid return code when callable returns null", Integer.MIN_VALUE, returnVal);
+  }
+
+}

--- a/cdh51/test-src/org/pentaho/hadoop/shim/cdh51/ShimRegistrationTest.java
+++ b/cdh51/test-src/org/pentaho/hadoop/shim/cdh51/ShimRegistrationTest.java
@@ -1,0 +1,90 @@
+/*******************************************************************************
+*
+* Pentaho Big Data
+*
+* Copyright (C) 2002-2013 by Pentaho : http://www.pentaho.com
+*
+*******************************************************************************
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License. You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*
+******************************************************************************/
+
+package org.pentaho.hadoop.shim.cdh51;
+
+import static org.junit.Assert.assertTrue;
+
+import java.util.ServiceLoader;
+
+import org.junit.Test;
+import org.pentaho.hadoop.shim.common.CommonPigShim;
+import org.pentaho.hadoop.shim.spi.PigShim;
+import org.pentaho.hadoop.shim.spi.SqoopShim;
+import org.pentaho.hadoop.shim.spi.SnappyShim;
+import org.pentaho.hbase.shim.spi.HBaseShim;
+
+/**
+ * Validate that our Shim service providers have been registered properly
+ */
+public class ShimRegistrationTest {
+
+  /**
+   * Make sure we've registered our Hadoop Shim
+   */
+  @Test
+  public void hadoopShimRegistered() {
+    ServiceLoader<org.pentaho.hadoop.shim.spi.HadoopShim> l = ServiceLoader.load(org.pentaho.hadoop.shim.spi.HadoopShim.class);
+    org.pentaho.hadoop.shim.spi.HadoopShim s = l.iterator().next();
+    assertTrue(org.pentaho.hadoop.shim.cdh51.HadoopShim.class.isAssignableFrom(s.getClass()));
+  }
+
+  /**
+   * Make sure we've registered our Pig Shim
+   */
+  @Test
+  public void pigShimRegistered() {
+    ServiceLoader<PigShim> l = ServiceLoader.load(PigShim.class);
+    PigShim s = l.iterator().next();
+    assertTrue(CommonPigShim.class.isAssignableFrom(s.getClass()));
+  }
+
+  /**
+   * Make sure we've registered our Pig Shim
+   */
+  @Test
+  public void sqoopShimRegistered() {
+    ServiceLoader<SqoopShim> l = ServiceLoader.load(SqoopShim.class);
+    SqoopShim s = l.iterator().next();
+    assertTrue(org.pentaho.hadoop.shim.cdh51.ClassPathModifyingSqoopShim.class.equals(s.getClass()));
+  }
+
+  /**
+   * Make sure we've registered our Snappy Shim
+   */
+  @Test
+  public void snappyShimRegistered() {
+    ServiceLoader<SnappyShim> l = ServiceLoader.load(SnappyShim.class);
+    SnappyShim s = l.iterator().next();
+    assertTrue(org.pentaho.hadoop.shim.cdh51.SnappyShim.class.isAssignableFrom(s.getClass()));
+  }
+
+  /**
+   * Make sure we've registered our HBase Shim
+   */
+  @Test
+  public void hbaseShimRegistered() {
+    ServiceLoader<HBaseShim> l = ServiceLoader.load(HBaseShim.class);
+    HBaseShim s = l.iterator().next();
+    assertTrue(org.pentaho.hbase.shim.cdh51.HBaseShimImpl.class.isAssignableFrom(s.getClass()));
+  }
+}


### PR DESCRIPTION
Initial version of CDH51 shim.
Working: HDFS, Hive, Hadoop Job Executor, SqoopExport
Failing: HBase, PMR, SqoopImport, Pig, Oozie
Not testsd: Yarn Cluster
