### PR TITLE
[TEST]-fix hdp related unit tests

### DIFF
--- a/common/test-src/org/pentaho/hadoop/shim/common/CommonPigShimTest.java
+++ b/common/test-src/org/pentaho/hadoop/shim/common/CommonPigShimTest.java
@@ -38,17 +38,7 @@ public class CommonPigShimTest {
   class TestPigShim extends CommonPigShim {
     @Override public int[] executeScript( String pigScript, ExecutionMode executionMode, Properties properties )
       throws Exception {
-      ClassLoader cl = Thread.currentThread().getContextClassLoader();
-      Thread.currentThread().setContextClassLoader( getClass().getClassLoader() );
-      try {
-        PigServer pigServer = new PigServer( getExecType( executionMode ), properties );
-        GruntParser grunt = new GruntParser( new StringReader( pigScript ) );
-        grunt.setInteractive( false );
-        grunt.setParams( pigServer );
-        return grunt.parseStopOnError( false );
-      } finally {
-        Thread.currentThread().setContextClassLoader( cl );
-      }
+      return new int[0];
     }
   }
 

--- a/hdp21/ivy.xml
+++ b/hdp21/ivy.xml
@@ -98,6 +98,7 @@
     <dependency conf="test->default" org="junit" name="junit" rev="4.5"/>
     <dependency conf="test->default" org="org.safehaus.jug" name="jug-lgpl" rev="2.0.0" />
     <dependency conf="test->default" org="pentaho" name="pentaho-hadoop-shims-api-test" rev="${project.revision}" changing="true"/>
+    <dependency conf="test->default" org="org.mockito" name="mockito-all" rev="1.9.5" transitive="false" />
 
     <!-- Exclude log4j from default libraries - it's brought in transitively through many of the Hadoop dependencies and should not be included -->
     <exclude org="log4j" module="log4j" conf="default" />

--- a/hdp22/ivy.xml
+++ b/hdp22/ivy.xml
@@ -100,6 +100,7 @@
     <dependency conf="test->default" org="junit" name="junit" rev="4.5"/>
     <dependency conf="test->default" org="org.safehaus.jug" name="jug-lgpl" rev="2.0.0" />
     <dependency conf="test->default" org="pentaho" name="pentaho-hadoop-shims-api-test" rev="${project.revision}" changing="true"/>
+    <dependency conf="test->default" org="org.mockito" name="mockito-all" rev="1.9.5" transitive="false" />
 
     <!-- Exclude log4j from default libraries - it's brought in transitively through many of the Hadoop dependencies and should not be included -->
     <exclude org="log4j" module="log4j" conf="default" />


### PR DESCRIPTION
Changes:
* added mockito dependency for hdp21 and hdp22
* simplified TestPigShim.executeScript() method to avoid hdp22 compilation error because of changes in GruntParser API (the method is only used to have concrete class and is never invoked).