### PR TITLE
[BAD-494] - MapR 4.1: Pig, Sqoop impersonated users are not picked up in 6.1 release

### DIFF
--- a/common/src-hadoop-shim-1.0/org/pentaho/hadoop/shim/common/ConfigurationProxyV2.java
+++ b/common/src-hadoop-shim-1.0/org/pentaho/hadoop/shim/common/ConfigurationProxyV2.java
@@ -37,11 +37,11 @@ import java.io.IOException;
  */
 public class ConfigurationProxyV2 implements Configuration {
 
-  private Job job;
+  protected Job job;
 
   public ConfigurationProxyV2() throws IOException {
     job = Job.getInstance();
-    getJobConf().addResource( "hdfs-site.xml" );
+    job.getConfiguration().addResource( "hdfs-site.xml" );
   }
 
   public JobConf getJobConf() {

--- a/hsp101/src/org/pentaho/hadoop/shim/hsp101/authorization/ShimNoOpHadoopAuthorizationService.java
+++ b/hsp101/src/org/pentaho/hadoop/shim/hsp101/authorization/ShimNoOpHadoopAuthorizationService.java
@@ -20,7 +20,7 @@
 *
 ******************************************************************************/
 
-package org.pentaho.hadoop.shim.hsp101.authorizaion;
+package org.pentaho.hadoop.shim.hsp101.authorization;
 
 
 import org.pentaho.hadoop.shim.common.CommonHadoopShim;

--- a/mapr401/src/org/pentaho/hadoop/shim/mapr401/ConfigurationProxyV2.java
+++ b/mapr401/src/org/pentaho/hadoop/shim/mapr401/ConfigurationProxyV2.java
@@ -32,8 +32,6 @@ import java.io.IOException;
  */
 public class ConfigurationProxyV2 extends org.pentaho.hadoop.shim.common.ConfigurationProxyV2 {
 
-  private Job job;
-
   protected class JobProxy extends Job {
     private JobProxy( JobConf conf ) throws IOException {
       super( conf );

--- a/mapr410/src/org/pentaho/hadoop/shim/mapr410/ConfigurationProxyV2.java
+++ b/mapr410/src/org/pentaho/hadoop/shim/mapr410/ConfigurationProxyV2.java
@@ -32,8 +32,6 @@ import java.io.IOException;
  */
 public class ConfigurationProxyV2 extends org.pentaho.hadoop.shim.common.ConfigurationProxyV2 {
 
-  private Job job;
-
   protected class JobProxy extends Job {
     private JobProxy( JobConf conf ) throws IOException {
       super( conf );


### PR DESCRIPTION
* Mistype in package name
* Change the way of getting job conf in constructor which caused fail on init