### PR TITLE
[BAD-601]: The bunch of unit tests for pentaho-hadoop-shims (master b…

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,3 +30,23 @@ If you want to remote debug a single java unit test (default port is 5005):
 $ cd server/core
 $ mvn test -Dtest=PlaceTest -Dmaven.surefire.debug
 ```
+__Running tests on Windows__
+
+Running tests on Window requires additional environment set up because of existing problems running Hadoop on Windows (please see https://wiki.apache.org/hadoop/WindowsProblems).
+
+Exactly it needs to have **hadoop.home.dir** variable pointed to dir with ` \bin\winutils.exe`.
+
+__Steps to set up environment:__
+ 
+ - Download *winutils.exe*  binary. E.g. from: https://mvnrepository.com/artifact/org.apache.hadoop/hadoop-winutils
+ - Create any dir (e.g. d:\TEMP_DIR) and **bin** sub dir in it. Then put **winutils.exe** in **bin**:
+ `d:\TEMP_DIR\bin\winutils.exe`
+ 
+ - Set system property `hadoop.home.dir="d:\TEMP_DIR"` or just run the Java process with this property:
+```
+$ mvn test -Dhadoop.home.dir="d:\TEMP_DIR"
+```
+or
+```
+$ mvn clean install -Dhadoop.home.dir="d:\TEMP_DIR"
+```

--- a/common/common-shim/src/main/java/org/pentaho/hadoop/shim/common/DistributedCacheUtilImpl.java
+++ b/common/common-shim/src/main/java/org/pentaho/hadoop/shim/common/DistributedCacheUtilImpl.java
@@ -2,7 +2,7 @@
  *
  * Pentaho Big Data
  *
- * Copyright (C) 2002-2015 by Pentaho : http://www.pentaho.com
+ * Copyright (C) 2002-2017 by Pentaho : http://www.pentaho.com
  *
  *******************************************************************************
  *
@@ -149,11 +149,7 @@ public class DistributedCacheUtilImpl implements org.pentaho.hadoop.shim.api.Dis
    */
   public boolean isKettleEnvironmentInstalledAt( FileSystem fs, Path root ) throws IOException {
     // These directories must exist
-    Path[] directories = new Path[] {
-        new Path( root, PATH_LIB ),
-        new Path( root, PATH_PLUGINS ),
-        new Path( new Path( root, PATH_PLUGINS ), PENTAHO_BIG_DATA_PLUGIN_FOLDER_NAME )
-    };
+    Path[] directories = new Path[] { new Path( root, PATH_LIB ), new Path( root, PATH_PLUGINS ), new Path( new Path( root, PATH_PLUGINS ), PENTAHO_BIG_DATA_PLUGIN_FOLDER_NAME ) };
     // This file must not exist
     Path lock = getLockFileAt( root );
     // These directories must exist
@@ -183,7 +179,9 @@ public class DistributedCacheUtilImpl implements org.pentaho.hadoop.shim.api.Dis
 
     // Write lock file while we're installing
     Path lockFile = getLockFileAt( destination );
-    fs.create( lockFile, true );
+    FSDataOutputStream out = fs.create( lockFile, true );
+    //We should close output stream, otherwise the file will be locked on Windows
+    out.close();
 
     stageForCache( extracted, fs, destination, true );
 
@@ -433,8 +431,7 @@ public class DistributedCacheUtilImpl implements org.pentaho.hadoop.shim.api.Dis
   }
 
   private void copyConfigProperties( FileObject source, FileSystem fs, Path dest ) {
-    try (FSDataOutputStream output = fs.create( dest );
-         InputStream input = source.getContent().getInputStream() ) {
+    try ( FSDataOutputStream output = fs.create( dest ); InputStream input = source.getContent().getInputStream() ) {
 
       List<String> lines = IOUtils.readLines( input );
       for ( String line : lines ) {


### PR DESCRIPTION
…ranch) are failed on windows

Hadoop requires native libraries on Windows to work properly.
That includes to access the file:// filesystem, where Hadoop uses some Windows APIs to implement posix-like file access permissions.
In particular, %HADOOP_HOME%\BIN\WINUTILS.EXE must be locatable.
So added info about how to set up env on Windows to run test in README.md;
Also fixed issue with attempt to delete an opened file on Windows.