### PR TITLE
[BACKLOG-9591]-As a BDS administrator, I want one place to configure big data security to ease configuration tasks.

### DIFF
--- a/common/src-modern/org/pentaho/hadoop/shim/common/authorization/AuthenticatingHadoopShim.java
+++ b/common/src-modern/org/pentaho/hadoop/shim/common/authorization/AuthenticatingHadoopShim.java
@@ -1,23 +1,18 @@
 /*******************************************************************************
- *
  * Pentaho Big Data
- *
- * Copyright (C) 2002-2014 by Pentaho : http://www.pentaho.com
- *
- *******************************************************************************
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with
+ * <p>
+ * Copyright (C) 2002-2016 by Pentaho : http://www.pentaho.com
+ * <p>
+ * ******************************************************************************
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
- *
- *    http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- *
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
  ******************************************************************************/
 
 package org.pentaho.hadoop.shim.common.authorization;
@@ -39,6 +34,9 @@ import java.net.URLClassLoader;
 import java.util.Properties;
 
 public class AuthenticatingHadoopShim extends DelegatingHadoopShim {
+
+  public static final String MAPPING_IMPERSONATION_TYPE = "pentaho.authentication.default.mapping.impersonation.type";
+
   @Override
   public void onLoad( HadoopConfiguration config, HadoopConfigurationFileSystemManager fsm ) throws Exception {
     AuthenticationConsumerPluginType.getInstance().registerPlugin( (URLClassLoader) getClass().getClassLoader(),
@@ -58,8 +56,12 @@ public class AuthenticatingHadoopShim extends DelegatingHadoopShim {
       }
     }
     String provider = NoAuthenticationAuthenticationProvider.NO_AUTH_ID;
-    if ( config.getConfigProperties().containsKey( SUPER_USER ) ) {
+    if ( config.getConfigProperties().containsKey( SUPER_USER ) && !config.getConfigProperties()
+      .getProperty( MAPPING_IMPERSONATION_TYPE, "" ).trim().equalsIgnoreCase( "disabled" ) ) {
       provider = config.getConfigProperties().getProperty( SUPER_USER );
+      if ( provider.trim().length() == 0 ) {
+        provider = NoAuthenticationAuthenticationProvider.NO_AUTH_ID;
+      }
     }
     AuthenticationManager manager = AuthenticationPersistenceManager.getAuthenticationManager();
     new PropertyAuthenticationProviderParser( config.getConfigProperties(), manager ).process( PROVIDER_LIST );


### PR DESCRIPTION
We want the failover to work all the time for now as well, except when the impersonation type=disabled, which means no Kerberos at all.