### PR TITLE
[PDI-12886] - PDI Sqoop Jobs fail when SQOOP_HOME is defined

### DIFF
--- a/mapr31/package-res/config.properties
+++ b/mapr31/package-res/config.properties
@@ -3,7 +3,8 @@ name=MapR 3.1
 
 # Comma-separated list of directories and files to make available to this
 # configuration on linux. Any resources found here will overwrite ones in lib/.
-linux.classpath=/opt/mapr/conf,/opt/mapr/hadoop/hadoop-0.20.2/lib
+# Important: in case of using sqoop you should replace %SQOOP_HOME% to real path
+linux.classpath=/opt/mapr/conf,/opt/mapr/hadoop/hadoop-0.20.2/lib,$SQOOP_HOME/lib
 
 # Comma-separated list of paths that contain native libraries to load. These
 # could be added to LD_LIBRARY_PATH or set with -Djava.library.path instead.
@@ -19,7 +20,8 @@ ignored.classes=
 # These are Windows-specific classpath and library paths. 
 # Please make sure to update the MapR versions in the paths to match your
 # locally installed MapR client.
-windows.classpath=file:///C:/opt/mapr/conf,file:///C:/opt/mapr/hadoop/hadoop-0.20.2/lib
+# Important: in case of using sqoop you should replace %SQOOP_HOME% to real path
+windows.classpath=file:///C:/opt/mapr/conf,file:///C:/opt/mapr/hadoop/hadoop-0.20.2/lib,%SQOOP_HOME%/lib
 windows.library.path=C:\\opt\\mapr\\lib
 
 java.system.hadoop.login=hybrid


### PR DESCRIPTION
@mattyb149, could you review please
I've make changes according to your proposals ( http://jira.pentaho.com/browse/PDI-12886 ).
Supposed that path to sqoop libs user will fill by himself. It's beacause we have no possibility to detect where sqoop has been installed.