### PR TITLE
[BACKLOG-9528] -  YARN job fails on MapR 5.1 unsecure cluster while runing a transformation step (tests passed on Windows but failed on Linux)

### DIFF
--- a/api/src/org/pentaho/hadoop/shim/HadoopConfigurationLocator.java
+++ b/api/src/org/pentaho/hadoop/shim/HadoopConfigurationLocator.java
@@ -210,14 +210,19 @@ public class HadoopConfigurationLocator implements HadoopConfigurationProvider {
       excludedJars = excludedJarsProperty.split( "," );
       if ( excludedJars != null ) {
         for ( String excludedJar : excludedJars ) {
-          pattern = Pattern.compile( ".*/" + excludedJar.toLowerCase() + "-\\d[\\.\\w]*\\.jar$" );
+          pattern = Pattern.compile( ".*/" + excludedJar.toLowerCase() + "-.*\\.jar$" );
+          matcher = pattern.matcher( "" );
           Iterator<URL> iterator = urls.listIterator();
           while ( iterator.hasNext() ) {
             URL url = iterator.next();
             if ( url.toString().toLowerCase().contains( excludedJar.toLowerCase() ) ) {
-              matcher = pattern.matcher( url.toString().toLowerCase() );
-              if ( matcher.matches() ) {
+              if ( excludedJar.endsWith( ".jar" ) || url.toString().toLowerCase()
+                .contains( excludedJar.toLowerCase() + ".jar" ) ) {
                 iterator.remove();
+              } else {
+                if ( matcher.reset( url.toString().toLowerCase() ).matches() ) {
+                  iterator.remove();
+                }
               }
             }
           }

--- a/api/test-src/org/pentaho/hadoop/shim/HadoopConfigurationLocatorTest.java
+++ b/api/test-src/org/pentaho/hadoop/shim/HadoopConfigurationLocatorTest.java
@@ -1,18 +1,23 @@
 /*******************************************************************************
+ *
  * Pentaho Big Data
- * <p>
+ *
  * Copyright (C) 2002-2016 by Pentaho : http://www.pentaho.com
- * <p>
- * ******************************************************************************
- * <p>
- * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ *
+ *******************************************************************************
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
- * <p>
- * http://www.apache.org/licenses/LICENSE-2.0
- * <p>
- * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
- * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
- * specific language governing permissions and limitations under the License.
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
  ******************************************************************************/
 
 package org.pentaho.hadoop.shim;
@@ -67,28 +72,12 @@ public class HadoopConfigurationLocatorTest {
     p.setProperty( "classpath", "" );
     p.setProperty( "library.path", "" );
     p.setProperty( "required.classes", HadoopConfigurationLocatorTest.class.getName() );
-    p.setProperty( "exclude.jars", "" );
     p.store( configFile.getContent().getOutputStream(), "Test Configuration A" );
     configFile.close();
 
     // Create the implementation jar
     FileObject implJar = aConfigFolder.resolveFile( "a-config.jar" );
     implJar.createFile();
-
-    FileObject implXercesJar = aConfigFolder.resolveFile( "xercesImpl-2.9.1.jar" );
-    implXercesJar.createFile();
-
-    FileObject implXmlApisJar = aConfigFolder.resolveFile( "xml-apis-1.3.04.jar" );
-    implXmlApisJar.createFile();
-
-    FileObject implXmlApisExtJar = aConfigFolder.resolveFile( "xml-apis-ext-1.3.04.jar" );
-    implXmlApisExtJar.createFile();
-
-    FileObject implXercesFakeVersionJar = aConfigFolder.resolveFile( "xerces-version-1.8.0.jar" );
-    implXercesFakeVersionJar.createFile();
-
-    FileObject implXercesImpl2Jar = aConfigFolder.resolveFile( "xercesImpl2-2.9.1.jar" );
-    implXercesImpl2Jar.createFile();
 
     // Use ShrinkWrap to create the jar and write it out to VFS
     JavaArchive archive = ShrinkWrap.create( JavaArchive.class, "a-configuration.jar" ).addAsServiceProvider(
@@ -322,66 +311,8 @@ public class HadoopConfigurationLocatorTest {
     FileObject root = VFS.getManager().resolveFile( HADOOP_CONFIGURATIONS_PATH );
 
     List<URL> urls = locator.parseURLs( root, "a,b" );
-    assertEquals( 7, urls.size() );
+    assertEquals( 2, urls.size() );
     assertEquals( root.getURL().toURI().resolve( "hadoop-configurations/a/" ), urls.get( 0 ).toURI() );
     assertEquals( root.getURL().toURI().resolve( "hadoop-configurations/a/a-config.jar" ), urls.get( 1 ).toURI() );
-  }
-
-  @Test
-  public void filterJars_null_args() throws Exception {
-    HadoopConfigurationLocator locator = new HadoopConfigurationLocator();
-    FileObject root = VFS.getManager().resolveFile( HADOOP_CONFIGURATIONS_PATH );
-
-    List<URL> list = locator.filterJars( null, null );
-
-    assertNull( list );
-  }
-
-  @Test
-  public void filterJars_null_arg_excludedJarsProperty() throws Exception {
-    HadoopConfigurationLocator locator = new HadoopConfigurationLocator();
-    FileObject root = VFS.getManager().resolveFile( HADOOP_CONFIGURATIONS_PATH );
-
-    List<URL> urls = locator.parseURLs( root, "a,b" );
-    List<URL> list = locator.filterJars( urls, null );
-
-    assertEquals( 7, list.size() );
-  }
-
-  @Test
-  public void filterJars_arg_excludedJarsProperty_emptyString() throws Exception {
-    HadoopConfigurationLocator locator = new HadoopConfigurationLocator();
-    FileObject root = VFS.getManager().resolveFile( HADOOP_CONFIGURATIONS_PATH );
-
-    List<URL> urls = locator.parseURLs( root, "a,b" );
-    List<URL> list = locator.filterJars( urls, "" );
-
-    assertEquals( 7, list.size() );
-  }
-
-  @Test
-  public void filterJars_arg_urls_containsOnlyExcludedJars() throws Exception {
-    HadoopConfigurationLocator locator = new HadoopConfigurationLocator();
-    FileObject root = VFS.getManager().resolveFile( HADOOP_CONFIGURATIONS_PATH );
-
-    List<URL> urls = locator.parseURLs( root, "a,b" );
-    urls.remove( 0 );
-    urls.remove( 0 );
-
-    List<URL> list = locator.filterJars( urls, "xercesImpl,xml-apis,xml-apis-ext,xerces-version,xercesImpl2" );
-
-    assertEquals( 0, list.size() );
-    assertNotNull( list );
-  }
-
-  @Test
-  public void filterJars_removeOnlyXercesImpl() throws Exception {
-    HadoopConfigurationLocator locator = new HadoopConfigurationLocator();
-    FileObject root = VFS.getManager().resolveFile( HADOOP_CONFIGURATIONS_PATH );
-
-    List<URL> urls = locator.parseURLs( root, "a,b" );
-    List<URL> list = locator.filterJars( urls, "xercesImpl" );
-
-    assertEquals( 6, list.size() );
   }
 }

--- a/api/test-src/org/pentaho/hadoop/shim/HadoopExcludeJarsTest.java
+++ b/api/test-src/org/pentaho/hadoop/shim/HadoopExcludeJarsTest.java
@@ -1,0 +1,167 @@
+/*******************************************************************************
+ * Pentaho Big Data
+ * <p>
+ * Copyright (C) 2002-2016 by Pentaho : http://www.pentaho.com
+ * <p>
+ * ******************************************************************************
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ ******************************************************************************/
+
+package org.pentaho.hadoop.shim;
+
+import org.apache.commons.vfs2.AllFileSelector;
+import org.apache.commons.vfs2.FileObject;
+import org.apache.commons.vfs2.FileType;
+import org.apache.commons.vfs2.VFS;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import java.net.URL;
+import java.util.Iterator;
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+
+public class HadoopExcludeJarsTest {
+
+  private static String HADOOP_CONFIGURATIONS_PATH = System.getProperty( "java.io.tmpdir" ) + "/exclude-jars";
+  private int count;
+
+
+  @BeforeClass
+  public static void setup() throws Exception {
+    // Create a test hadoop configuration
+    FileObject ramRoot = VFS.getManager().resolveFile( HADOOP_CONFIGURATIONS_PATH );
+    if ( ramRoot.exists() ) {
+      ramRoot.delete( new AllFileSelector() );
+    }
+    ramRoot.createFolder();
+
+    // Create the implementation jars
+    ramRoot.resolveFile( "xercesImpl-2.9.1.jar" ).createFile();
+    ramRoot.resolveFile( "xml-apis-1.3.04.jar" ).createFile();
+    ramRoot.resolveFile( "xml-apis-ext-1.3.04.jar" ).createFile();
+    ramRoot.resolveFile( "xerces-version-1.8.0.jar" ).createFile();
+    ramRoot.resolveFile( "xercesImpl2-2.9.1.jar" ).createFile();
+    ramRoot.resolveFile( "pentaho-hadoop-shims-api-61.2016.04.01-196.jar" ).createFile();
+    ramRoot.resolveFile( "commands-3.3.0-I20070605-0010.jar" ).createFile();
+    ramRoot.resolveFile( "postgresql-9.3-1102-jdbc4.jar" ).createFile();
+    ramRoot.resolveFile( "trilead-ssh2-build213.jar" ).createFile();
+    ramRoot.resolveFile( "trilead-ssh2-build215.jar" ).createFile();
+  }
+
+  @Test
+  public void filterJars_null_args() throws Exception {
+    HadoopConfigurationLocator locator = new HadoopConfigurationLocator();
+
+    List<URL> list = locator.filterJars( null, null );
+    assertNull( list );
+  }
+
+  @Test
+  public void filterJars_null_arg_excludedJarsProperty() throws Exception {
+    HadoopConfigurationLocator locator = new HadoopConfigurationLocator();
+    FileObject root = VFS.getManager().resolveFile( HADOOP_CONFIGURATIONS_PATH );
+
+    List<URL> urls = locator.parseURLs( root, root.toString() );
+    count = urls.size();
+    List<URL> list = locator.filterJars( urls, null );
+    assertEquals( count, list.size() );
+  }
+
+  @Test
+  public void filterJars_arg_excludedJarsProperty_emptyString() throws Exception {
+    HadoopConfigurationLocator locator = new HadoopConfigurationLocator();
+    FileObject root = VFS.getManager().resolveFile( HADOOP_CONFIGURATIONS_PATH );
+
+    List<URL> urls = locator.parseURLs( root, root.toString() );
+    count = urls.size();
+    List<URL> list = locator.filterJars( urls, "" );
+    assertEquals( count, list.size() );
+  }
+
+  @Test
+  public void filterJars_arg_urls_containsOnlyExcludedJars() throws Exception {
+    HadoopConfigurationLocator locator = new HadoopConfigurationLocator();
+    FileObject root = VFS.getManager().resolveFile( HADOOP_CONFIGURATIONS_PATH );
+
+    List<URL> urls = locator.parseURLs( root, root.toString() );
+    Iterator<URL> iterator = urls.listIterator();
+    while ( iterator.hasNext() ) {
+      URL url = iterator.next();
+      if ( FileType.FOLDER.equals( root.resolveFile( url.toString().trim() ).getType() ) ) {
+        iterator.remove();
+      }
+    }
+    List<URL> list = locator.filterJars( urls,
+      "xercesImpl,xml-apis-1.3.04.jar,xml-apis-ext-1.3.04,xerces-version-1.8.0,xercesImpl2-2.9.1,"
+        + "pentaho-hadoop-shims-api-61.2016.04.01-196,commands-3.3.0-I20070605-0010,postgresql,trilead-ssh2-build213"
+        + ".jar,trilead-ssh2-build215.jar" );
+    assertEquals( 0, list.size() );
+  }
+
+  @Test
+  public void filterJars_removeOnlyXercesImpl() throws Exception {
+    HadoopConfigurationLocator locator = new HadoopConfigurationLocator();
+    FileObject root = VFS.getManager().resolveFile( HADOOP_CONFIGURATIONS_PATH );
+
+    List<URL> urls = locator.parseURLs( root, root.toString() );
+    count = urls.size();
+    List<URL> list = locator.filterJars( urls, "xercesImpl" );
+    assertEquals( count - 1, list.size() );
+  }
+
+  @Test
+  public void filterJars_removeOnlyByArtifactIdTemplate() throws Exception {
+    HadoopConfigurationLocator locator = new HadoopConfigurationLocator();
+    FileObject root = VFS.getManager().resolveFile( HADOOP_CONFIGURATIONS_PATH );
+
+    List<URL> urls = locator.parseURLs( root, root.toString() );
+    count = urls.size();
+    List<URL> list = locator.filterJars( urls, "pentaho-hadoop-shims-api" );
+    assertEquals( count - 1, list.size() );
+  }
+
+  @Test
+  public void filterJars_removeOnlyByArtifactIdVersionTemplate() throws Exception {
+    HadoopConfigurationLocator locator = new HadoopConfigurationLocator();
+    FileObject root = VFS.getManager().resolveFile( HADOOP_CONFIGURATIONS_PATH );
+
+    List<URL> urls = locator.parseURLs( root, root.toString() );
+    count = urls.size();
+    List<URL> list = locator.filterJars( urls, "pentaho-hadoop-shims-api-61.2016.04.01-196" );
+    assertEquals( count - 1, list.size() );
+  }
+
+  @Test
+  public void filterJars_removeOnlyByWholeJarName() throws Exception {
+    HadoopConfigurationLocator locator = new HadoopConfigurationLocator();
+    FileObject root = VFS.getManager().resolveFile( HADOOP_CONFIGURATIONS_PATH );
+
+    List<URL> urls = locator.parseURLs( root, root.toString() );
+    count = urls.size();
+    List<URL> list = locator.filterJars( urls, "pentaho-hadoop-shims-api-61.2016.04.01-196.jar" );
+    assertEquals( count - 1, list.size() );
+  }
+
+  @Test
+  public void filterJars_removeThreeJarsWithDifferentTemplates() throws Exception {
+    HadoopConfigurationLocator locator = new HadoopConfigurationLocator();
+    FileObject root = VFS.getManager().resolveFile( HADOOP_CONFIGURATIONS_PATH );
+
+    List<URL> urls = locator.parseURLs( root, root.toString() );
+    count = urls.size();
+    List<URL> list =
+      locator.filterJars( urls, "xercesImpl,trilead-ssh2-build215,pentaho-hadoop-shims-api-61.2016.04.01-196.jar" );
+    assertEquals( count - 3, list.size() );
+  }
+}


### PR DESCRIPTION
Repaired two of my tests because they failed on Linux: 
http://devci.pentaho.com/job/master-snapshot/job/big-data-hadoop-shims/679/ .
Created new class HadoopExcludeJarsTest, added more tests to check changed regular expression.