### PR TITLE
[BACKLOG-15060]-Hbase-comparators jar is not included in QAT builds after shim mavenization

### DIFF
--- a/shims/cdh510/assemblies/cdh510-shim/pom.xml
+++ b/shims/cdh510/assemblies/cdh510-shim/pom.xml
@@ -14,6 +14,11 @@
       <artifactId>pentaho-hadoop-shims-cdh510</artifactId>
       <version>${project.version}</version>
     </dependency>
+    <dependency>
+      <groupId>org.pentaho</groupId>
+      <artifactId>pentaho-hadoop-shims-hbase-comparators</artifactId>
+      <version>${project.version}</version>
+    </dependency>
   </dependencies>
   <build>
     <plugins>

--- a/shims/cdh510/assemblies/cdh510-shim/src/assembly/assembly.xml
+++ b/shims/cdh510/assemblies/cdh510-shim/src/assembly/assembly.xml
@@ -24,6 +24,14 @@
       </includes>
     </dependencySet>
     <dependencySet>
+      <outputDirectory>external-libs</outputDirectory>
+      <useTransitiveDependencies>false</useTransitiveDependencies>
+      <useTransitiveFiltering>false</useTransitiveFiltering>
+      <includes>
+        <include>org.pentaho:pentaho-hadoop-shims-hbase-comparators</include>
+      </includes>
+    </dependencySet>
+    <dependencySet>
       <outputDirectory>lib</outputDirectory>
       <useTransitiveDependencies>true</useTransitiveDependencies>
       <useTransitiveFiltering>false</useTransitiveFiltering>

--- a/shims/cdh58/assemblies/cdh58-shim/pom.xml
+++ b/shims/cdh58/assemblies/cdh58-shim/pom.xml
@@ -14,6 +14,11 @@
       <artifactId>pentaho-hadoop-shims-cdh58</artifactId>
       <version>${project.version}</version>
     </dependency>
+    <dependency>
+      <groupId>org.pentaho</groupId>
+      <artifactId>pentaho-hadoop-shims-hbase-comparators</artifactId>
+      <version>${project.version}</version>
+    </dependency>
   </dependencies>
   <build>
     <plugins>

--- a/shims/cdh58/assemblies/cdh58-shim/src/assembly/assembly.xml
+++ b/shims/cdh58/assemblies/cdh58-shim/src/assembly/assembly.xml
@@ -24,6 +24,14 @@
       </includes>
     </dependencySet>
     <dependencySet>
+      <outputDirectory>external-libs</outputDirectory>
+      <useTransitiveDependencies>false</useTransitiveDependencies>
+      <useTransitiveFiltering>false</useTransitiveFiltering>
+      <includes>
+        <include>org.pentaho:pentaho-hadoop-shims-hbase-comparators</include>
+      </includes>
+    </dependencySet>
+    <dependencySet>
       <outputDirectory>lib</outputDirectory>
       <useTransitiveDependencies>true</useTransitiveDependencies>
       <useTransitiveFiltering>false</useTransitiveFiltering>

--- a/shims/cdh59/assemblies/cdh59-shim/pom.xml
+++ b/shims/cdh59/assemblies/cdh59-shim/pom.xml
@@ -14,6 +14,11 @@
       <artifactId>pentaho-hadoop-shims-cdh59</artifactId>
       <version>${project.version}</version>
     </dependency>
+    <dependency>
+      <groupId>org.pentaho</groupId>
+      <artifactId>pentaho-hadoop-shims-hbase-comparators</artifactId>
+      <version>${project.version}</version>
+    </dependency>
   </dependencies>
   <build>
     <plugins>

--- a/shims/cdh59/assemblies/cdh59-shim/src/assembly/assembly.xml
+++ b/shims/cdh59/assemblies/cdh59-shim/src/assembly/assembly.xml
@@ -24,6 +24,14 @@
       </includes>
     </dependencySet>
     <dependencySet>
+      <outputDirectory>external-libs</outputDirectory>
+      <useTransitiveDependencies>false</useTransitiveDependencies>
+      <useTransitiveFiltering>false</useTransitiveFiltering>
+      <includes>
+        <include>org.pentaho:pentaho-hadoop-shims-hbase-comparators</include>
+      </includes>
+    </dependencySet>
+    <dependencySet>
       <outputDirectory>lib</outputDirectory>
       <useTransitiveDependencies>true</useTransitiveDependencies>
       <useTransitiveFiltering>false</useTransitiveFiltering>

--- a/shims/emr46/assemblies/emr46-shim/pom.xml
+++ b/shims/emr46/assemblies/emr46-shim/pom.xml
@@ -14,6 +14,11 @@
       <artifactId>pentaho-hadoop-shims-emr46</artifactId>
       <version>${project.version}</version>
     </dependency>
+    <dependency>
+      <groupId>org.pentaho</groupId>
+      <artifactId>pentaho-hadoop-shims-hbase-comparators</artifactId>
+      <version>${project.version}</version>
+    </dependency>
   </dependencies>
   <build>
     <plugins>

--- a/shims/emr46/assemblies/emr46-shim/src/assembly/assembly.xml
+++ b/shims/emr46/assemblies/emr46-shim/src/assembly/assembly.xml
@@ -24,6 +24,14 @@
       </includes>
     </dependencySet>
     <dependencySet>
+      <outputDirectory>external-libs</outputDirectory>
+      <useTransitiveDependencies>false</useTransitiveDependencies>
+      <useTransitiveFiltering>false</useTransitiveFiltering>
+      <includes>
+        <include>org.pentaho:pentaho-hadoop-shims-hbase-comparators</include>
+      </includes>
+    </dependencySet>
+    <dependencySet>
       <outputDirectory>lib</outputDirectory>
       <useTransitiveDependencies>true</useTransitiveDependencies>
       <useTransitiveFiltering>false</useTransitiveFiltering>

--- a/shims/emr52/assemblies/emr52-shim/pom.xml
+++ b/shims/emr52/assemblies/emr52-shim/pom.xml
@@ -14,6 +14,11 @@
       <artifactId>pentaho-hadoop-shims-emr52</artifactId>
       <version>${project.version}</version>
     </dependency>
+    <dependency>
+      <groupId>org.pentaho</groupId>
+      <artifactId>pentaho-hadoop-shims-hbase-comparators</artifactId>
+      <version>${project.version}</version>
+    </dependency>
   </dependencies>
   <build>
     <plugins>

--- a/shims/emr52/assemblies/emr52-shim/src/assembly/assembly.xml
+++ b/shims/emr52/assemblies/emr52-shim/src/assembly/assembly.xml
@@ -24,6 +24,14 @@
       </includes>
     </dependencySet>
     <dependencySet>
+      <outputDirectory>external-libs</outputDirectory>
+      <useTransitiveDependencies>false</useTransitiveDependencies>
+      <useTransitiveFiltering>false</useTransitiveFiltering>
+      <includes>
+        <include>org.pentaho:pentaho-hadoop-shims-hbase-comparators</include>
+      </includes>
+    </dependencySet>
+    <dependencySet>
       <outputDirectory>lib</outputDirectory>
       <useTransitiveDependencies>true</useTransitiveDependencies>
       <useTransitiveFiltering>false</useTransitiveFiltering>

--- a/shims/hdi35/assemblies/hdi35-shim/pom.xml
+++ b/shims/hdi35/assemblies/hdi35-shim/pom.xml
@@ -14,6 +14,11 @@
       <artifactId>pentaho-hadoop-shims-hdi35</artifactId>
       <version>${project.version}</version>
     </dependency>
+    <dependency>
+      <groupId>org.pentaho</groupId>
+      <artifactId>pentaho-hadoop-shims-hbase-comparators</artifactId>
+      <version>${project.version}</version>
+    </dependency>
   </dependencies>
   <build>
     <plugins>

--- a/shims/hdi35/assemblies/hdi35-shim/src/assembly/assembly.xml
+++ b/shims/hdi35/assemblies/hdi35-shim/src/assembly/assembly.xml
@@ -24,6 +24,14 @@
       </includes>
     </dependencySet>
     <dependencySet>
+      <outputDirectory>external-libs</outputDirectory>
+      <useTransitiveDependencies>false</useTransitiveDependencies>
+      <useTransitiveFiltering>false</useTransitiveFiltering>
+      <includes>
+        <include>org.pentaho:pentaho-hadoop-shims-hbase-comparators</include>
+      </includes>
+    </dependencySet>
+    <dependencySet>
       <outputDirectory>lib</outputDirectory>
       <useTransitiveDependencies>true</useTransitiveDependencies>
       <useTransitiveFiltering>false</useTransitiveFiltering>

--- a/shims/hdp24/assemblies/hdp24-shim/pom.xml
+++ b/shims/hdp24/assemblies/hdp24-shim/pom.xml
@@ -14,6 +14,11 @@
       <artifactId>pentaho-hadoop-shims-hdp24</artifactId>
       <version>${project.version}</version>
     </dependency>
+    <dependency>
+      <groupId>org.pentaho</groupId>
+      <artifactId>pentaho-hadoop-shims-hbase-comparators</artifactId>
+      <version>${project.version}</version>
+    </dependency>
   </dependencies>
   <build>
     <plugins>

--- a/shims/hdp24/assemblies/hdp24-shim/src/assembly/assembly.xml
+++ b/shims/hdp24/assemblies/hdp24-shim/src/assembly/assembly.xml
@@ -24,6 +24,14 @@
       </includes>
     </dependencySet>
     <dependencySet>
+      <outputDirectory>external-libs</outputDirectory>
+      <useTransitiveDependencies>false</useTransitiveDependencies>
+      <useTransitiveFiltering>false</useTransitiveFiltering>
+      <includes>
+        <include>org.pentaho:pentaho-hadoop-shims-hbase-comparators</include>
+      </includes>
+    </dependencySet>
+    <dependencySet>
       <outputDirectory>lib</outputDirectory>
       <useTransitiveDependencies>true</useTransitiveDependencies>
       <useTransitiveFiltering>false</useTransitiveFiltering>

--- a/shims/hdp25/assemblies/hdp25-shim/pom.xml
+++ b/shims/hdp25/assemblies/hdp25-shim/pom.xml
@@ -14,6 +14,11 @@
       <artifactId>pentaho-hadoop-shims-hdp25</artifactId>
       <version>${project.version}</version>
     </dependency>
+    <dependency>
+      <groupId>org.pentaho</groupId>
+      <artifactId>pentaho-hadoop-shims-hbase-comparators</artifactId>
+      <version>${project.version}</version>
+    </dependency>
   </dependencies>
   <build>
     <plugins>

--- a/shims/hdp25/assemblies/hdp25-shim/src/assembly/assembly.xml
+++ b/shims/hdp25/assemblies/hdp25-shim/src/assembly/assembly.xml
@@ -24,6 +24,14 @@
       </includes>
     </dependencySet>
     <dependencySet>
+      <outputDirectory>external-libs</outputDirectory>
+      <useTransitiveDependencies>false</useTransitiveDependencies>
+      <useTransitiveFiltering>false</useTransitiveFiltering>
+      <includes>
+        <include>org.pentaho:pentaho-hadoop-shims-hbase-comparators</include>
+      </includes>
+    </dependencySet>
+    <dependencySet>
       <outputDirectory>lib</outputDirectory>
       <useTransitiveDependencies>true</useTransitiveDependencies>
       <useTransitiveFiltering>false</useTransitiveFiltering>

--- a/shims/mapr510/assemblies/mapr510-shim/pom.xml
+++ b/shims/mapr510/assemblies/mapr510-shim/pom.xml
@@ -14,6 +14,11 @@
       <artifactId>pentaho-hadoop-shims-mapr510</artifactId>
       <version>${project.version}</version>
     </dependency>
+    <dependency>
+      <groupId>org.pentaho</groupId>
+      <artifactId>pentaho-hadoop-shims-hbase-comparators</artifactId>
+      <version>${project.version}</version>
+    </dependency>
   </dependencies>
   <build>
     <plugins>

--- a/shims/mapr510/assemblies/mapr510-shim/src/assembly/assembly.xml
+++ b/shims/mapr510/assemblies/mapr510-shim/src/assembly/assembly.xml
@@ -24,6 +24,14 @@
       </includes>
     </dependencySet>
     <dependencySet>
+      <outputDirectory>external-libs</outputDirectory>
+      <useTransitiveDependencies>false</useTransitiveDependencies>
+      <useTransitiveFiltering>false</useTransitiveFiltering>
+      <includes>
+        <include>org.pentaho:pentaho-hadoop-shims-hbase-comparators</include>
+      </includes>
+    </dependencySet>
+    <dependencySet>
       <outputDirectory>lib</outputDirectory>
       <useTransitiveDependencies>true</useTransitiveDependencies>
       <useTransitiveFiltering>false</useTransitiveFiltering>

--- a/shims/mapr520/assemblies/mapr520-shim/pom.xml
+++ b/shims/mapr520/assemblies/mapr520-shim/pom.xml
@@ -14,6 +14,11 @@
       <artifactId>pentaho-hadoop-shims-mapr520</artifactId>
       <version>${project.version}</version>
     </dependency>
+    <dependency>
+      <groupId>org.pentaho</groupId>
+      <artifactId>pentaho-hadoop-shims-hbase-comparators</artifactId>
+      <version>${project.version}</version>
+    </dependency>
   </dependencies>
   <build>
     <plugins>

--- a/shims/mapr520/assemblies/mapr520-shim/src/assembly/assembly.xml
+++ b/shims/mapr520/assemblies/mapr520-shim/src/assembly/assembly.xml
@@ -24,6 +24,14 @@
       </includes>
     </dependencySet>
     <dependencySet>
+      <outputDirectory>external-libs</outputDirectory>
+      <useTransitiveDependencies>false</useTransitiveDependencies>
+      <useTransitiveFiltering>false</useTransitiveFiltering>
+      <includes>
+        <include>org.pentaho:pentaho-hadoop-shims-hbase-comparators</include>
+      </includes>
+    </dependencySet>
+    <dependencySet>
       <outputDirectory>lib</outputDirectory>
       <useTransitiveDependencies>true</useTransitiveDependencies>
       <useTransitiveFiltering>false</useTransitiveFiltering>


### PR DESCRIPTION
hbase-comparators to external-lib folder in every shim
not to have dublication of classes and have comparators classes in separate jar