### PR TITLE
[PDI-13407]: Fixed error in Hive/Impala drivers during connect / getActiveDriver()

### DIFF
--- a/hive-jdbc/src/org/apache/hadoop/hive/jdbc/HiveDriver.java
+++ b/hive-jdbc/src/org/apache/hadoop/hive/jdbc/HiveDriver.java
@@ -112,7 +112,7 @@ public class HiveDriver implements java.sql.Driver {
     // doesn't contain one since it'll be found in one of the parent class loaders
     // so we also need to make sure we didn't return ourself... :)
     if ( driver == null || driver.getClass() == this.getClass() ) {
-      throw new SQLException( "The active Hadoop configuration does not contain a Hive JDBC driver" );
+      driver = null;
     }
 
     return driver;
@@ -123,7 +123,7 @@ public class HiveDriver implements java.sql.Driver {
     if ( drv != null ) {
       return callback.callWithDriver( drv );
     } else {
-      throw new SQLException( "Unable to find Hive JDBC driver for the active Hadoop configuration" );
+      throw new SQLException( "The active Hadoop configuration does not contain a Hive JDBC driver" );
     }
   }
 

--- a/hive-jdbc/src/org/apache/hive/jdbc/HiveDriver.java
+++ b/hive-jdbc/src/org/apache/hive/jdbc/HiveDriver.java
@@ -2,7 +2,7 @@
  *
  * Pentaho Big Data
  *
- * Copyright (C) 2002-2013 by Pentaho : http://www.pentaho.com
+ * Copyright (C) 2002-2014 by Pentaho : http://www.pentaho.com
  *
  *******************************************************************************
  *
@@ -112,7 +112,7 @@ public class HiveDriver implements java.sql.Driver {
     // doesn't contain one since it'll be found in one of the parent class loaders
     // so we also need to make sure we didn't return ourself... :)
     if ( driver != null && driver.getClass() == this.getClass() ) {
-      throw new SQLException( "The active Hadoop configuration does not contain a Hive Server 2 JDBC driver" );
+      driver = null;
     }
 
     return driver;
@@ -123,7 +123,7 @@ public class HiveDriver implements java.sql.Driver {
     if ( drv != null ) {
       return callback.callWithDriver( drv );
     } else {
-      throw new SQLException( "Unable to find Hive JDBC driver for the active Hadoop configuration" );
+      throw new SQLException( "The active Hadoop configuration does not contain a Hive Server 2 / Impala JDBC driver" );
     }
   }
 

--- a/hive-jdbc/src/org/apache/hive/jdbc/ImpalaDriver.java
+++ b/hive-jdbc/src/org/apache/hive/jdbc/ImpalaDriver.java
@@ -2,7 +2,7 @@
  *
  * Pentaho Big Data
  *
- * Copyright (C) 2002-2013 by Pentaho : http://www.pentaho.com
+ * Copyright (C) 2002-2014 by Pentaho : http://www.pentaho.com
  *
  *******************************************************************************
  *
@@ -101,7 +101,7 @@ public class ImpalaDriver extends HiveDriver {
     // doesn't contain one since it'll be found in one of the parent class loaders
     // so we also need to make sure we didn't return ourself... :)
     if ( driver == null || driver.getClass() == this.getClass() ) {
-      throw new SQLException( "The active Hadoop configuration does not contain a Impala JDBC driver" );
+      driver = null;
     }
 
     return driver;

--- a/hive-jdbc/test-src/org/apache/hive/jdbc/ImpalaDriverTest.java
+++ b/hive-jdbc/test-src/org/apache/hive/jdbc/ImpalaDriverTest.java
@@ -1,0 +1,26 @@
+/*******************************************************************************
+ *
+ * Pentaho Big Data
+ *
+ * Copyright (C) 2002-2014 by Pentaho : http://www.pentaho.com
+ *
+ *******************************************************************************
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ******************************************************************************/
+
+package org.apache.hive.jdbc;
+
+public class ImpalaDriverTest extends HiveDriverTest {
+}


### PR DESCRIPTION
From previous fixes/cases, we missed the case where the driver is not present but we call connect() on it anyway. The current behavior throws an exception that connect does not catch.  I believe getActiveDriver() should not throw an exception if the driver cannot be found; rather it should return null, and everyone that needs the active driver (callWithActiveDriver, connect, e.g.) should deal with both null and exception conditions as appropriate.