### PR TITLE
[BACKLOG-9012][TYPO] - Master: cdh55 shim in CE-version: configuration name should be updated in the "config.properties" file

### DIFF
--- a/cdh55/package-res/config.properties
+++ b/cdh55/package-res/config.properties
@@ -1,5 +1,5 @@
 # Friendly name for this configuration
-name=Cloudera CDH 5.4
+name=Cloudera CDH 5.5
 
 # Comma-separated list of directories and files to make available to this
 # configuration. Any resources found here will overwrite ones in lib/.


### PR DESCRIPTION
- Typo fix