### PR TITLE
[BACKLOG-10018] - throw exception when zookeeper host in named cluster differs from the one in configs, in that case credentials for another host won't work and will retry always to reconnect in hadoop

### DIFF
--- a/common/src/org/pentaho/hbase/shim/common/messages/messages_en_US.properties
+++ b/common/src/org/pentaho/hbase/shim/common/messages/messages_en_US.properties
@@ -1,5 +1,6 @@
 CommonHBaseConnection.Error.MalformedConfigURL=Malformed configuration URL for HBase site/default
 CommonHBaseConnection.Error.UnableToParseZookeeperPort=Unable to parse zookeeper port - using default
+CommonHBaseConnection.Error.MismatchZookeeperNamedClusterVsConfiguration=Configuration zookeeper url doesn''t match named cluster one. Please verify shim configuration files. Client zookeeper quorum is {0} while in configuration {1}. Incorrect zookeeper host will come to hanging connection.
 CommonHBaseConnection.Error.ConnectionHasNotBeenConfigured=Connection has not been configured yet
 CommonHBaseConnection.Error.NoSourceTable=No source table has been specified
 CommonHBaseConnection.Error.NoSourceScan=No source scan has been defined


### PR DESCRIPTION
Make test of zookeeper host in named cluster and in config, if different makes hadoop hang on zookeeper connection and attempts by default 36 times reconnect, after fail delete KerberosTicket, for now check of mismatch zookeeper connection added to hadoop shims, the check is made if all host in named cluster zookeeper quorum string are contained in config, or at least one host from config is contained in named cluster zookeeper quorum - last check added for case when short alias are used in config
actually for now warning is shown to user as for possible option to use alias not connected with host name or ips, this logic can be skipped
the main fix for issue is in reinitializing Kerberos ticket in pull request for pentaho-big-data-ee
https://github.com/pentaho/pentaho-big-data-ee/pull/137
