### PR TITLE
[BACKLOG-115] Certify support for Kerberos for CDH 5.1

### DIFF
--- a/cdh51/build.properties
+++ b/cdh51/build.properties
@@ -21,3 +21,4 @@ dependency.apache-hbase.revision=0.98.1-cdh5.1.0
 dependency.apache-oozie.revision=4.0.0-cdh5.1.0
 dependency.apache-sqoop.revision=1.4.4-cdh5.1.0
 dependency.pig.revision=0.12.0-cdh5.1.0
+dependency.zookeeper.revision=3.4.5-cdh5.1.0

--- a/cdh51/ivy.xml
+++ b/cdh51/ivy.xml
@@ -27,6 +27,10 @@
 
     <dependency conf="client->default" org="org.apache.hadoop" name="hadoop-client" rev="${dependency.hadoop.revision}" changing="true"/>
     <dependency conf="client->default" org="org.apache.hadoop" name="hadoop-core" rev="${dependency.hadoop.mr1.revision}" transitive="false" changing="true"/>
+    <dependency conf="client->default" org="org.apache.hadoop" name="hadoop-mapreduce-client-app" rev="${dependency.hadoop.revision}" />
+    <dependency conf="client->default" org="org.apache.hadoop" name="hadoop-mapreduce-client-common" rev="${dependency.hadoop.revision}"/>
+    <dependency conf="client->default" org="org.apache.hadoop" name="hadoop-mapreduce-client-jobclient" rev="${dependency.hadoop.revision}" />
+    <dependency conf="client->default" org="org.apache.hadoop" name="hadoop-mapreduce-client-shuffle" rev="${dependency.hadoop.revision}" />
 
     <!--
       This patch gets us around bugs like MAPREDUCE-5665 where MapReduce jobs submitted from a Windows client to YARN
@@ -44,6 +48,7 @@
     <dependency conf="pmr->default" org="org.apache.hbase" name="hbase-server" rev="${dependency.apache-hbase.revision}" transitive="false" changing="true"/>
     <dependency conf="pmr->default" org="org.apache.hbase" name="hbase-thrift" rev="${dependency.apache-hbase.revision}" transitive="false" changing="true"/>
     <dependency conf="pmr->default" org="org.cloudera.htrace" name="htrace-core" rev="2.01" transitive="false" changing="true"/>
+    <dependency conf="pmr->default" org="org.apache.zookeeper" name="zookeeper" rev="${dependency.zookeeper.revision}" transitive="false"/>
 
     <dependency org="pentaho" name="pentaho-hdfs-vfs" rev="${dependency.pentaho-hdfs-vfs.revision}" transitive="false" changing="true"/>
 


### PR DESCRIPTION
Add mapreduce-client libs. Fixes pentaho mapreduce jobs.
