### PR TITLE
[BACKLOG-6547] - CDH55 secure shim: PUC: DB Table(s) Data Source cannot be created based on Secured Cloudera Impala JDBC connection

### DIFF
--- a/cdh54/src/org/apache/hadoop/hive/jdbc/HiveDriver.java
+++ b/cdh54/src/org/apache/hadoop/hive/jdbc/HiveDriver.java
@@ -37,9 +37,12 @@ import java.util.logging.Logger;
  *
  */
 public class HiveDriver implements Driver {
+  private static final String SQL_STATE_NOT_SUPPORTED = "0A000";
 
-  public HiveDriver() {
-    throw new RuntimeException( "Currently active Hadoop shim does not support the HiveServer1 JDBC driver" );
+  public HiveDriver() throws SQLException {
+    throw new SQLException(
+        "Currently active Hadoop shim does not support the HiveServer1 JDBC driver",
+        SQL_STATE_NOT_SUPPORTED );
   }
 
   @Override

--- a/cdh55/src/org/apache/hadoop/hive/jdbc/HiveDriver.java
+++ b/cdh55/src/org/apache/hadoop/hive/jdbc/HiveDriver.java
@@ -37,9 +37,12 @@ import java.util.logging.Logger;
  *
  */
 public class HiveDriver implements Driver {
+  private static final String SQL_STATE_NOT_SUPPORTED = "0A000";
 
-  public HiveDriver() {
-    throw new RuntimeException( "Currently active Hadoop shim does not support the HiveServer1 JDBC driver" );
+  public HiveDriver() throws SQLException {
+    throw new SQLException(
+        "Currently active Hadoop shim does not support the HiveServer1 JDBC driver",
+        SQL_STATE_NOT_SUPPORTED );
   }
 
   @Override

--- a/common/test-src/org/pentaho/hadoop/shim/common/DriverProxyInvocationChainTest.java
+++ b/common/test-src/org/pentaho/hadoop/shim/common/DriverProxyInvocationChainTest.java
@@ -85,7 +85,7 @@ public class DriverProxyInvocationChainTest {
   }
 
   @Test
-  public void testGetProxyNotNull() {
+  public void testGetProxyNotNull() throws Exception {
     assertTrue( DriverProxyInvocationChain.isInitialized() );
     if ( Boolean.parseBoolean( System.getProperty( "org.pentaho.hadoop.shims.check.hive1", "true" ) ) ) {
       // Create Hive driver

--- a/hdp23/src/org/apache/hadoop/hive/jdbc/HiveDriver.java
+++ b/hdp23/src/org/apache/hadoop/hive/jdbc/HiveDriver.java
@@ -37,9 +37,12 @@ import java.util.logging.Logger;
  *
  */
 public class HiveDriver implements Driver {
+  private static final String SQL_STATE_NOT_SUPPORTED = "0A000";
 
-  public HiveDriver() {
-    throw new RuntimeException( "Currently active Hadoop shim does not support the HiveServer1 JDBC driver" );
+  public HiveDriver() throws SQLException {
+    throw new SQLException(
+        "Currently active Hadoop shim does not support the HiveServer1 JDBC driver",
+        SQL_STATE_NOT_SUPPORTED );
   }
 
   @Override


### PR DESCRIPTION
this is the same as https://github.com/pentaho/pentaho-hadoop-shims/pull/334 but for 6.1
the backport has been requested by @kcruzada 

@brosander @hudak @dkincade 