### PR TITLE
SP-1612 - Regression of PDI-13082 - Regression: MapReduce Input is missing Serializable Data Type (5.2 Suite)

### DIFF
--- a/common/src-mapred/org/pentaho/hbase/mapred/PentahoTableRecordReaderImpl.java
+++ b/common/src-mapred/org/pentaho/hbase/mapred/PentahoTableRecordReaderImpl.java
@@ -262,7 +262,7 @@ public class PentahoTableRecordReaderImpl {
 
         try {
           Method m = result.getClass().getMethod( "copyFrom", Result.class );
-          m.invoke( result, value );
+          m.invoke( value, result );
         } catch ( NoSuchMethodException e ) {
           throw new IOException( e );
         } catch ( SecurityException e ) {


### PR DESCRIPTION
this is backport for 5.2 branch. 
See https://github.com/pentaho/pentaho-hadoop-shims/pull/174
