### PR TITLE
[PDI-12190][5.2] Add null check to Hive2's HiveDriver.acceptsUrl()

### DIFF
--- a/hive-jdbc/src/org/apache/hive/jdbc/HiveDriver.java
+++ b/hive-jdbc/src/org/apache/hive/jdbc/HiveDriver.java
@@ -143,12 +143,18 @@ public class HiveDriver implements java.sql.Driver {
 
   @Override
   public boolean acceptsURL(final String url) throws SQLException {
-    return Boolean.TRUE.equals(callWithActiveDriver(new JDBCDriverCallable<Boolean>() {
-      @Override
-      public Boolean call() throws Exception {
-        return driver.acceptsURL(url);
-      }
-    }));
+    if ( getActiveDriver() == null ) {
+      // Ignore connection attempt in case corresponding driver is not provided by the shim
+      return false;
+    }
+    else {
+      return Boolean.TRUE.equals(callWithActiveDriver(new JDBCDriverCallable<Boolean>() {
+              @Override
+              public Boolean call() throws Exception {
+                  return driver.acceptsURL(url);
+              }
+          }));
+    }
   }
 
   @Override

--- a/hive-jdbc/test-src/org/apache/hive/jdbc/HiveDriverTest.java
+++ b/hive-jdbc/test-src/org/apache/hive/jdbc/HiveDriverTest.java
@@ -106,6 +106,18 @@ public class HiveDriverTest {
   }
 
   @Test
+  public void getActiveDriver_null_in_getJdbcDriver() throws Exception {
+    HadoopShim shim = new MockHadoopShim() {
+      public java.sql.Driver getJdbcDriver(String scheme) {
+        return null;
+      }
+    };
+    HiveDriver d = new HiveDriver(getMockUtil(shim));
+
+    assertNull( d.getActiveDriver() );
+  }
+
+  @Test
   public void getActiveDriver_same_driver() {
     HadoopShim shim = new MockHadoopShim() {
       public java.sql.Driver getJdbcDriver(String scheme) {
@@ -171,6 +183,21 @@ public class HiveDriverTest {
 
     d.acceptsURL(null);
     assertTrue(called.get());
+  }
+
+  @Test
+  public void acceptsURL_no_driver() throws SQLException {
+    final AtomicBoolean called = new AtomicBoolean(false);
+    HadoopShim shim = new MockHadoopShim() {
+      @Override
+      public Driver getJdbcDriver(String scheme) {
+        return null;
+      }
+    };
+    HiveDriver d = new HiveDriver( getMockUtil( shim ) );
+
+    assertFalse( d.acceptsURL( "jdbc:postgres://" ) );
+
   }
 
   @Test


### PR DESCRIPTION
Now that getActiveDriver() returns null instead of throwing an exception, we need to pull null check(s) around the calls that DriverManager makes to a driver whether it will be "selected" as a driver or not. This was done for connect() but not acceptsUrl(), this PR adds the null check to acceptsUrl
