### PR TITLE
[BAD-165] - MapR401: All Sqoop jobs fail if MapR cluster is running Hadoop 2.4 version

### DIFF
--- a/mapr401/build.properties
+++ b/mapr401/build.properties
@@ -19,6 +19,6 @@ dependency.hive-jdbc.revision=0.12-mapr-1409
 dependency.apache-hive-jdbc.revision=0.12-mapr-1409
 dependency.apache-hbase.revision=0.98.4-mapr-1408
 dependency.apache-zookeeper.revision=3.4.5-mapr-1406
-dependency.apache-sqoop.revision=1.4.5-mapr-1410
+dependency.apache-sqoop.revision=1.4.5-mapr-1410-h2
 dependency.pig.revision=0.13.1-mapr-1410
 dependency.apache-oozie.revision=4.0.1-mapr-1409


### PR DESCRIPTION
* Changed Sqoop version