### PR TITLE
[BAD-507]: PMR job can't be finish successfully because of time out exception on hdp 2.4 secure cluster

### DIFF
--- a/hdp24/ivy.xml
+++ b/hdp24/ivy.xml
@@ -115,5 +115,6 @@
     <exclude org="org.apache.hadoop" module="hadoop-yarn-server-common" conf="default" />
     <exclude org="org.apache.hadoop" module="hadoop-yarn-server-resourcemanager" conf="default" />
     <exclude org="org.apache.hadoop" module="hadoop-yarn-server-web-proxy" conf="default" />
+    <exclude org="org.apache.hadoop" module="hadoop-hdfs" conf="default" />
   </dependencies>
 </ivy-module>


### PR DESCRIPTION
There was duplication of jars for hdp24 in hdp24/lib, hdp24/lib/client, hdp24/lib/pmr.
Fixed with excluding hadoop-hdfs module from default config.