### PR TITLE
[BAD-436] - Exclude xml-apis-1.3.04.jar from emr 4.1 shim

### DIFF
--- a/emr41/ivy.xml
+++ b/emr41/ivy.xml
@@ -102,8 +102,7 @@
 
     <exclude org="org.antlr" conf="provided->provided" />
     <exclude org="javax.xml.stream" />
-    <exclude org="xerces" artifact="xercesImpl" conf="client->default"/>
-    <exclude org="xml-apis" artifact="xml-apis" conf="client->default"/>
+    <exclude org="xml-apis" artifact="xml-apis" conf="client" />
     <exclude org="org.apache.calcite" />
 
   </dependencies>


### PR DESCRIPTION
*  Backported from master