### PR TITLE
[BACKLOG-365][5.2] Unable to create a database table data source against Apache Hadoop

### DIFF
--- a/common/src/org/pentaho/hadoop/shim/common/DriverProxyInvocationChain.java
+++ b/common/src/org/pentaho/hadoop/shim/common/DriverProxyInvocationChain.java
@@ -247,8 +247,10 @@ public class DriverProxyInvocationChain {
           Throwable cause = t.getCause();
 
           if ( cause instanceof SQLException ) {
-            if ( cause.getMessage().equals( "Method not supported" ) ) {
-              String methodName = method.getName();
+            String methodName = method.getName();
+            if ( cause.getMessage().equals( "Method not supported" )
+                // shims with pentaho's hive driver (hadoop-20, hdp13)
+                || cause.getMessage().equals( "Method not supported - setAutoCommit(false)" )) {
               if ( "createStatement".equals( methodName ) ) {
                 o = createStatement( connection, args );
               } else if ( "isReadOnly".equals( methodName ) ) {

--- a/hive-jdbc/test-src/org/apache/hive/jdbc/HiveDriverTest.java
+++ b/hive-jdbc/test-src/org/apache/hive/jdbc/HiveDriverTest.java
@@ -22,6 +22,8 @@
 
 package org.apache.hive.jdbc;
 
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.nullValue;
 import static org.junit.Assert.*;
 
 import java.lang.reflect.InvocationTargetException;
@@ -66,7 +68,7 @@ public class HiveDriverTest {
   public void getActiveDriver() throws SQLException {
     final AtomicBoolean called = new AtomicBoolean(false);
     HadoopShim shim = new MockHadoopShim() {
-      
+
       public java.sql.Driver getJdbcDriver(String scheme) {
         if(scheme.equalsIgnoreCase("hive2")) {
           called.set(true);
@@ -86,7 +88,7 @@ public class HiveDriverTest {
       public java.sql.Driver getJdbcDriver(String scheme) {
         if(scheme.equalsIgnoreCase("hive2")) {
           throw new RuntimeException();
-        } 
+        }
         else {
           return null;
         }
@@ -155,6 +157,26 @@ public class HiveDriverTest {
 
     d.connect(null, null);
     assertTrue(called.get());
+  }
+
+  @Test
+  public void connect_returns_null_if_shim_doesnt_have_hive2_driver() {
+    HadoopShim shim = new MockHadoopShim() {
+      public java.sql.Driver getJdbcDriver( String scheme ) {
+        if ( scheme.equalsIgnoreCase( "hive2" ) ) {
+          throw new RuntimeException();
+        } else {
+          return null;
+        }
+      }
+    };
+    HiveDriver d = new HiveDriver( getMockUtil( shim ) );
+
+    try {
+      assertThat( d.connect( null, null ), is( nullValue() ) );
+    } catch ( SQLException ex ) {
+      fail( "Should not get exception if there is no hive2 driver in shim" );
+    }
   }
 
   @Test
@@ -264,7 +286,7 @@ public class HiveDriverTest {
     d.jdbcCompliant();
     assertTrue(called.get());
   }
-  
+
   @Test
   public void jdbcCompliant_exception() throws SQLException {
     Driver driver = new MockDriver() {
@@ -274,7 +296,7 @@ public class HiveDriverTest {
       }
     };
     HiveDriver d = new HiveDriver(getMockUtil(getMockShimWithDriver(driver)));
-    
+
     // should return false if there is an exception
     assertFalse(d.jdbcCompliant());
   }


### PR DESCRIPTION
Handle case with old shims not having hive2 driver.
Detect pentaho hive's error message in setAutoCommit.
