### PR TITLE
[BACKLOG-9528] - YARN job fails on MapR 5.1 unsecure cluster while runing a transformation step

### DIFF
--- a/api/src/org/pentaho/hadoop/shim/HadoopConfigurationLocator.java
+++ b/api/src/org/pentaho/hadoop/shim/HadoopConfigurationLocator.java
@@ -1,23 +1,18 @@
 /*******************************************************************************
- *
  * Pentaho Big Data
- *
+ * <p>
  * Copyright (C) 2002-2016 by Pentaho : http://www.pentaho.com
- *
- *******************************************************************************
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with
+ * <p>
+ * ******************************************************************************
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
- *
- *    http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- *
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
  ******************************************************************************/
 
 package org.pentaho.hadoop.shim;
@@ -36,6 +31,8 @@ import java.util.Properties;
 import java.util.ServiceLoader;
 import java.util.Set;
 import java.util.Map.Entry;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 import org.apache.commons.vfs2.FileObject;
 import org.apache.commons.vfs2.FileSelectInfo;
@@ -68,6 +65,8 @@ public class HadoopConfigurationLocator implements HadoopConfigurationProvider {
   private static final String CONFIG_PROPERTIES_FILE = "config.properties";
 
   private static final String CONFIG_PROPERTY_IGNORE_CLASSES = "ignore.classes";
+
+  private static final String CONFIG_PROPERTY_EXCLUDE_JARS = "exclude.jars";
 
   private static final String SHIM_CLASSPATH_IGNORE = "classpath.ignore";
 
@@ -193,6 +192,41 @@ public class HadoopConfigurationLocator implements HadoopConfigurationProvider {
     }
   }
 
+  /**
+   * Exclude jars contained in exclude.jars property in config.properties file from the list of URLs
+   *
+   * @param urls                 the list of all the URLs to add to the class loader
+   * @param excludedJarsProperty exclude.jars property from a config.properties file
+   * @return The rest of the jars in {@code urls} after excluding the jars listed in {@code excludedJarsProperty}.
+   */
+
+  protected List<URL> filterJars( List<URL> urls, String excludedJarsProperty ) {
+
+    Pattern pattern;
+    Matcher matcher;
+    String[] excludedJars;
+
+    if ( !( excludedJarsProperty == null || excludedJarsProperty.trim().isEmpty() ) ) {
+      excludedJars = excludedJarsProperty.split( "," );
+      if ( excludedJars != null ) {
+        for ( String excludedJar : excludedJars ) {
+          pattern = Pattern.compile( ".*/" + excludedJar.toLowerCase() + "-\\d[\\.\\w]*\\.jar$" );
+          Iterator<URL> iterator = urls.listIterator();
+          while ( iterator.hasNext() ) {
+            URL url = iterator.next();
+            if ( url.toString().toLowerCase().contains( excludedJar.toLowerCase() ) ) {
+              matcher = pattern.matcher( url.toString().toLowerCase() );
+              if ( matcher.matches() ) {
+                iterator.remove();
+              }
+            }
+          }
+        }
+      }
+    }
+    return urls;
+  }
+
   private List<URL> findJarsIn( FileObject path, final int maxdepth, final Set<String> paths )
     throws FileSystemException {
     FileObject[] jars = path.findFiles( new FileSelector() {
@@ -284,6 +318,8 @@ public class HadoopConfigurationLocator implements HadoopConfigurationProvider {
       if ( classpathUrls != null ) {
         jars.addAll( 0, classpathUrls );
       }
+      //Exclude jars contained in exclude.jars property in config.properties file from the list of jars
+      jars = filterJars( jars, configurationProperties.getProperty( CONFIG_PROPERTY_EXCLUDE_JARS ) );
 
       return new HadoopConfigurationClassLoader( jars.toArray( EMPTY_URL_ARRAY ),
         parent, ignoredClasses );
@@ -402,7 +438,8 @@ public class HadoopConfigurationLocator implements HadoopConfigurationProvider {
       hadoopShim.onLoad( config, fsm );
       return config;
     } catch ( Throwable t ) {
-      throw new ConfigurationException( BaseMessages.getString( PKG, "Error.LoadingConfiguration" ) + " " + t.toString(), t );
+      throw new ConfigurationException(
+        BaseMessages.getString( PKG, "Error.LoadingConfiguration" ) + " " + t.toString(), t );
     }
   }
 

--- a/api/test-src/org/pentaho/hadoop/shim/HadoopConfigurationLocatorTest.java
+++ b/api/test-src/org/pentaho/hadoop/shim/HadoopConfigurationLocatorTest.java
@@ -1,23 +1,18 @@
 /*******************************************************************************
- *
  * Pentaho Big Data
- *
- * Copyright (C) 2002-2015 by Pentaho : http://www.pentaho.com
- *
- *******************************************************************************
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with
+ * <p>
+ * Copyright (C) 2002-2016 by Pentaho : http://www.pentaho.com
+ * <p>
+ * ******************************************************************************
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
- *
- *    http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- *
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
  ******************************************************************************/
 
 package org.pentaho.hadoop.shim;
@@ -72,12 +67,28 @@ public class HadoopConfigurationLocatorTest {
     p.setProperty( "classpath", "" );
     p.setProperty( "library.path", "" );
     p.setProperty( "required.classes", HadoopConfigurationLocatorTest.class.getName() );
+    p.setProperty( "exclude.jars", "" );
     p.store( configFile.getContent().getOutputStream(), "Test Configuration A" );
     configFile.close();
 
     // Create the implementation jar
     FileObject implJar = aConfigFolder.resolveFile( "a-config.jar" );
     implJar.createFile();
+
+    FileObject implXercesJar = aConfigFolder.resolveFile( "xercesImpl-2.9.1.jar" );
+    implXercesJar.createFile();
+
+    FileObject implXmlApisJar = aConfigFolder.resolveFile( "xml-apis-1.3.04.jar" );
+    implXmlApisJar.createFile();
+
+    FileObject implXmlApisExtJar = aConfigFolder.resolveFile( "xml-apis-ext-1.3.04.jar" );
+    implXmlApisExtJar.createFile();
+
+    FileObject implXercesFakeVersionJar = aConfigFolder.resolveFile( "xerces-version-1.8.0.jar" );
+    implXercesFakeVersionJar.createFile();
+
+    FileObject implXercesImpl2Jar = aConfigFolder.resolveFile( "xercesImpl2-2.9.1.jar" );
+    implXercesImpl2Jar.createFile();
 
     // Use ShrinkWrap to create the jar and write it out to VFS
     JavaArchive archive = ShrinkWrap.create( JavaArchive.class, "a-configuration.jar" ).addAsServiceProvider(
@@ -132,8 +143,8 @@ public class HadoopConfigurationLocatorTest {
       Assert.fail( "Should have got exception " );
     } catch ( ConfigurationException e ) {
       assertEquals(
-        "Unable to load class this.class.does.not.Exist that is required to start the Test Configuration A Hadoop Shim"
-        , e.getCause().getMessage() );
+        "Unable to load class this.class.does.not.Exist that is required to start the Test Configuration A Hadoop Shim",
+        e.getCause().getMessage() );
     } finally {
       properties.setProperty( "required.classes", HadoopConfigurationLocator.class.getName() );
       properties.store( configFile.getContent().getOutputStream(), "Test Configuration A" );
@@ -311,8 +322,66 @@ public class HadoopConfigurationLocatorTest {
     FileObject root = VFS.getManager().resolveFile( HADOOP_CONFIGURATIONS_PATH );
 
     List<URL> urls = locator.parseURLs( root, "a,b" );
-    assertEquals( 2, urls.size() );
+    assertEquals( 7, urls.size() );
     assertEquals( root.getURL().toURI().resolve( "hadoop-configurations/a/" ), urls.get( 0 ).toURI() );
     assertEquals( root.getURL().toURI().resolve( "hadoop-configurations/a/a-config.jar" ), urls.get( 1 ).toURI() );
+  }
+
+  @Test
+  public void filterJars_null_args() throws Exception {
+    HadoopConfigurationLocator locator = new HadoopConfigurationLocator();
+    FileObject root = VFS.getManager().resolveFile( HADOOP_CONFIGURATIONS_PATH );
+
+    List<URL> list = locator.filterJars( null, null );
+
+    assertNull( list );
+  }
+
+  @Test
+  public void filterJars_null_arg_excludedJarsProperty() throws Exception {
+    HadoopConfigurationLocator locator = new HadoopConfigurationLocator();
+    FileObject root = VFS.getManager().resolveFile( HADOOP_CONFIGURATIONS_PATH );
+
+    List<URL> urls = locator.parseURLs( root, "a,b" );
+    List<URL> list = locator.filterJars( urls, null );
+
+    assertEquals( 7, list.size() );
+  }
+
+  @Test
+  public void filterJars_arg_excludedJarsProperty_emptyString() throws Exception {
+    HadoopConfigurationLocator locator = new HadoopConfigurationLocator();
+    FileObject root = VFS.getManager().resolveFile( HADOOP_CONFIGURATIONS_PATH );
+
+    List<URL> urls = locator.parseURLs( root, "a,b" );
+    List<URL> list = locator.filterJars( urls, "" );
+
+    assertEquals( 7, list.size() );
+  }
+
+  @Test
+  public void filterJars_arg_urls_containsOnlyExcludedJars() throws Exception {
+    HadoopConfigurationLocator locator = new HadoopConfigurationLocator();
+    FileObject root = VFS.getManager().resolveFile( HADOOP_CONFIGURATIONS_PATH );
+
+    List<URL> urls = locator.parseURLs( root, "a,b" );
+    urls.remove( 0 );
+    urls.remove( 0 );
+
+    List<URL> list = locator.filterJars( urls, "xercesImpl,xml-apis,xml-apis-ext,xerces-version,xercesImpl2" );
+
+    assertEquals( 0, list.size() );
+    assertNotNull( list );
+  }
+
+  @Test
+  public void filterJars_removeOnlyXercesImpl() throws Exception {
+    HadoopConfigurationLocator locator = new HadoopConfigurationLocator();
+    FileObject root = VFS.getManager().resolveFile( HADOOP_CONFIGURATIONS_PATH );
+
+    List<URL> urls = locator.parseURLs( root, "a,b" );
+    List<URL> list = locator.filterJars( urls, "xercesImpl" );
+
+    assertEquals( 6, list.size() );
   }
 }


### PR DESCRIPTION
 - added a new property exclude.jars to the config.properties file for a shim. This property contains the list of the excluded jars (without version, for instance, xercesImpl,xmp-apis) from the classpath;
 - created a new method filterJars in pentaho-hadoop-shims/api/src/org/pentaho/hadoop/shim/HadoopConfigurationLocator;
 - added changes to createConfigurationLoader (added calling the filterJars method );
 - created new Tests in pentaho-hadoop-shims/api/test-src/org/pentaho/hadoop/shim/HadoopConfigurationLocatorTest.