### PR TITLE
[PDI-13635]- MapR: Yarn job fails on MapR Hadoop 4.0.1 on Windows client

### DIFF
--- a/mapr401/build.properties
+++ b/mapr401/build.properties
@@ -14,6 +14,7 @@ dependency.xstream.revision=1.4.2
 dependency.commons-lang.revision=2.5
 
 dependency.thrift.revision=0.9.0
+dependency.hadoop2-windows-patch.revision=08072014
 dependency.hadoop.revision=2.4.1-mapr-1408
 dependency.hive-jdbc.revision=0.12-mapr-1409
 dependency.apache-hive-jdbc.revision=0.12-mapr-1409

--- a/mapr401/ivy.xml
+++ b/mapr401/ivy.xml
@@ -70,6 +70,13 @@
     <dependency conf="test->default" org="pentaho" name="pentaho-hadoop-shims-api-test" rev="${project.revision}" changing="true"/>
     <dependency conf="test->default" org="org.mockito" name="mockito-all" rev="1.9.5" transitive="false"/>
     <dependency conf="provided->default" org="pentaho" name="pentaho-hadoop-shims-api" rev="${project.revision}" changing="true"/>
+    <!--
+      This patch gets us around bugs like MAPREDUCE-5665 where MapReduce jobs submitted from a Windows client to YARN
+      fail because of client-side attributes used during cluster-side execution.
+     -->
+    <dependency conf="default" org="pentaho" name="hadoop2-windows-patch" rev="${dependency.hadoop2-windows-patch.revision}" transitive="false">
+      <artifact name="hadoop2-windows-patch" ext="jar"/>
+    </dependency>
     <exclude org="org.antlr" conf="default->provided" />
 
   </dependencies>

--- a/mapr401/package-res/config.properties
+++ b/mapr401/package-res/config.properties
@@ -22,7 +22,8 @@ ignored.classes=
 # These are Windows-specific classpath and library paths. 
 # Please make sure to update the MapR versions in the paths to match your
 # locally installed MapR client.
-windows.classpath=file:///C:/opt/mapr/conf,file:///C:/opt/mapr/hadoop/hadoop-0.20.2/lib
+# Make sure you have properly configured windows.classpath property (if you are using PDI on windows): The first entrance should be relative path to lib/hadoop2-windows-patch-08072014.jar
+windows.classpath=lib/hadoop2-windows-patch-08072014.jar,file:///C:/opt/mapr/conf,file:///C:/opt/mapr/hadoop/hadoop-0.20.2/lib
 windows.library.path=C:\\opt\\mapr\\lib
 
 java.system.hadoop.login=hybrid


### PR DESCRIPTION
Added missed patch jar.