### PR TITLE
[BACKLOG-15983]-HDP shims don't contain core-site.xml

### DIFF
--- a/shims/hdp24/assemblies/hdp24-shim/src/main/resources/core-site.xml
+++ b/shims/hdp24/assemblies/hdp24-shim/src/main/resources/core-site.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0"?>
+<?xml-stylesheet type="text/xsl" href="configuration.xsl"?>
+
+<!-- Put site-specific property overrides in this file. -->
+
+<configuration>
+
+</configuration>

--- a/shims/hdp25/assemblies/hdp25-shim/src/main/resources/core-site.xml
+++ b/shims/hdp25/assemblies/hdp25-shim/src/main/resources/core-site.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0"?>
+<?xml-stylesheet type="text/xsl" href="configuration.xsl"?>
+
+<!-- Put site-specific property overrides in this file. -->
+
+<configuration>
+
+</configuration>


### PR DESCRIPTION
Added core-site.xml to both hdp24 and hdp25 shims into pentaho-hadoop-shims\shims\hdp24\assemblies\hdp24-shim\src\main\resources and pentaho-hadoop-shims\shims\hdp25\assemblies\hdp25-shim\src\main\resources appropriately.