### PR TITLE
[BACKLOG-8540] - Create the MapR 5.1 Shim (against Pentaho 7.0) - add oss-license.filename property

### DIFF
--- a/mapr510/build.properties
+++ b/mapr510/build.properties
@@ -5,6 +5,7 @@ ivy.artifact.group=pentaho
 project.revision=7.0-SNAPSHOT
 package.id=pentaho-hadoop-shims-mapr510-package
 package.root.dir=mapr510
+oss-license.filename=PentahoHadoopShim_mapr510_OSS_Licenses.html
 
 dependency.kettle.revision=7.0-SNAPSHOT
 dependency.pentaho-hdfs-vfs.revision=7.0-SNAPSHOT
@@ -35,5 +36,5 @@ dependency.apache-oozie.revision=4.2.0-mapr-1602
 dependency.maprfs.revision=5.1.0-mapr
 dependency.automaton.revision=1.11-8
 
-izpack.version=5.0.6
-pentaho-eula-wrap-config.version=1.0.8
+izpack.version=5.0.7-RC1
+pentaho-eula-wrap-config.version=1.0.10


### PR DESCRIPTION
Added oss-license.filename=PentahoHadoopShim_mapr510_OSS_Licenses.html in the build.property file.