### PR TITLE
[BAD-614][BAD-639]-CDH 5.9/5.10 Secure: MapReduce Job with mapper con…

### DIFF
--- a/common/hadoop-shim/pom.xml
+++ b/common/hadoop-shim/pom.xml
@@ -11,7 +11,7 @@
   <packaging>jar</packaging>
   <properties>
     <org.apache.hive.version>2.1.0</org.apache.hive.version>
-    <org.apache.hadoop.version>2.2.0</org.apache.hadoop.version>
+    <org.apache.hadoop.version>2.7.3</org.apache.hadoop.version>
   </properties>
   <dependencies>
     <dependency>

--- a/common/hadoop-shim/src/main/java/org/pentaho/hadoop/shim/common/ConfigurationProxyV2.java
+++ b/common/hadoop-shim/src/main/java/org/pentaho/hadoop/shim/common/ConfigurationProxyV2.java
@@ -2,7 +2,7 @@
  *
  * Pentaho Big Data
  *
- * Copyright (C) 2002-2014 by Pentaho : http://www.pentaho.com
+ * Copyright (C) 2002-2017 by Pentaho : http://www.pentaho.com
  *
  *******************************************************************************
  *
@@ -21,6 +21,7 @@
  ******************************************************************************/
 package org.pentaho.hadoop.shim.common;
 
+import com.google.common.annotations.VisibleForTesting;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.mapred.JobConf;
 import org.apache.hadoop.mapreduce.Job;
@@ -28,7 +29,6 @@ import org.apache.hadoop.mapreduce.lib.input.FileInputFormat;
 import org.apache.hadoop.mapreduce.lib.output.FileOutputFormat;
 import org.pentaho.hadoop.shim.api.Configuration;
 import org.pentaho.hadoop.shim.api.mapred.RunningJob;
-import org.pentaho.hadoop.shim.common.RunningJobProxyV2;
 
 import java.io.IOException;
 
@@ -41,8 +41,14 @@ public class ConfigurationProxyV2 implements Configuration {
 
   public ConfigurationProxyV2() throws IOException {
     job = Job.getInstance();
+    addConfigsForJobConf();
+  }
+
+  @VisibleForTesting
+  void addConfigsForJobConf() {
     job.getConfiguration().addResource( "hdfs-site.xml" );
     job.getConfiguration().addResource( "hive-site.xml" );
+    job.getConfiguration().addResource( "hbase-site.xml" );
   }
 
   public JobConf getJobConf() {

--- a/common/hadoop-shim/src/test/java/org/pentaho/hadoop/shim/common/ConfigurationProxyV2Test.java
+++ b/common/hadoop-shim/src/test/java/org/pentaho/hadoop/shim/common/ConfigurationProxyV2Test.java
@@ -1,0 +1,63 @@
+/*! ******************************************************************************
+ *
+ * Pentaho Big Data
+ *
+ * Copyright (C) 2002-2017 by Pentaho : http://www.pentaho.com
+ *
+ *******************************************************************************
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ******************************************************************************/
+package org.pentaho.hadoop.shim.common;
+
+import org.junit.Test;
+
+import java.io.IOException;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
+
+/**
+ * test checks whether hbase-site.xml, hive-site.xml, hdfs-site.xml from classpath are
+ * added for hadoop configuration, according test files with hadoop properties are in resource
+ * folder for test
+ *
+ * Created by Vasilina_Terehova on 4/12/2017.
+ */
+public class ConfigurationProxyV2Test {
+
+  @Test
+  public void checkConfigsInConfigurationAddedHbaseSiteXml() throws IOException {
+    ConfigurationProxyV2 configurationProxyV2 = new ConfigurationProxyV2();
+    System.out.println( configurationProxyV2.getJobConf() );
+    assertEquals( "15", configurationProxyV2.get( "hbase.client.primaryCallTimeout.get" ) );
+    assertEquals( "16", configurationProxyV2.get( "hbase.client.primaryCallTimeout.multiget" ) );
+  }
+
+  @Test
+  public void checkConfigsInConfigurationAddedHDFSSiteXml() throws IOException {
+    ConfigurationProxyV2 configurationProxyV2 = new ConfigurationProxyV2();
+    System.out.println( configurationProxyV2.getJobConf() );
+    assertEquals( "true", configurationProxyV2.get( "hive.optimize.bucketmapjoin.sortedmerge" ) );
+    assertEquals( "11000", configurationProxyV2.get( "hive.smbjoin.cache.rows" ) );
+  }
+
+  @Test
+  public void checkConfigsInConfigurationAddedHiveSiteXml() throws IOException {
+    ConfigurationProxyV2 configurationProxyV2 = new ConfigurationProxyV2();
+    System.out.println( configurationProxyV2.getJobConf() );
+    assertEquals( "4", configurationProxyV2.get( "dfs.replication" ) );
+    assertEquals( "true", configurationProxyV2.get( "dfs.client.domain.socket.data.traffic" ) );
+  }
+}

--- a/common/hadoop-shim/src/test/resources/hbase-site.xml
+++ b/common/hadoop-shim/src/test/resources/hbase-site.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration>
+  <property>
+    <name>hbase.client.primaryCallTimeout.get</name>
+    <value>15</value>
+  </property>
+  <property>
+    <name>hbase.client.primaryCallTimeout.multiget</name>
+    <value>16</value>
+  </property>
+</configuration>

--- a/common/hadoop-shim/src/test/resources/hdfs-site.xml
+++ b/common/hadoop-shim/src/test/resources/hdfs-site.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration>
+  <property>
+    <name>dfs.replication</name>
+    <value>4</value>
+  </property>
+  <property>
+    <name>dfs.client.domain.socket.data.traffic</name>
+    <value>true</value>
+  </property>
+</configuration>

--- a/common/hadoop-shim/src/test/resources/hive-site.xml
+++ b/common/hadoop-shim/src/test/resources/hive-site.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration>
+  <property>
+    <name>hive.optimize.bucketmapjoin.sortedmerge</name>
+    <value>true</value>
+  </property>
+  <property>
+    <name>hive.smbjoin.cache.rows</name>
+    <value>11000</value>
+  </property>
+</configuration>

--- a/shims/pom.xml
+++ b/shims/pom.xml
@@ -242,6 +242,13 @@
                     <overWrite>false</overWrite>
                     <outputDirectory>${project.build.directory}/test-src</outputDirectory>
                   </artifactItem>
+                  <artifactItem>
+                    <groupId>org.pentaho</groupId>
+                    <artifactId>pentaho-hadoop-shims-common-hadoop-shim</artifactId>
+                    <classifier>test-sources</classifier>
+                    <overWrite>false</overWrite>
+                    <outputDirectory>${project.build.directory}/test-src</outputDirectory>
+                  </artifactItem>
                 </artifactItems>
               </configuration>
             </execution>
@@ -299,6 +306,7 @@
                       <include>**/*.ktr</include>
                       <include>**/*.zip</include>
                       <include>**/*.jar</include>
+                      <include>**/*.xml</include>
                     </includes>
                   </resource>
                 </resources>


### PR DESCRIPTION
…taining Hbase Row Decoder step is failling on secure clusters,HDP shims: MapReduce Job with mapper containing Hbase Row Decoder step is failling on secure clusters - the reason was that job.xml generated by hadoop for mapreduce jobs according to JobConf prepared on pentaho side didn't contain hbase-site.xml properties needed during run for zookeeper security connection such as hbase.security.authentication