### PR TITLE
[PDI-13008] Spoon crashes if the cluster does not have kerberos turned on HDP 2.1 CDH 5.1

### DIFF
--- a/cdh51/src/org/pentaho/hadoop/shim/cdh51/authorization/AuthenticatingHadoopShim.java
+++ b/cdh51/src/org/pentaho/hadoop/shim/cdh51/authorization/AuthenticatingHadoopShim.java
@@ -44,8 +44,14 @@ public class AuthenticatingHadoopShim extends DelegatingHadoopShim {
   public void onLoad( HadoopConfiguration config, HadoopConfigurationFileSystemManager fsm ) throws Exception {
     AuthenticationConsumerPluginType.getInstance().registerPlugin( (URLClassLoader) getClass().getClassLoader(),
       HadoopNoAuthConsumer.HadoopNoAuthConsumerType.class );
+
+    String provider = NoAuthenticationAuthenticationProvider.NO_AUTH_ID;
+    if ( config.getConfigProperties().containsKey( SUPER_USER ) ) {
+      provider = config.getConfigProperties().getProperty( SUPER_USER );
+    }
+
     String activators = config.getConfigProperties().getProperty( "activator.classes" );
-    if ( activators != null ) {
+    if ( activators != null && !provider.equals( NoAuthenticationAuthenticationProvider.NO_AUTH_ID ) ) {
       activators = activators.trim();
       for ( String className : activators.split( "," ) ) {
         className = className.trim();
@@ -58,10 +64,7 @@ public class AuthenticatingHadoopShim extends DelegatingHadoopShim {
         }
       }
     }
-    String provider = NoAuthenticationAuthenticationProvider.NO_AUTH_ID;
-    if ( config.getConfigProperties().containsKey( SUPER_USER ) ) {
-      provider = config.getConfigProperties().getProperty( SUPER_USER );
-    }
+
     AuthenticationManager manager = AuthenticationPersistenceManager.getAuthenticationManager();
     new PropertyAuthenticationProviderParser( config.getConfigProperties(), manager ).process( PROVIDER_LIST );
     AuthenticationPerformer<HadoopAuthorizationService, Properties> performer =

--- a/cdh51/test-src/org/pentaho/hadoop/shim/cdh51/authorization/AuthenticatingHadoopShimTest.java
+++ b/cdh51/test-src/org/pentaho/hadoop/shim/cdh51/authorization/AuthenticatingHadoopShimTest.java
@@ -1,0 +1,82 @@
+/*! ******************************************************************************
+ *
+ * Pentaho Data Integration
+ *
+ * Copyright (C) 2002-2014 by Pentaho : http://www.pentaho.com
+ *
+ *******************************************************************************
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ******************************************************************************/
+package org.pentaho.hadoop.shim.cdh51.authorization;
+
+import org.junit.Test;
+import org.pentaho.di.core.auth.NoAuthenticationAuthenticationProvider;
+import org.pentaho.hadoop.shim.HadoopConfiguration;
+import org.pentaho.hadoop.shim.HadoopConfigurationFileSystemManager;
+import org.pentaho.hadoop.shim.cdh51.delegating.DelegatingHadoopShim;
+
+import java.util.Properties;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * User: Dzmitry Stsiapanau Date: 10/7/14 Time: 3:48 PM
+ */
+public class AuthenticatingHadoopShimTest {
+  static AtomicInteger countInstancesPerCLassLoader = new AtomicInteger( 0 );
+
+//  public class FakeActivator {
+//    public FakeActivator() {
+//      AuthenticatingHadoopShimTest.countInstancesPerCLassLoader.incrementAndGet();
+//    }
+//  }
+
+  @Test
+  public void testOnLoadNoAuthSuccess() throws Exception {
+    AuthenticatingHadoopShim shim = new AuthenticatingHadoopShim();
+    HadoopConfiguration hc = mock( HadoopConfiguration.class );
+    Properties prop = new Properties();
+    prop.put( DelegatingHadoopShim.SUPER_USER, NoAuthenticationAuthenticationProvider.NO_AUTH_ID );
+    prop.put( "activator.classes", FakeActivator.class.getCanonicalName() );
+    when( hc.getConfigProperties() ).thenReturn( prop );
+    HadoopConfigurationFileSystemManager fsm = mock( HadoopConfigurationFileSystemManager.class );
+    try {
+      shim.onLoad( hc, fsm );
+    } catch ( RuntimeException e ) {
+      //Predictable
+    }
+    assertEquals( "Was tried to instantiate activator class with no_auth", 0, countInstancesPerCLassLoader.get() );
+  }
+
+  @Test
+  public void testOnLoadWithActivatorSuccess() throws Exception {
+    AuthenticatingHadoopShim shim = new AuthenticatingHadoopShim();
+    HadoopConfiguration hc = mock( HadoopConfiguration.class );
+    Properties prop = new Properties();
+    prop.put( DelegatingHadoopShim.SUPER_USER, "any other no auth" );
+    prop.put( "activator.classes", FakeActivator.class.getCanonicalName() );
+    when( hc.getConfigProperties() ).thenReturn( prop );
+    HadoopConfigurationFileSystemManager fsm = mock( HadoopConfigurationFileSystemManager.class );
+    try {
+      shim.onLoad( hc, fsm );
+    } catch ( RuntimeException e ) {
+      //Predictable
+    }
+    assertEquals( "Was not tried to instantiate activator class with no_auth", 1, countInstancesPerCLassLoader.get() );
+  }
+}

--- a/cdh51/test-src/org/pentaho/hadoop/shim/cdh51/authorization/FakeActivator.java
+++ b/cdh51/test-src/org/pentaho/hadoop/shim/cdh51/authorization/FakeActivator.java
@@ -1,0 +1,32 @@
+/*! ******************************************************************************
+ *
+ * Pentaho Data Integration
+ *
+ * Copyright (C) 2002-2014 by Pentaho : http://www.pentaho.com
+ *
+ *******************************************************************************
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ******************************************************************************/
+package org.pentaho.hadoop.shim.cdh51.authorization;
+
+/**
+ * User: Dzmitry Stsiapanau Date: 10/8/14 Time: 11:50 AM
+ */
+public class FakeActivator {
+
+  public FakeActivator() {
+    AuthenticatingHadoopShimTest.countInstancesPerCLassLoader.incrementAndGet();
+  }
+}

--- a/hdp21/ivy.xml
+++ b/hdp21/ivy.xml
@@ -98,6 +98,8 @@
     <dependency conf="test->default" org="junit" name="junit" rev="4.5"/>
     <dependency conf="test->default" org="org.safehaus.jug" name="jug-lgpl" rev="2.0.0" />
     <dependency conf="test->default" org="pentaho" name="pentaho-hadoop-shims-api-test" rev="${project.revision}" changing="true"/>
+    <dependency conf="test->default" org="org.mockito" name="mockito-all" rev="1.9.5" transitive="false" />
+
 
     <!-- Exclude log4j from default libraries - it's brought in transitively through many of the Hadoop dependencies and should not be included -->
     <exclude org="log4j" module="log4j" conf="default" />

--- a/hdp21/src/org/pentaho/hadoop/shim/hdp21/authorization/AuthenticatingHadoopShim.java
+++ b/hdp21/src/org/pentaho/hadoop/shim/hdp21/authorization/AuthenticatingHadoopShim.java
@@ -44,8 +44,14 @@ public class AuthenticatingHadoopShim extends DelegatingHadoopShim {
   public void onLoad( HadoopConfiguration config, HadoopConfigurationFileSystemManager fsm ) throws Exception {
     AuthenticationConsumerPluginType.getInstance().registerPlugin( (URLClassLoader) getClass().getClassLoader(),
       HadoopNoAuthConsumer.HadoopNoAuthConsumerType.class );
+
+    String provider = NoAuthenticationAuthenticationProvider.NO_AUTH_ID;
+    if ( config.getConfigProperties().containsKey( SUPER_USER ) ) {
+      provider = config.getConfigProperties().getProperty( SUPER_USER );
+    }
+
     String activators = config.getConfigProperties().getProperty( "activator.classes" );
-    if ( activators != null ) {
+    if ( activators != null && !provider.equals( NoAuthenticationAuthenticationProvider.NO_AUTH_ID ) ) {
       activators = activators.trim();
       for ( String className : activators.split( "," ) ) {
         className = className.trim();
@@ -58,10 +64,7 @@ public class AuthenticatingHadoopShim extends DelegatingHadoopShim {
         }
       }
     }
-    String provider = NoAuthenticationAuthenticationProvider.NO_AUTH_ID;
-    if ( config.getConfigProperties().containsKey( SUPER_USER ) ) {
-      provider = config.getConfigProperties().getProperty( SUPER_USER );
-    }
+
     AuthenticationManager manager = AuthenticationPersistenceManager.getAuthenticationManager();
     new PropertyAuthenticationProviderParser( config.getConfigProperties(), manager ).process( PROVIDER_LIST );
     AuthenticationPerformer<HadoopAuthorizationService, Properties> performer =

--- a/hdp21/test-src/org/pentaho/hadoop/shim/hdp21/authorization/AuthenticatingHadoopShimTest.java
+++ b/hdp21/test-src/org/pentaho/hadoop/shim/hdp21/authorization/AuthenticatingHadoopShimTest.java
@@ -1,0 +1,82 @@
+/*! ******************************************************************************
+ *
+ * Pentaho Data Integration
+ *
+ * Copyright (C) 2002-2014 by Pentaho : http://www.pentaho.com
+ *
+ *******************************************************************************
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ******************************************************************************/
+package org.pentaho.hadoop.shim.hdp21.authorization;
+
+import org.junit.Test;
+import org.pentaho.di.core.auth.NoAuthenticationAuthenticationProvider;
+import org.pentaho.hadoop.shim.HadoopConfiguration;
+import org.pentaho.hadoop.shim.HadoopConfigurationFileSystemManager;
+import org.pentaho.hadoop.shim.hdp21.delegating.DelegatingHadoopShim;
+
+import java.util.Properties;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * User: Dzmitry Stsiapanau Date: 10/7/14 Time: 3:48 PM
+ */
+public class AuthenticatingHadoopShimTest {
+  static AtomicInteger countInstancesPerCLassLoader = new AtomicInteger( 0 );
+
+//  public class FakeActivator {
+//    public FakeActivator() {
+//      AuthenticatingHadoopShimTest.countInstancesPerCLassLoader.incrementAndGet();
+//    }
+//  }
+
+  @Test
+  public void testOnLoadNoAuthSuccess() throws Exception {
+    AuthenticatingHadoopShim shim = new AuthenticatingHadoopShim();
+    HadoopConfiguration hc = mock( HadoopConfiguration.class );
+    Properties prop = new Properties();
+    prop.put( DelegatingHadoopShim.SUPER_USER, NoAuthenticationAuthenticationProvider.NO_AUTH_ID );
+    prop.put( "activator.classes", FakeActivator.class.getCanonicalName() );
+    when( hc.getConfigProperties() ).thenReturn( prop );
+    HadoopConfigurationFileSystemManager fsm = mock( HadoopConfigurationFileSystemManager.class );
+    try {
+      shim.onLoad( hc, fsm );
+    } catch ( RuntimeException e ) {
+      //Predictable
+    }
+    assertEquals( "Was tried to instantiate activator class with no_auth", 0, countInstancesPerCLassLoader.get() );
+  }
+
+  @Test
+  public void testOnLoadWithActivatorSuccess() throws Exception {
+    AuthenticatingHadoopShim shim = new AuthenticatingHadoopShim();
+    HadoopConfiguration hc = mock( HadoopConfiguration.class );
+    Properties prop = new Properties();
+    prop.put( DelegatingHadoopShim.SUPER_USER, "any other no auth" );
+    prop.put( "activator.classes", FakeActivator.class.getCanonicalName() );
+    when( hc.getConfigProperties() ).thenReturn( prop );
+    HadoopConfigurationFileSystemManager fsm = mock( HadoopConfigurationFileSystemManager.class );
+    try {
+      shim.onLoad( hc, fsm );
+    } catch ( RuntimeException e ) {
+      //Predictable
+    }
+    assertEquals( "Was not tried to instantiate activator class with no_auth", 1, countInstancesPerCLassLoader.get() );
+  }
+}

--- a/hdp21/test-src/org/pentaho/hadoop/shim/hdp21/authorization/FakeActivator.java
+++ b/hdp21/test-src/org/pentaho/hadoop/shim/hdp21/authorization/FakeActivator.java
@@ -1,0 +1,32 @@
+/*! ******************************************************************************
+ *
+ * Pentaho Data Integration
+ *
+ * Copyright (C) 2002-2014 by Pentaho : http://www.pentaho.com
+ *
+ *******************************************************************************
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ******************************************************************************/
+package org.pentaho.hadoop.shim.hdp21.authorization;
+
+/**
+ * User: Dzmitry Stsiapanau Date: 10/8/14 Time: 11:50 AM
+ */
+public class FakeActivator {
+
+  public FakeActivator() {
+    AuthenticatingHadoopShimTest.countInstancesPerCLassLoader.incrementAndGet();
+  }
+}


### PR DESCRIPTION
- Added check for NO_AUTH super user to ignore activator  - to not crashe for Both CDH51 and HDP21
- Added unit tests
- Added missed mockito dependency for HDP21
