### PR TITLE
[BAD-140] - [BAD-140] - Compile HDP 2.2 shim

### DIFF
--- a/hdp22/ivy.xml
+++ b/hdp22/ivy.xml
@@ -108,5 +108,10 @@
     <!--  Exclude xerces, it's provided and will wreak havoc if there are multiple instances / versions -->
     <exclude org="xml-apis" module="xml-apis" conf="*" />
     <exclude org="xerces" module="xercesImpl" conf="*" />
+
+    <!-- Temporarily exclude to avoid build issue. -->
+    <exclude org="org.pentaho" module="pentaho-aggdesigner-algorithm"/>
+    <exclude org="org.mortbay.jetty" module="jetty"/>
+    <exclude org="org.mortbay.jetty" module="jetty-util"/>
   </dependencies>
 </ivy-module>


### PR DESCRIPTION
Temporarily excluded 
* pentaho-aggdesigner-algorithm-5.1.3-jhyde.jar,
* jetty-6.1.26.hwx.jar
* jetty-util-6.1.26.hwx.jar

files to workaround build failure.