### PR TITLE
[ENGOPS-2974]-OSS license file is not put in pentaho-hadoop-shims assembly zip archive

### DIFF
--- a/shims/cdh510/assemblies/cdh510-shim/pom.xml
+++ b/shims/cdh510/assemblies/cdh510-shim/pom.xml
@@ -56,8 +56,8 @@
                   <artifactId>oss-licenses</artifactId>
                   <type>zip</type>
                   <overWrite>false</overWrite>
-                  <outputDirectory>${oss.license.directory}</outputDirectory>
-                  <includes>*${shim.name}*</includes>
+                  <outputDirectory>${oss.license.unpack.directory}</outputDirectory>
+                  <includes>**/*${shim.name}*</includes>
                 </artifactItem>
               </artifactItems>
             </configuration>

--- a/shims/cdh510/assemblies/cdh510-shim/src/assembly/assembly.xml
+++ b/shims/cdh510/assemblies/cdh510-shim/src/assembly/assembly.xml
@@ -10,7 +10,7 @@
       <outputDirectory>/</outputDirectory>
     </fileSet>
     <fileSet>
-      <directory>${oss.license.directory}</directory>
+      <directory>${oss.license.subdirectory}</directory>
       <outputDirectory>/</outputDirectory>
     </fileSet>
   </fileSets>

--- a/shims/cdh59/assemblies/cdh59-shim/pom.xml
+++ b/shims/cdh59/assemblies/cdh59-shim/pom.xml
@@ -56,8 +56,8 @@
                   <artifactId>oss-licenses</artifactId>
                   <type>zip</type>
                   <overWrite>false</overWrite>
-                  <outputDirectory>${oss.license.directory}</outputDirectory>
-                  <includes>*${shim.name}*</includes>
+                  <outputDirectory>${oss.license.unpack.directory}</outputDirectory>
+                  <includes>**/*${shim.name}*</includes>
                 </artifactItem>
               </artifactItems>
             </configuration>

--- a/shims/cdh59/assemblies/cdh59-shim/src/assembly/assembly.xml
+++ b/shims/cdh59/assemblies/cdh59-shim/src/assembly/assembly.xml
@@ -10,7 +10,7 @@
       <outputDirectory>/</outputDirectory>
     </fileSet>
     <fileSet>
-      <directory>${oss.license.directory}</directory>
+      <directory>${oss.license.subdirectory}</directory>
       <outputDirectory>/</outputDirectory>
     </fileSet>
   </fileSets>

--- a/shims/emr46/assemblies/emr46-shim/pom.xml
+++ b/shims/emr46/assemblies/emr46-shim/pom.xml
@@ -56,8 +56,8 @@
                   <artifactId>oss-licenses</artifactId>
                   <type>zip</type>
                   <overWrite>false</overWrite>
-                  <outputDirectory>${oss.license.directory}</outputDirectory>
-                  <includes>*${shim.name}*</includes>
+                  <outputDirectory>${oss.license.unpack.directory}</outputDirectory>
+                  <includes>**/*${shim.name}*</includes>
                 </artifactItem>
               </artifactItems>
             </configuration>

--- a/shims/emr46/assemblies/emr46-shim/src/assembly/assembly.xml
+++ b/shims/emr46/assemblies/emr46-shim/src/assembly/assembly.xml
@@ -10,7 +10,7 @@
       <outputDirectory>/</outputDirectory>
     </fileSet>
     <fileSet>
-      <directory>${oss.license.directory}</directory>
+      <directory>${oss.license.subdirectory}</directory>
       <outputDirectory>/</outputDirectory>
     </fileSet>
   </fileSets>

--- a/shims/emr52/assemblies/emr52-shim/pom.xml
+++ b/shims/emr52/assemblies/emr52-shim/pom.xml
@@ -56,8 +56,8 @@
                   <artifactId>oss-licenses</artifactId>
                   <type>zip</type>
                   <overWrite>false</overWrite>
-                  <outputDirectory>${oss.license.directory}</outputDirectory>
-                  <includes>*${shim.name}*</includes>
+                  <outputDirectory>${oss.license.unpack.directory}</outputDirectory>
+                  <includes>**/*${shim.name}*</includes>
                 </artifactItem>
               </artifactItems>
             </configuration>

--- a/shims/emr52/assemblies/emr52-shim/src/assembly/assembly.xml
+++ b/shims/emr52/assemblies/emr52-shim/src/assembly/assembly.xml
@@ -10,7 +10,7 @@
       <outputDirectory>/</outputDirectory>
     </fileSet>
     <fileSet>
-      <directory>${oss.license.directory}</directory>
+      <directory>${oss.license.subdirectory}</directory>
       <outputDirectory>/</outputDirectory>
     </fileSet>
   </fileSets>

--- a/shims/hdi35/assemblies/hdi35-shim/pom.xml
+++ b/shims/hdi35/assemblies/hdi35-shim/pom.xml
@@ -56,8 +56,8 @@
                   <artifactId>oss-licenses</artifactId>
                   <type>zip</type>
                   <overWrite>false</overWrite>
-                  <outputDirectory>${oss.license.directory}</outputDirectory>
-                  <includes>*${shim.name}*</includes>
+                  <outputDirectory>${oss.license.unpack.directory}</outputDirectory>
+                  <includes>**/*${shim.name}*</includes>
                 </artifactItem>
               </artifactItems>
             </configuration>

--- a/shims/hdi35/assemblies/hdi35-shim/src/assembly/assembly.xml
+++ b/shims/hdi35/assemblies/hdi35-shim/src/assembly/assembly.xml
@@ -10,7 +10,7 @@
       <outputDirectory>/</outputDirectory>
     </fileSet>
     <fileSet>
-      <directory>${oss.license.directory}</directory>
+      <directory>${oss.license.subdirectory}</directory>
       <outputDirectory>/</outputDirectory>
     </fileSet>
   </fileSets>

--- a/shims/hdp24/assemblies/hdp24-shim/pom.xml
+++ b/shims/hdp24/assemblies/hdp24-shim/pom.xml
@@ -56,8 +56,8 @@
                   <artifactId>oss-licenses</artifactId>
                   <type>zip</type>
                   <overWrite>false</overWrite>
-                  <outputDirectory>${oss.license.directory}</outputDirectory>
-                  <includes>*${shim.name}*</includes>
+                  <outputDirectory>${oss.license.unpack.directory}</outputDirectory>
+                  <includes>**/*${shim.name}*</includes>
                 </artifactItem>
               </artifactItems>
             </configuration>

--- a/shims/hdp24/assemblies/hdp24-shim/src/assembly/assembly.xml
+++ b/shims/hdp24/assemblies/hdp24-shim/src/assembly/assembly.xml
@@ -10,7 +10,7 @@
       <outputDirectory>/</outputDirectory>
     </fileSet>
     <fileSet>
-      <directory>${oss.license.directory}</directory>
+      <directory>${oss.license.subdirectory}</directory>
       <outputDirectory>/</outputDirectory>
     </fileSet>
   </fileSets>

--- a/shims/hdp25/assemblies/hdp25-shim/pom.xml
+++ b/shims/hdp25/assemblies/hdp25-shim/pom.xml
@@ -56,8 +56,8 @@
                   <artifactId>oss-licenses</artifactId>
                   <type>zip</type>
                   <overWrite>false</overWrite>
-                  <outputDirectory>${oss.license.directory}</outputDirectory>
-                  <includes>*${shim.name}*</includes>
+                  <outputDirectory>${oss.license.unpack.directory}</outputDirectory>
+                  <includes>**/*${shim.name}*</includes>
                 </artifactItem>
               </artifactItems>
             </configuration>

--- a/shims/hdp25/assemblies/hdp25-shim/src/assembly/assembly.xml
+++ b/shims/hdp25/assemblies/hdp25-shim/src/assembly/assembly.xml
@@ -10,7 +10,7 @@
       <outputDirectory>/</outputDirectory>
     </fileSet>
     <fileSet>
-      <directory>${oss.license.directory}</directory>
+      <directory>${oss.license.subdirectory}</directory>
       <outputDirectory>/</outputDirectory>
     </fileSet>
   </fileSets>

--- a/shims/mapr510/assemblies/mapr510-shim/pom.xml
+++ b/shims/mapr510/assemblies/mapr510-shim/pom.xml
@@ -56,8 +56,8 @@
                   <artifactId>oss-licenses</artifactId>
                   <type>zip</type>
                   <overWrite>false</overWrite>
-                  <outputDirectory>${oss.license.directory}</outputDirectory>
-                  <includes>*${shim.name}*</includes>
+                  <outputDirectory>${oss.license.unpack.directory}</outputDirectory>
+                  <includes>**/*${shim.name}*</includes>
                 </artifactItem>
               </artifactItems>
             </configuration>

--- a/shims/mapr510/assemblies/mapr510-shim/src/assembly/assembly.xml
+++ b/shims/mapr510/assemblies/mapr510-shim/src/assembly/assembly.xml
@@ -10,7 +10,7 @@
       <outputDirectory>/</outputDirectory>
     </fileSet>
     <fileSet>
-      <directory>${oss.license.directory}</directory>
+      <directory>${oss.license.subdirectory}</directory>
       <outputDirectory>/</outputDirectory>
     </fileSet>
   </fileSets>

--- a/shims/mapr520/assemblies/mapr520-shim/pom.xml
+++ b/shims/mapr520/assemblies/mapr520-shim/pom.xml
@@ -56,8 +56,8 @@
                   <artifactId>oss-licenses</artifactId>
                   <type>zip</type>
                   <overWrite>false</overWrite>
-                  <outputDirectory>${oss.license.directory}</outputDirectory>
-                  <includes>*${shim.name}*</includes>
+                  <outputDirectory>${oss.license.unpack.directory}</outputDirectory>
+                  <includes>**/*${shim.name}*</includes>
                 </artifactItem>
               </artifactItems>
             </configuration>

--- a/shims/mapr520/assemblies/mapr520-shim/src/assembly/assembly.xml
+++ b/shims/mapr520/assemblies/mapr520-shim/src/assembly/assembly.xml
@@ -10,7 +10,7 @@
       <outputDirectory>/</outputDirectory>
     </fileSet>
     <fileSet>
-      <directory>${oss.license.directory}</directory>
+      <directory>${oss.license.subdirectory}</directory>
       <outputDirectory>/</outputDirectory>
     </fileSet>
   </fileSets>

--- a/shims/pom.xml
+++ b/shims/pom.xml
@@ -11,7 +11,8 @@
   <packaging>pom</packaging>
   <properties>
     <xerces.version>2.8.1</xerces.version>
-    <oss.license.directory>${project.build.directory}/oss_license</oss.license.directory>
+    <oss.license.unpack.directory>${project.build.directory}/oss_license</oss.license.unpack.directory>
+    <oss.license.subdirectory>${oss.license.unpack.directory}/oss-licenses-${project.version}/licenses</oss.license.subdirectory>
     <org.safehaus.jug.version>2.0.0</org.safehaus.jug.version>
     <com.yammer.metrics.version>2.2.0</com.yammer.metrics.version>
     <commons-lang.version>2.6</commons-lang.version>


### PR DESCRIPTION
Renamed oss.license.directory to oss.license.unpack.directory.
Added oss.license.subdirectory property to pentaho-hadoop-shims/shims/pom.xml.
Updated assembly.xml descriptor and assemblies/&#60;shimName&#62;-shim/pom.xml fro all shims.