### PR TITLE
[BACKLOG-9277]: Delete hbase-examples-1.2.0 from EMR 4.6 shim

### DIFF
--- a/emr46/ivy.xml
+++ b/emr46/ivy.xml
@@ -147,7 +147,6 @@
     <dependency conf="pmr->default" org="org.apache.hbase" name="hbase-common" rev="${dependency.apache-hbase.revision}" transitive="false"/>
     <dependency conf="pmr->default" org="org.apache.hbase" name="hbase-thrift" rev="${dependency.apache-hbase.revision}" transitive="false"/>
     <dependency conf="pmr->default" org="org.apache.hbase" name="hbase-server" rev="${dependency.apache-hbase.revision}" transitive="false"/>
-    <dependency conf="pmr->default" org="org.apache.hbase" name="hbase-examples" rev="${dependency.apache-hbase.revision}" transitive="false"/>
     <dependency conf="pmr->default" org="com.yammer.metrics" name="metrics-core" rev="${dependency.metrics-core.revision}" transitive="false" changing="true"/>
     <dependency conf="pmr->default" org="org.apache.zookeeper" name="zookeeper" rev="${dependency.apache-zookeeper.revision}" transitive="false"/>
 


### PR DESCRIPTION
It needs to delete hbase-examples-1.2.0 from EMR 4.6 shim because it has been rejected on Architecture Review (see COMP-3144).