### PR TITLE
Revert "[BAD-592]-MapR 5.1/5.2: ClassNotFoundException when running MapReduce Job with mapper containing Hbase Row Decoder step"

### DIFF
--- a/api/src/main/java/org/pentaho/hadoop/shim/HadoopConfigurationLocator.java
+++ b/api/src/main/java/org/pentaho/hadoop/shim/HadoopConfigurationLocator.java
@@ -1,7 +1,7 @@
 /*******************************************************************************
  * Pentaho Big Data
  * <p>
- * Copyright (C) 2002-2017 by Pentaho : http://www.pentaho.com
+ * Copyright (C) 2002-2016 by Pentaho : http://www.pentaho.com
  * <p>
  * ******************************************************************************
  * <p>
@@ -18,7 +18,6 @@
 package org.pentaho.hadoop.shim;
 
 import java.io.IOException;
-import java.io.InputStream;
 import java.lang.reflect.Field;
 import java.net.URL;
 import java.util.ArrayList;
@@ -35,7 +34,6 @@ import java.util.Map.Entry;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-import com.google.common.annotations.VisibleForTesting;
 import org.apache.commons.vfs2.FileObject;
 import org.apache.commons.vfs2.FileSelectInfo;
 import org.apache.commons.vfs2.FileSelector;
@@ -70,8 +68,6 @@ public class HadoopConfigurationLocator implements HadoopConfigurationProvider {
 
   private static final String CONFIG_PROPERTY_EXCLUDE_JARS = "exclude.jars";
 
-  private static final String CONFIG_PROPERTY_EXCLUDE_CLUSTER_JARS = "exclude.cluster.jars";
-
   private static final String SHIM_CLASSPATH_IGNORE = "classpath.ignore";
 
   private static final String CONFIG_PROPERTY_CLASSPATH = "classpath";
@@ -79,8 +75,6 @@ public class HadoopConfigurationLocator implements HadoopConfigurationProvider {
   private static final String CONFIG_PROPERTY_LIBRARY_PATH = "library.path";
 
   private static final String CONFIG_PROPERTY_NAME = "name";
-
-  private static final String PMR_PROPERTIES = "pmr.properties";
 
   private static final URL[] EMPTY_URL_ARRAY = new URL[ 0 ];
 
@@ -332,54 +326,11 @@ public class HadoopConfigurationLocator implements HadoopConfigurationProvider {
       //Exclude jars contained in exclude.jars property in config.properties file from the list of jars
       jars = filterJars( jars, configurationProperties.getProperty( CONFIG_PROPERTY_EXCLUDE_JARS ) );
 
-      //Exclude jars contained in exclude.cluster.jars property in config.properties file from the list of jars
-      jars = filterClusterJars( jars, configurationProperties.getProperty( CONFIG_PROPERTY_EXCLUDE_CLUSTER_JARS ) );
-
       return new HadoopConfigurationClassLoader( jars.toArray( EMPTY_URL_ARRAY ),
         parent, ignoredClasses );
     } catch ( Exception ex ) {
       throw new ConfigurationException( BaseMessages.getString( PKG, "Error.CreatingClassLoader" ), ex );
     }
-  }
-
-  private Properties getPmrProperties() {
-    InputStream pmrProperties = getClass().getClassLoader().getResourceAsStream(
-      PMR_PROPERTIES );
-    Properties properties = new Properties();
-    if ( pmrProperties != null ) {
-      try {
-        properties.load( pmrProperties );
-      } catch ( IOException ioe ) {
-        // pmr.properties not available
-      } finally {
-        if ( pmrProperties != null ) {
-          try {
-            pmrProperties.close();
-          } catch ( IOException e ) {
-            // pmr.properties not available
-          }
-        }
-      }
-    }
-    return properties;
-  }
-
-  /**
-   * Exclude jars contained in exclude.cluster.jars property in config.properties file from the list of URLs
-   *
-   * @param urls                        the list of all the URLs to add to the class loader
-   * @param excludedClusterJarsProperty exclude.cluster.jars property from a config.properties file
-   * @return The rest of the jars in {@code urls} after excluding the jars listed in {@code
-   * excludedClusterJarsProperty}.
-   */
-  @VisibleForTesting
-  List<URL> filterClusterJars( List<URL> urls, String excludedClusterJarsProperty ) {
-    Properties pmrProperties = getPmrProperties();
-    String isPmr = pmrProperties.getProperty( "isPmr", "false" );
-    if ( "true".equals( isPmr ) ) {
-      urls = filterJars( urls, excludedClusterJarsProperty );
-    }
-    return urls;
   }
 
   /**

--- a/api/src/test/java/org/pentaho/hadoop/shim/HadoopExcludeJarsTest.java
+++ b/api/src/test/java/org/pentaho/hadoop/shim/HadoopExcludeJarsTest.java
@@ -1,7 +1,7 @@
 /*******************************************************************************
  * Pentaho Big Data
  * <p>
- * Copyright (C) 2002-2017 by Pentaho : http://www.pentaho.com
+ * Copyright (C) 2002-2016 by Pentaho : http://www.pentaho.com
  * <p>
  * ******************************************************************************
  * <p>
@@ -22,16 +22,9 @@ import org.apache.commons.vfs2.FileObject;
 import org.apache.commons.vfs2.FileType;
 import org.apache.commons.vfs2.VFS;
 import org.junit.BeforeClass;
-import org.junit.ClassRule;
 import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
 
-import java.io.File;
-import java.io.IOException;
-import java.net.URISyntaxException;
 import java.net.URL;
-import java.nio.file.Files;
-import java.nio.file.Paths;
 import java.util.Iterator;
 import java.util.List;
 
@@ -41,30 +34,17 @@ import static org.junit.Assert.assertNull;
 public class HadoopExcludeJarsTest {
 
   private static String HADOOP_CONFIGURATIONS_PATH = System.getProperty( "java.io.tmpdir" ) + "/exclude-jars";
-  private static String HADOOP_CLUSTER_JARS_PATH = System.getProperty( "java.io.tmpdir" ) + "/exclude-cluster-jars";
-  private static String PMR_PROPERTIES = "pmr.properties";
-  private static File pmrFolder;
-  private static URL urlTestResources;
   private int count;
 
-
-  @ClassRule
-  public static TemporaryFolder tempFolder = new TemporaryFolder();
 
   @BeforeClass
   public static void setup() throws Exception {
     // Create a test hadoop configuration
     FileObject ramRoot = VFS.getManager().resolveFile( HADOOP_CONFIGURATIONS_PATH );
-    FileObject ramRootCluster = VFS.getManager().resolveFile( HADOOP_CLUSTER_JARS_PATH );
     if ( ramRoot.exists() ) {
       ramRoot.delete( new AllFileSelector() );
     }
     ramRoot.createFolder();
-
-    if ( ramRootCluster.exists() ) {
-      ramRootCluster.delete( new AllFileSelector() );
-    }
-    ramRootCluster.createFolder();
 
     // Create the implementation jars
     ramRoot.resolveFile( "xercesImpl-2.9.1.jar" ).createFile();
@@ -77,13 +57,6 @@ public class HadoopExcludeJarsTest {
     ramRoot.resolveFile( "postgresql-9.3-1102-jdbc4.jar" ).createFile();
     ramRoot.resolveFile( "trilead-ssh2-build213.jar" ).createFile();
     ramRoot.resolveFile( "trilead-ssh2-build215.jar" ).createFile();
-
-    ramRootCluster.resolveFile( "hadoop-common-2.7.0-mapr-1607.jar" ).createFile();
-    ramRootCluster.resolveFile( "hadoop-mapreduce-client-core-2.7.0-mapr-1506.jar" ).createFile();
-
-    pmrFolder = tempFolder.newFolder( "pmr" );
-    urlTestResources = Thread.currentThread().getContextClassLoader().getResource( PMR_PROPERTIES );
-    Files.copy( Paths.get( urlTestResources.toURI() ), Paths.get( pmrFolder.getAbsolutePath(), PMR_PROPERTIES ) );
   }
 
   @Test
@@ -190,110 +163,5 @@ public class HadoopExcludeJarsTest {
     List<URL> list =
       locator.filterJars( urls, "xercesImpl,trilead-ssh2-build215,pentaho-hadoop-shims-api-61.2016.04.01-196.jar" );
     assertEquals( count - 3, list.size() );
-  }
-
-  private void activatePmrFile() throws URISyntaxException, IOException {
-    if ( !Files.exists( Paths.get( urlTestResources.toURI() ) ) ) {
-      Files.copy( Paths.get( pmrFolder.getAbsolutePath(), PMR_PROPERTIES ), Paths.get( urlTestResources.toURI() ) );
-    }
-  }
-
-  private void disablePmrFile() throws URISyntaxException, IOException {
-    Files.deleteIfExists( Paths.get( urlTestResources.toURI() ) );
-  }
-
-  @Test
-  public void filterClusterJars_isPmrTrue_null_args() throws Exception {
-    HadoopConfigurationLocator locator = new HadoopConfigurationLocator();
-
-    activatePmrFile();
-    List<URL> list = locator.filterClusterJars( null, null );
-    assertNull( list );
-  }
-
-  @Test
-  public void filterClusterJars_isPmrTrue_arg_excludedJarsProperty_emptyString() throws Exception {
-    HadoopConfigurationLocator locator = new HadoopConfigurationLocator();
-
-    activatePmrFile();
-    FileObject root = VFS.getManager().resolveFile( HADOOP_CLUSTER_JARS_PATH );
-    List<URL> urls = locator.parseURLs( root, root.toString() );
-
-    count = urls.size();
-    List<URL> list = locator.filterClusterJars( urls, "" );
-    assertEquals( count, list.size() );
-  }
-
-  @Test
-  public void filterClusterJars_isPmrTrue_removeOnlyHadoopCommon() throws Exception {
-    HadoopConfigurationLocator locator = new HadoopConfigurationLocator();
-
-    activatePmrFile();
-    FileObject root = VFS.getManager().resolveFile( HADOOP_CLUSTER_JARS_PATH );
-    List<URL> urls = locator.parseURLs( root, root.toString() );
-    boolean containsJar = false;
-
-    count = urls.size();
-    List<URL> list = locator.filterClusterJars( urls, "hadoop-common" );
-    assertEquals( count - 1, list.size() );
-
-    for ( URL url : list ) {
-      if ( url.getPath().contains( "hadoop-common" ) ) {
-        containsJar = true;
-        break;
-      }
-    }
-    assertEquals( false, containsJar );
-  }
-
-  @Test
-  public void filterClusterJars_isPmrTrue_arg_urls_containsOnlyExcludedJars() throws Exception {
-    HadoopConfigurationLocator locator = new HadoopConfigurationLocator();
-
-    activatePmrFile();
-    FileObject root = VFS.getManager().resolveFile( HADOOP_CLUSTER_JARS_PATH );
-    List<URL> urls = locator.parseURLs( root, root.toString() );
-    Iterator<URL> iterator = urls.listIterator();
-    while ( iterator.hasNext() ) {
-      URL url = iterator.next();
-      if ( FileType.FOLDER.equals( root.resolveFile( url.toString().trim() ).getType() ) ) {
-        iterator.remove();
-      }
-    }
-
-    count = urls.size();
-    List<URL> list =
-      locator.filterClusterJars( urls, "hadoop-common-2.7.0-mapr-1607.jar,hadoop-client-2.7.0-mapr-1607.jar" );
-    assertEquals( 1, list.size() );
-  }
-
-  @Test
-  public void filterClusterJars_isPmrFalse_arg_excludedJarsProperty_emptyString() throws Exception {
-    HadoopConfigurationLocator locator = new HadoopConfigurationLocator();
-
-    try {
-      disablePmrFile();
-      FileObject root = VFS.getManager().resolveFile( HADOOP_CLUSTER_JARS_PATH );
-      List<URL> urls = locator.parseURLs( root, root.toString() );
-
-      count = urls.size();
-      List<URL> list = locator.filterClusterJars( urls, "" );
-      assertEquals( count, list.size() );
-    } finally {
-      activatePmrFile();
-    }
-  }
-
-  @Test
-  public void filterClusterJars_isPmrFalse_null_args() throws Exception {
-    HadoopConfigurationLocator locator = new HadoopConfigurationLocator();
-
-    try {
-      disablePmrFile();
-      List<URL> list = locator.filterClusterJars( null, null );
-      assertNull( list );
-    } finally {
-      activatePmrFile();
-    }
   }
 }

--- a/api/src/test/resources/pmr.properties
+++ b/api/src/test/resources/pmr.properties
@@ -1,3 +1,0 @@
-isPmr=true
-maxTimeoutBeforeLoadingShim=300
-notificationsBeforeLoadingShim=1

--- a/shims/mapr520/assemblies/mapr520-shim/src/assembly/assembly.xml
+++ b/shims/mapr520/assemblies/mapr520-shim/src/assembly/assembly.xml
@@ -31,6 +31,11 @@
       <includes>
         <include>dk.brics.automaton:automaton</include>
         <include>pentaho:hadoop2-windows-patch</include>
+        <include>org.apache.hbase:hbase-client</include>
+        <include>org.apache.hbase:hbase-common</include>
+        <include>org.apache.hbase:hbase-hadoop-compat</include>
+        <include>org.apache.hbase:hbase-protocol</include>
+        <include>org.apache.hbase:hbase-server</include>
         <include>org.apache.hive:hive-common</include>
         <include>org.apache.hive:hive-exec</include>
         <include>org.apache.hive:hive-jdbc</include>
@@ -58,11 +63,6 @@
       <includes>
         <include>org.apache.htrace:htrace-core</include>
         <include>org.apache.zookeeper:zookeeper</include>
-        <include>org.apache.hbase:hbase-client</include>
-        <include>org.apache.hbase:hbase-common</include>
-        <include>org.apache.hbase:hbase-hadoop-compat</include>
-        <include>org.apache.hbase:hbase-protocol</include>
-        <include>org.apache.hbase:hbase-server</include>
       </includes>
       <excludes>
         <exclude>*:tests:*</exclude>

--- a/shims/mapr520/assemblies/mapr520-shim/src/main/resources/config.properties
+++ b/shims/mapr520/assemblies/mapr520-shim/src/main/resources/config.properties
@@ -5,7 +5,7 @@ name=MapR 5.2.0
 # configuration on linux. Any resources found here will overwrite ones in lib/.
 # Current classpath was received from running "hadoop classpath" and concating ${PENTAHO_INSTALLED_DIR}/design-tools/data-integration/plugins/pentaho-big-data-plugin/hadoop-configurations/mapr520,/opt/mapr/lib
 # For example:
-linux.classpath=/opt/mapr/hadoop/hadoop-2.7.0/etc/hadoop,/opt/mapr/hadoop/hadoop-2.7.0/share/hadoop/common/lib,/opt/mapr/hadoop/hadoop-2.7.0/share/hadoop/common,/opt/mapr/hadoop/hadoop-2.7.0/share/hadoop/hdfs,/opt/mapr/hadoop/hadoop-2.7.0/share/hadoop/hdfs/lib,/opt/mapr/hadoop/hadoop-2.7.0/share/hadoop/yarn/lib,/opt/mapr/hadoop/hadoop-2.7.0/share/hadoop/yarn,/opt/mapr/hadoop/hadoop-2.7.0/share/hadoop/mapreduce/lib,/opt/mapr/hadoop/hadoop-2.7.0/share/hadoop/mapreduce,/opt/mapr/sqoop/sqoop-1.4.6,/opt/mapr/sqoop/sqoop-1.4.6/lib,/contrib/capacity-scheduler,/opt/data-integration/plugins/pentaho-big-data-plugin/hadoop-configurations/mapr520,/opt/Pentaho/design-tools/data-integration/plugins/pentaho-big-data-plugin/hadoop-configurations/mapr520,/opt/mapr/lib
+linux.classpath=/opt/mapr/hadoop/hadoop-2.7.0/etc/hadoop,/opt/mapr/hadoop/hadoop-2.7.0/share/hadoop/common/lib,/opt/mapr/hadoop/hadoop-2.7.0/share/hadoop/common,/opt/mapr/hadoop/hadoop-2.7.0/share/hadoop/hdfs,/opt/mapr/hadoop/hadoop-2.7.0/share/hadoop/hdfs/lib,/opt/mapr/hadoop/hadoop-2.7.0/share/hadoop/yarn/lib,/opt/mapr/hadoop/hadoop-2.7.0/share/hadoop/yarn,/opt/mapr/hadoop/hadoop-2.7.0/share/hadoop/mapreduce/lib,/opt/mapr/hadoop/hadoop-2.7.0/share/hadoop/mapreduce,/opt/mapr/sqoop/sqoop-1.4.6,/opt/mapr/sqoop/sqoop-1.4.6/lib,/contrib/capacity-scheduler,/opt/data-integration/plugins/pentaho-big-data-plugin/hadoop-configurations/mapr520,/opt/data-integration/plugins/pentaho-big-data-plugin/hadoop-configurations/mapr520/lib,/opt/mapr/lib
 
 
 # Comma-separated list of paths that contain native libraries to load. These
@@ -26,15 +26,6 @@ ignored.classes=
 # with jar extension - xercesImpl-2.9.1.jar,xml-apis-1.3.04.jar
 # Note, the two jars above lead to libraries conflicts on Mapr 5.2 cluster so they are added to exclude.jars property below
 exclude.jars=xercesImpl,xml-apis
-
-# Comma-separated list of jars to explicitly ignore when
-# loading classes from the resources within this Hadoop configuration directory
-# or the classpath property on the cluster side
-# e.g.: without versions - hadoop-common or with versions - hadoop-common-2.7.0-mapr-1607 or
-# with jar extension - hadoop-common-2.7.0-mapr-1607.jar
-# Note, the jar above is excluded to keep HBase-related steps (including HBase Row Decoder Step) working
-#so this one is added to exclude.cluster.jars property below
-exclude.cluster.jars=hadoop-common
 
 # These are Windows-specific classpath and library paths. 
 # Please make sure to update the MapR versions in the paths to match your


### PR DESCRIPTION
Reverts pentaho/pentaho-hadoop-shims#452