### PR TITLE
[PDI-14443] - Hadoop Kerberos security ticket not renewed after expire

### DIFF
--- a/common/src/org/pentaho/hbase/shim/common/CommonHBaseConnection.java
+++ b/common/src/org/pentaho/hbase/shim/common/CommonHBaseConnection.java
@@ -146,7 +146,7 @@ public class CommonHBaseConnection extends HBaseConnection {
         log.logDebug( "Opening HBase connection ..." );
       }
 
-      m_factory = getHBaseClientFactory();
+      m_factory = getHBaseClientFactory( m_config );
 
       m_admin = m_factory.getHBaseAdmin();
     } finally {
@@ -154,8 +154,8 @@ public class CommonHBaseConnection extends HBaseConnection {
     }
   }
 
-  HBaseClientFactory getHBaseClientFactory() {
-    return HBaseClientFactoryLocator.getHBaseClientFactory( m_config );
+  protected HBaseClientFactory getHBaseClientFactory( Configuration configuration ) {
+    return HBaseClientFactoryLocator.getHBaseClientFactory( configuration );
   }
 
   @Override


### PR DESCRIPTION
Add Configuration argument to getHBaseClientFactory() method.