### PR TITLE
[PDI-13080][5.2] When no records get sent to a PMR Reducer, the PMR Job Fails with Null Pointer Exceptions

### DIFF
--- a/common/src-mapred/org/pentaho/hadoop/mapreduce/GenericTransReduce.java
+++ b/common/src-mapred/org/pentaho/hadoop/mapreduce/GenericTransReduce.java
@@ -298,8 +298,9 @@ public class GenericTransReduce<K extends WritableComparable<?>, V extends Itera
 
   @Override
   public void close() throws IOException {
-    rowProducer.finished();
-
+    if ( rowProducer != null ) {
+      rowProducer.finished();
+    }
     // Stop the executor if any is defined...
     if ( isSingleThreaded() && executor != null ) {
       try {
@@ -310,7 +311,9 @@ public class GenericTransReduce<K extends WritableComparable<?>, V extends Itera
       }
 
     } else if ( !isSingleThreaded() && trans != null ) {
-      trans.waitUntilFinished();
+      if ( rowProducer != null ) {
+        trans.waitUntilFinished();
+      }
       disposeTransformation();
     }
 

--- a/common/test-src/org/pentaho/hadoop/mapreduce/GenericTransReduceTest.java
+++ b/common/test-src/org/pentaho/hadoop/mapreduce/GenericTransReduceTest.java
@@ -1,0 +1,43 @@
+/*! ******************************************************************************
+ *
+ * Pentaho Data Integration
+ *
+ * Copyright (C) 2002-2014 by Pentaho : http://www.pentaho.com
+ *
+ *******************************************************************************
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ******************************************************************************/
+package org.pentaho.hadoop.mapreduce;
+
+import org.junit.Test;
+import org.pentaho.di.core.exception.KettleException;
+import java.io.IOException;
+import static org.junit.Assert.*;
+
+/**
+ * User: Dzmitry Stsiapanau Date: 10/29/14 Time: 12:44 PM
+ */
+public class GenericTransReduceTest {
+  @Test
+  public void testClose() throws KettleException , IOException {
+    GenericTransReduce gtr = new GenericTransReduce();
+    try {
+      gtr.close();
+    } catch ( NullPointerException ex ) {
+      ex.printStackTrace();
+      fail( " Null pointer on close look PDI-13080 " + ex.getMessage() );
+    }
+  }
+}


### PR DESCRIPTION
Backport of https://github.com/pentaho/pentaho-hadoop-shims/pull/167 to 5.2
