### PR TITLE
[BACKLOG-6693] - Pig job failed on the DI server with NoSuchMethod error.

### DIFF
--- a/hdp24/ivy.xml
+++ b/hdp24/ivy.xml
@@ -100,7 +100,8 @@
     <!-- Exclude log4j from default libraries - it's brought in transitively through many of the Hadoop dependencies and should not be included -->
     <exclude org="log4j" module="log4j" conf="default" />
     <!-- Exclude antlr. Hive brings in a version that's not compatible with Pig. -->
-    <exclude org="org.antlr" conf="default" />
+    <!-- Need to check pig antlr dependency does not conflict with hive antlr`s dependency. Currently we are using hive`s version. -->
+    <!--exclude org="org.antlr" conf="default" /-->
     <!--  Exclude xerces, it's provided and will wreak havoc if there are multiple instances / versions -->
     <exclude org="xml-apis" module="xml-apis" conf="*" />
     <exclude org="commons-collections" artifact="commons-collections" conf="default,pmr,client" />


### PR DESCRIPTION
Antlr dependency has been excluding fromshims distribution since the first shim. Hive and Pig have different antlr dependencies. So to not produce conflict this library was exluded - to force user choose manually which version of the antlr library suits him. Checking HDP24 shim was found that Hive->Antlr 3.4 and PIG->Antlr 3.4,3.3. 
It was decided to use antlr 3.4 version  coming from hive.
New introduced dependencies: 
-antlr-runtime-3.4.jar
-antlr-2.7.7.jar
-stringtemplate-3.2.1.jar
