### PR TITLE
[BAD-318] Hadoop File Output/Input steps fail to output to HDFS with Hadoop-snappy compression

### DIFF
--- a/emr34/build.properties
+++ b/emr34/build.properties
@@ -8,7 +8,6 @@ package.root.dir=emr34
 
 dependency.kettle.revision=6.0-SNAPSHOT
 dependency.pentaho-hdfs-vfs.revision=6.0-SNAPSHOT
-dependency.pentaho-hadoop-snappy.revision=0.0.1
 dependency.pentaho-vfs-browser.revision=6.0-SNAPSHOT
 
 dependency.xstream.revision=1.4.2

--- a/emr34/ivy.xml
+++ b/emr34/ivy.xml
@@ -57,7 +57,6 @@
     <!--<dependency conf="default->provided" org="com.mapr.fs" name="libprotodefs" rev="4.0.1-mapr" changing="false" transitive="false" />-->
 
     <dependency conf="default,provided->default" org="pentaho" name="pentaho-hdfs-vfs" rev="${dependency.pentaho-hdfs-vfs.revision}" transitive="false" changing="true"/>
-    <dependency conf="default,provided->default" org="pentaho" name="pentaho-hadoop-snappy" rev="${dependency.pentaho-hadoop-snappy.revision}" changing="true" transitive="false"/>
     <!--
           This patch gets us around bugs like MAPREDUCE-5665 where MapReduce jobs submitted from a Windows client to YARN
           fail because of client-side attributes used during cluster-side execution.

--- a/emr34/src/org/pentaho/hadoop/shim/emr34/SnappyShim.java
+++ b/emr34/src/org/pentaho/hadoop/shim/emr34/SnappyShim.java
@@ -23,7 +23,6 @@
 package org.pentaho.hadoop.shim.emr34;
 
 import org.apache.hadoop.io.compress.SnappyCodec;
-import org.apache.hadoop.conf.Configuration;
 import org.pentaho.hadoop.shim.common.CommonSnappyShim;
 
 public class SnappyShim extends CommonSnappyShim {
@@ -37,7 +36,7 @@ public class SnappyShim extends CommonSnappyShim {
     ClassLoader cl = Thread.currentThread().getContextClassLoader();
     Thread.currentThread().setContextClassLoader( getClass().getClassLoader() );
     try {
-      return SnappyCodec.isNativeSnappyLoaded( new Configuration() );
+      return SnappyCodec.isNativeCodeLoaded( );
     } catch ( Throwable t ) {
       return false;
     } finally {

--- a/hdp20/build.properties
+++ b/hdp20/build.properties
@@ -8,7 +8,7 @@ package.root.dir=hdp20
 
 dependency.kettle.revision=6.0-SNAPSHOT
 dependency.pentaho-hdfs-vfs.revision=6.0-SNAPSHOT
-dependency.pentaho-hadoop-snappy.revision=0.0.1
+
 
 dependency.xstream.revision=1.4.2
 dependency.commons-lang.revision=2.5

--- a/hdp20/ivy.xml
+++ b/hdp20/ivy.xml
@@ -22,7 +22,6 @@
     <dependency conf="provided->default" org="pentaho-kettle" name="kettle-engine" rev="${dependency.kettle.revision}" changing="true"/>
 
     <dependency org="pentaho" name="pentaho-hdfs-vfs" rev="${dependency.pentaho-hdfs-vfs.revision}" transitive="false" changing="true"/>
-    <dependency org="pentaho" name="pentaho-hadoop-snappy" rev="${dependency.pentaho-hadoop-snappy.revision}" changing="true"/>
 
     <dependency conf="client->default" org="commons-httpclient" name="commons-httpclient" rev="${dependency.commons-httpclient.revision}" transitive="false" />
     <dependency conf="client->default" org="commons-net" name="commons-net" rev="${dependency.commons-net.revision}" transitive="false" />

--- a/hdp21/build.properties
+++ b/hdp21/build.properties
@@ -8,7 +8,7 @@ package.root.dir=hdp21
 
 dependency.kettle.revision=6.0-SNAPSHOT
 dependency.pentaho-hdfs-vfs.revision=6.0-SNAPSHOT
-dependency.pentaho-hadoop-snappy.revision=0.0.1
+
 
 dependency.xstream.revision=1.4.2
 dependency.commons-lang.revision=2.5

--- a/hdp21/ivy.xml
+++ b/hdp21/ivy.xml
@@ -22,7 +22,6 @@
     <dependency conf="provided->default" org="pentaho-kettle" name="kettle-engine" rev="${dependency.kettle.revision}" changing="true"/>
 
     <dependency org="pentaho" name="pentaho-hdfs-vfs" rev="${dependency.pentaho-hdfs-vfs.revision}" transitive="false" changing="true"/>
-    <dependency org="pentaho" name="pentaho-hadoop-snappy" rev="${dependency.pentaho-hadoop-snappy.revision}" changing="true"/>
 
     <dependency conf="client->default" org="commons-httpclient" name="commons-httpclient" rev="${dependency.commons-httpclient.revision}" transitive="false" />
     <dependency conf="client->default" org="commons-net" name="commons-net" rev="${dependency.commons-net.revision}" transitive="false" />

--- a/hdp22/build.properties
+++ b/hdp22/build.properties
@@ -8,7 +8,7 @@ package.root.dir=hdp22
 
 dependency.kettle.revision=6.0-SNAPSHOT
 dependency.pentaho-hdfs-vfs.revision=6.0-SNAPSHOT
-dependency.pentaho-hadoop-snappy.revision=0.0.1
+
 
 dependency.xstream.revision=1.4.2
 dependency.commons-lang.revision=2.5

--- a/hdp22/ivy.xml
+++ b/hdp22/ivy.xml
@@ -22,7 +22,6 @@
     <dependency conf="provided->default" org="pentaho-kettle" name="kettle-engine" rev="${dependency.kettle.revision}" changing="true"/>
 
     <dependency org="pentaho" name="pentaho-hdfs-vfs" rev="${dependency.pentaho-hdfs-vfs.revision}" transitive="false" changing="true"/>
-    <dependency org="pentaho" name="pentaho-hadoop-snappy" rev="${dependency.pentaho-hadoop-snappy.revision}" changing="true"/>
 
     <dependency conf="client->default" org="commons-httpclient" name="commons-httpclient" rev="${dependency.commons-httpclient.revision}" transitive="false" />
     <dependency conf="client->default" org="commons-net" name="commons-net" rev="${dependency.commons-net.revision}" transitive="false" />

--- a/mapr401/build.properties
+++ b/mapr401/build.properties
@@ -8,7 +8,6 @@ package.root.dir=mapr401
 
 dependency.kettle.revision=6.0-SNAPSHOT
 dependency.pentaho-hdfs-vfs.revision=6.0-SNAPSHOT
-dependency.pentaho-hadoop-snappy.revision=0.0.1
 
 dependency.xstream.revision=1.4.2
 dependency.commons-lang.revision=2.5

--- a/mapr401/ivy.xml
+++ b/mapr401/ivy.xml
@@ -51,8 +51,6 @@
     <dependency conf="provided->default" org="com.mapr.fs" name="libprotodefs" rev="4.0.1-mapr" changing="false" transitive="false" />
 
     <dependency conf="default" org="pentaho" name="pentaho-hdfs-vfs" rev="${dependency.pentaho-hdfs-vfs.revision}" transitive="false" changing="true"/>
-    <dependency conf="default" org="pentaho" name="pentaho-hadoop-snappy" rev="${dependency.pentaho-hadoop-snappy.revision}" changing="true" />
-
 
     <dependency conf="pmr->default" org="org.cloudera.htrace" name="htrace-core" rev="2.04" transitive="false" changing="true"/>
     <dependency conf="pmr->default" org="org.apache.zookeeper" name="zookeeper" rev="${dependency.apache-zookeeper.revision}" transitive="false"/>

--- a/mapr401/src/org/pentaho/hadoop/shim/mapr401/SnappyShim.java
+++ b/mapr401/src/org/pentaho/hadoop/shim/mapr401/SnappyShim.java
@@ -22,7 +22,6 @@
 
 package org.pentaho.hadoop.shim.mapr401;
 
-import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.io.compress.SnappyCodec;
 import org.pentaho.hadoop.shim.common.CommonSnappyShim;
 
@@ -38,7 +37,7 @@ public class SnappyShim extends CommonSnappyShim {
     ClassLoader cl = Thread.currentThread().getContextClassLoader();
     Thread.currentThread().setContextClassLoader( getClass().getClassLoader() );
     try {
-      return SnappyCodec.isNativeSnappyLoaded( new Configuration() );
+      return SnappyCodec.isNativeCodeLoaded( );
     } catch ( Throwable t ) {
       return false;
     } finally {


### PR DESCRIPTION
* Removed necessary for old shims pentaho-snappy artifact.
