### PR TITLE
[BACKLOG-8533]: Create the EMR 4.6 Shim (against Pentaho Master/7.0)

### DIFF
--- a/emr46/build.properties
+++ b/emr46/build.properties
@@ -115,7 +115,6 @@ izpack.version=5.0.7-RC1
 pentaho-eula-wrap-config.version=1.0.10
 
 #Test specific dependencies
-dependency.pentaho-hadoop-shims-api-test.revision=7.0-SNAPSHOT
 dependency.junit.revision=4.11
 dependency.hamcrest-core.revision=1.3
 dependency.mockito-all.revision=1.9.5

--- a/emr46/ivy.xml
+++ b/emr46/ivy.xml
@@ -164,7 +164,7 @@
     <dependency conf="test->default" org="org.hamcrest" name="hamcrest-core" rev="${dependency.hamcrest-core.revision}" transitive="false"/>
     <dependency conf="test->default" org="org.safehaus.jug" name="jug-lgpl" rev="${dependency.jug-lgpl.revision}" transitive="false"/>
     <dependency conf="test->default" org="org.mockito" name="mockito-all" rev="${dependency.mockito-all.revision}" transitive="false" />
-    <dependency conf="test->default" org="pentaho" name="pentaho-hadoop-shims-api-test" rev="${dependency.pentaho-hadoop-shims-api-test.revision}" changing="true"/>
+    <dependency conf="test->default" org="pentaho" name="pentaho-hadoop-shims-api-test" rev="${dependency.hadoop-shims-api.revision}" changing="true"/>
 
 
     <!--  OSS Licenses file -->


### PR DESCRIPTION
Fix the global version property for pentaho-hadoop-shims-api-test