### PR TITLE
[BACKLOG-8539] - Create the MapR 5.1 Shim (against Pentaho 6.1)  - add oss-license.filename property

### DIFF
--- a/mapr510/build.properties
+++ b/mapr510/build.properties
@@ -5,6 +5,7 @@ ivy.artifact.group=pentaho
 project.revision=6.1-SNAPSHOT
 package.id=pentaho-hadoop-shims-mapr510-package
 package.root.dir=mapr510
+oss-license.filename=PentahoHadoopShim_mapr510_OSS_Licenses.html
 
 dependency.kettle.revision=6.1-SNAPSHOT
 dependency.pentaho-hdfs-vfs.revision=6.1-SNAPSHOT


### PR DESCRIPTION
Added oss-license.filename=PentahoHadoopShim_mapr510_OSS_Licenses.html in the build.property file.