### PR TITLE
BAD-148: Add Cross-Platform MR Submission Setting

### DIFF
--- a/cdh53/package-res/mapred-site.xml
+++ b/cdh53/package-res/mapred-site.xml
@@ -14,4 +14,13 @@
     <value>clouderamanager.cdh5.test:10020</value>
     <description>MapReduce JobHistory Server IPC host:port</description>
   </property>
+  <!--
+    - The following property allows to run MR jobs cross-platformly.
+    - It means that jobs created on Windows MR client can be run on Linux cluster or vice versa.
+    -
+    -->
+  <property>
+    <name>mapreduce.app-submission.cross-platform</name>
+    <value>true</value>
+  </property>
 </configuration>


### PR DESCRIPTION
Adds mapreduce.app-submission.cross-platform setting to mapred-site.xml, in order to allow Windows users to submit jobs to a Hadoop cluster