### PR TITLE
[BACKLOG-3217] - EMR34 shim requires additional changes to run MapReduce jobs with Input-Output folders on S3

### DIFF
--- a/emr34/ivy.xml
+++ b/emr34/ivy.xml
@@ -87,5 +87,6 @@
     <dependency conf="test->default" org="pentaho" name="pentaho-hadoop-shims-api" rev="${project.revision}" changing="true"/>
 
     <exclude org="org.antlr" conf="default->provided" />
+    <exclude org="javax.xml.stream" />
   </dependencies>
 </ivy-module>


### PR DESCRIPTION
(Removed stax-api.jar)