### PR TITLE
[BAD-446] - Create and compile CDH 5.5 shim in the 6.0 branch

### DIFF
--- a/cdh55/ivy.xml
+++ b/cdh55/ivy.xml
@@ -120,6 +120,9 @@
     <exclude org="org.apache.hadoop" module="hadoop-yarn-server-resourcemanager" conf="default,pmr" />
     <exclude org="org.apache.hadoop" module="hadoop-yarn-server-web-proxy" conf="default,pmr" />
     <override org="org.apache.htrace" module="htrace-core4" rev="4.0.1-incubating" />
+    <override org="com.fasterxml.jackson.core" module="jackson-annotation" rev="2.2.3" />
+    <override org="com.fasterxml.jackson.core" module="jackson-databind" rev="2.2.3" />
+    <override org="com.fasterxml.jackson.core" module="jackson-core" rev="2.2.3" />
 
   </dependencies>
 </ivy-module>


### PR DESCRIPTION
Although the BAD-446 is closed - the decision has been made to use jackson 2.2.3 everywhere instead of 2.2.2 in some places (hive deps)

see also related COMP cases:
http://jira.pentaho.com/browse/COMP-2470
http://jira.pentaho.com/browse/COMP-2471
http://jira.pentaho.com/browse/COMP-2472 - has cite with the decision documented

@brosander @hudak Gentlemen, I'll appreciate if you had a chance to take a look