### PR TITLE
[BACKLOG-365][5.2] Unable to create a database table data source against Apac...

### DIFF
--- a/common/src/org/pentaho/hadoop/shim/common/CommonHadoopShim.java
+++ b/common/src/org/pentaho/hadoop/shim/common/CommonHadoopShim.java
@@ -101,7 +101,7 @@ public class CommonHadoopShim implements HadoopShim {
         Driver driverProxy = DriverProxyInvocationChain.getProxy( Driver.class, newInstance );
         return driverProxy;
       } else {
-        throw new Exception( "JDBC driver of type '" + driverType + "' not supported" );
+        return null;
       }
 
     } catch ( Exception ex ) {

--- a/common/src/org/pentaho/hadoop/shim/common/DriverProxyInvocationChain.java
+++ b/common/src/org/pentaho/hadoop/shim/common/DriverProxyInvocationChain.java
@@ -247,8 +247,9 @@ public class DriverProxyInvocationChain {
           Throwable cause = t.getCause();
 
           if ( cause instanceof SQLException ) {
-            if ( cause.getMessage().equals( "Method not supported" ) ) {
-              String methodName = method.getName();
+            String methodName = method.getName();
+            if ( cause.getMessage().startsWith( "Method not supported" )
+                || cause.getMessage().equals( "enabling autocommit is not supported" ) ) {
               if ( "createStatement".equals( methodName ) ) {
                 o = createStatement( connection, args );
               } else if ( "isReadOnly".equals( methodName ) ) {

--- a/hive-jdbc/src/org/apache/hive/jdbc/HiveDriver.java
+++ b/hive-jdbc/src/org/apache/hive/jdbc/HiveDriver.java
@@ -53,7 +53,7 @@ import org.pentaho.hadoop.hive.jdbc.JDBCDriverCallable;
  * JDBC driver via HadoopConfiguration#getHiveJdbcDriver.
  * </p>
  * <p>
- * All calls to the loaded HiveDriver will have the current Thread's context 
+ * All calls to the loaded HiveDriver will have the current Thread's context
  * class loader set to the class that loaded the driver so subsequent resource
  * lookups are successful.
  * </p>
@@ -63,7 +63,7 @@ public class HiveDriver implements java.sql.Driver {
    * Method name of {@link org.pentaho.hadoop.shim.spi.HadoopShim#getJdbcDriver()}
    */
   private static final String METHOD_GET_JDBC_DRIVER = "getJdbcDriver";
-  
+
   /**
    * Driver type = "hive"
    */
@@ -107,10 +107,10 @@ public class HiveDriver implements java.sql.Driver {
       throw new SQLException("Unable to load Hive Server 2 JDBC driver for the currently active Hadoop configuration", ex);
     }
 
-    // Check if the Shim contains a Hive driver. It may return this driver if it 
+    // Check if the Shim contains a Hive driver. It may return this driver if it
     // doesn't contain one since it'll be found in one of the parent class loaders
     // so we also need to make sure we didn't return ourself... :)
-    if (driver == null || driver.getClass() == this.getClass()) {
+    if (driver != null && driver.getClass() == this.getClass()) {
       throw new SQLException("The active Hadoop configuration does not contain a Hive Server 2 JDBC driver");
     }
 
@@ -129,6 +129,10 @@ public class HiveDriver implements java.sql.Driver {
    */
   @Override
   public Connection connect(final String url, final Properties info) throws SQLException {
+    if ( getActiveDriver() == null ) {
+      // Ignore connection attempt in case corresponding driver is not provided by the shim
+      return null;
+    }
     return callWithActiveDriver(new JDBCDriverCallable<Connection>() {
       @Override
       public Connection call() throws Exception {
@@ -202,7 +206,7 @@ public class HiveDriver implements java.sql.Driver {
       return false;
     }
   }
-  
+
   public Logger getParentLogger() throws SQLFeatureNotSupportedException {
     return null;
   }


### PR DESCRIPTION
Handle case with old shims not having hive2 driver.
Detect pentaho's hive error message in setAutoCommit.
