### PR TITLE
[BAD-509]: Create and Compile CDH 5.7 SHIM against Pentaho 6.1.x

### DIFF
--- a/cdh57/build.properties
+++ b/cdh57/build.properties
@@ -25,6 +25,7 @@ dependency.htrace.revision=3.2.0-incubating
 dependency.htrace-core4.revision=4.0.1-incubating
 dependency.jackson.revision=2.2.3
 
+dependency.metrics-core.revision=2.2.0
 dependency.hadoop.revision=2.6.0-cdh5.7.0
 dependency.hadoop2-windows-patch.revision=08072014
 dependency.hive-jdbc.revision=1.1.0-cdh5.7.0

--- a/cdh57/ivy.xml
+++ b/cdh57/ivy.xml
@@ -59,6 +59,7 @@
     <dependency conf="pmr->default" org="org.apache.hbase" name="hbase-server" rev="${dependency.apache-hbase.revision}" transitive="false" changing="true"/>
     <dependency conf="pmr->default" org="org.apache.hbase" name="hbase-thrift" rev="${dependency.apache-hbase.revision}" transitive="false" changing="true"/>
     <dependency conf="pmr->default" org="org.apache.htrace" name="htrace-core" rev="${dependency.htrace.revision}" transitive="false" changing="true"/>
+    <dependency conf="pmr->default" org="com.yammer.metrics" name="metrics-core" rev="${dependency.metrics-core.revision}" transitive="false" changing="true"/>
     <dependency conf="pmr->default" org="org.apache.zookeeper" name="zookeeper" rev="${dependency.zookeeper.revision}" transitive="false"/>
 
     <dependency org="pentaho" name="pentaho-hdfs-vfs" rev="${dependency.pentaho-hdfs-vfs.revision}" transitive="false" changing="true"/>


### PR DESCRIPTION
metrics-core-2.2.0.jar is needed for hbase-client and should be included into PMR configuration otherwise we have java.lang.NoClassDefFoundError: com/yammer/metrics/core/Gauge
at working with Hbase steps

This jar has already been uploaded into pentaho private-3rd-party-candidate-release repo and processed (please see http://jira.pentaho.com/browse/COMP-957)