### PR TITLE
[BACKLOG-15584]-MapR5.2: Hadoop Cluster Test fails (JAAS configuration could not be loaded at this time)

### DIFF
--- a/shims/mapr520/assemblies/mapr520-shim/src/main/resources/config.properties
+++ b/shims/mapr520/assemblies/mapr520-shim/src/main/resources/config.properties
@@ -17,7 +17,7 @@ linux.library.path=/opt/mapr/lib
 # or the classpath property
 # e.g.: org.apache.commons.log,org.apache.log4j
 # Note, the two packages above are automatically included for all configurations
-ignore.classes=
+ignored.classes=
 
 # Comma-separated list of jars to explicitly ignore when
 # loading classes from the resources within this Hadoop configuration directory


### PR DESCRIPTION
Replaced "ignore.classes=" with "ignored.classes=" as was earlier in config.properties