### PR TITLE
[BACKLOG-5746] - Spoon: PMR jobs failed because pentaho-mapreduce-libraries.zip can't be unzipped successfully

### DIFF
--- a/common/src/org/pentaho/hadoop/shim/common/DistributedCacheUtilImpl.java
+++ b/common/src/org/pentaho/hadoop/shim/common/DistributedCacheUtilImpl.java
@@ -531,7 +531,10 @@ public class DistributedCacheUtilImpl implements org.pentaho.hadoop.shim.api.Dis
         ZipEntry ze;
         while ( ( ze = zis.getNextEntry() ) != null ) {
           FileObject entry = KettleVFS.getFileObject( dest + Const.FILE_SEPARATOR + ze.getName() );
-
+          FileObject parent = entry.getParent();
+          if ( parent != null ) {
+            parent.createFolder();
+          }
           if ( ze.isDirectory() ) {
             entry.createFolder();
             continue;


### PR DESCRIPTION
* Added test for mixed entries in zip