### PR TITLE
[BACKLOG-15823]-MapR 5.1/5.2: ClassNotFoundException when running MapReduce Job with mapper containing Hbase Row Decoder step

### DIFF
--- a/api/src/main/java/org/pentaho/hadoop/shim/HadoopConfigurationClassLoader.java
+++ b/api/src/main/java/org/pentaho/hadoop/shim/HadoopConfigurationClassLoader.java
@@ -1,23 +1,18 @@
 /*******************************************************************************
- *
  * Pentaho Big Data
- *
- * Copyright (C) 2002-2015 by Pentaho : http://www.pentaho.com
- *
- *******************************************************************************
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with
+ * <p>
+ * Copyright (C) 2002-2017 by Pentaho : http://www.pentaho.com
+ * <p>
+ * ******************************************************************************
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
- *
- *    http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- *
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
  ******************************************************************************/
 
 package org.pentaho.hadoop.shim;
@@ -59,6 +54,26 @@ public class HadoopConfigurationClassLoader extends URLClassLoader {
     }
     loadClassesFromParent.add( "org.apache.commons.log" );
     loadClassesFromParent.add( "org.apache.log4j" );
+  }
+
+  /**
+   * Create a class loader capable of loading classes for a Hadoop configuration when mapr shim is used and ignore
+   * .cluster.classes
+   * property is set in config.properties file.
+   *
+   * @param ignoredClusterClasses Classes or package names to explicitly delegate loading to the parent class loader
+   *                              only on cluster side
+   * @param urls           Paths to directories or jars to load resources from
+   * @param parent         Parent class loader to delegate loading of resources to if we cannot find them within the
+   *                       list of URLs
+   * @param ignoredClasses Classes or package names to explicitly delegate loading to the parent class loader
+   */
+  public HadoopConfigurationClassLoader( String ignoredClusterClasses, URL[] urls, ClassLoader parent,
+                                         String... ignoredClasses ) {
+    this( urls, parent, ignoredClasses );
+    if ( !( ignoredClusterClasses == null || ignoredClusterClasses.trim().isEmpty() ) ) {
+      loadClassesFromParent.addAll( Arrays.asList( ignoredClusterClasses.split( "," ) ) );
+    }
   }
 
   /**

--- a/api/src/main/java/org/pentaho/hadoop/shim/HadoopConfigurationLocator.java
+++ b/api/src/main/java/org/pentaho/hadoop/shim/HadoopConfigurationLocator.java
@@ -1,7 +1,7 @@
 /*******************************************************************************
  * Pentaho Big Data
  * <p>
- * Copyright (C) 2002-2016 by Pentaho : http://www.pentaho.com
+ * Copyright (C) 2002-2017 by Pentaho : http://www.pentaho.com
  * <p>
  * ******************************************************************************
  * <p>
@@ -18,6 +18,7 @@
 package org.pentaho.hadoop.shim;
 
 import java.io.IOException;
+import java.io.InputStream;
 import java.lang.reflect.Field;
 import java.net.URL;
 import java.util.ArrayList;
@@ -34,6 +35,7 @@ import java.util.Map.Entry;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
+import com.google.common.annotations.VisibleForTesting;
 import org.apache.commons.vfs2.FileObject;
 import org.apache.commons.vfs2.FileSelectInfo;
 import org.apache.commons.vfs2.FileSelector;
@@ -66,7 +68,11 @@ public class HadoopConfigurationLocator implements HadoopConfigurationProvider {
 
   private static final String CONFIG_PROPERTY_IGNORE_CLASSES = "ignore.classes";
 
+  public static final String CONFIG_PROPERTY_IGNORE_CLUSTER_CLASSES = "ignore.cluster.classes";
+
   private static final String CONFIG_PROPERTY_EXCLUDE_JARS = "exclude.jars";
+
+  public static final String CONFIG_PROPERTY_EXCLUDE_CLUSTER_JARS = "exclude.cluster.jars";
 
   private static final String SHIM_CLASSPATH_IGNORE = "classpath.ignore";
 
@@ -75,6 +81,8 @@ public class HadoopConfigurationLocator implements HadoopConfigurationProvider {
   private static final String CONFIG_PROPERTY_LIBRARY_PATH = "library.path";
 
   private static final String CONFIG_PROPERTY_NAME = "name";
+
+  public static final String PMR_PROPERTIES = "pmr.properties";
 
   private static final URL[] EMPTY_URL_ARRAY = new URL[ 0 ];
 
@@ -326,11 +334,67 @@ public class HadoopConfigurationLocator implements HadoopConfigurationProvider {
       //Exclude jars contained in exclude.jars property in config.properties file from the list of jars
       jars = filterJars( jars, configurationProperties.getProperty( CONFIG_PROPERTY_EXCLUDE_JARS ) );
 
+      //Exclude jars contained in exclude.cluster.jars property in config.properties file from the list of jars
+      jars = filterClusterJars( jars, configurationProperties.getProperty( CONFIG_PROPERTY_EXCLUDE_CLUSTER_JARS ) );
+
+      if ( isIgnoreClusterClassesPropertyNotEmpty( configurationProperties.getProperty( CONFIG_PROPERTY_IGNORE_CLUSTER_CLASSES ) ) ) {
+        return new HadoopConfigurationClassLoader(
+          configurationProperties.getProperty( CONFIG_PROPERTY_IGNORE_CLUSTER_CLASSES ), jars.toArray( EMPTY_URL_ARRAY ),
+          parent, ignoredClasses );
+      }
+
       return new HadoopConfigurationClassLoader( jars.toArray( EMPTY_URL_ARRAY ),
         parent, ignoredClasses );
     } catch ( Exception ex ) {
       throw new ConfigurationException( BaseMessages.getString( PKG, "Error.CreatingClassLoader" ), ex );
     }
+  }
+
+  private Properties getPmrProperties() {
+    InputStream pmrProperties = getClass().getClassLoader().getResourceAsStream(
+      PMR_PROPERTIES );
+    Properties properties = new Properties();
+    if ( pmrProperties != null ) {
+      try {
+        properties.load( pmrProperties );
+      } catch ( IOException ioe ) {
+        // pmr.properties not available
+      } finally {
+        if ( pmrProperties != null ) {
+          try {
+            pmrProperties.close();
+          } catch ( IOException e ) {
+            // pmr.properties not available
+          }
+        }
+      }
+    }
+    return properties;
+  }
+
+  /**
+   * Exclude jars contained in exclude.cluster.jars property in config.properties file from the list of URLs
+   *
+   * @param urls                        the list of all the URLs to add to the class loader
+   * @param excludedClusterJarsProperty exclude.cluster.jars property from a config.properties file
+   * @return The rest of the jars in {@code urls} after excluding the jars listed in {@code
+   * excludedClusterJarsProperty}.
+   */
+  @VisibleForTesting
+  List<URL> filterClusterJars( List<URL> urls, String excludedClusterJarsProperty ) {
+    Properties pmrProperties = getPmrProperties();
+    String isPmr = pmrProperties.getProperty( "isPmr", "false" );
+    if ( "true".equals( isPmr ) ) {
+      urls = filterJars( urls, excludedClusterJarsProperty );
+    }
+    return urls;
+  }
+
+  @VisibleForTesting
+  boolean isIgnoreClusterClassesPropertyNotEmpty( String ignoreClusterClasses ) {
+    Properties pmrProperties = getPmrProperties();
+    String isPmr = pmrProperties.getProperty( "isPmr", "false" );
+    return ( "true".equals( isPmr ) && !( ignoreClusterClasses == null || ignoreClusterClasses.trim().isEmpty() ) );
   }
 
   /**

--- a/api/src/test/java/org/pentaho/hadoop/shim/HadoopConfigurationClassLoaderTest.java
+++ b/api/src/test/java/org/pentaho/hadoop/shim/HadoopConfigurationClassLoaderTest.java
@@ -2,7 +2,7 @@
  *
  * Pentaho Big Data
  *
- * Copyright (C) 2002-2015 by Pentaho : http://www.pentaho.com
+ * Copyright (C) 2002-2017 by Pentaho : http://www.pentaho.com
  *
  *******************************************************************************
  *
@@ -68,4 +68,56 @@ public class HadoopConfigurationClassLoaderTest {
       new HadoopConfigurationClassLoader( new URL[] { workingDir, srcDir }, getClass().getClassLoader() );
     assertEquals( workingDir.getFile() + File.pathSeparator + srcDir.getFile(), hccl.generateClassPathString() );
   }
+
+  @Test
+  public void ignoreClusterClasses_multiple_classes() {
+    String ignoredClusterClasses = "org.apache.hadoop.security.rpcauth.MaprAuthMethod,com.mapr.baseutils.BaseUtilsHelper";
+    HadoopConfigurationClassLoader hccl =
+      new HadoopConfigurationClassLoader( ignoredClusterClasses, new URL[ 0 ], getClass().getClassLoader() );
+    assertTrue( hccl.ignoreClass( "org.apache.commons.log" ) );
+    assertTrue( hccl.ignoreClass( "org.apache.log4j" ) );
+    assertTrue( hccl.ignoreClass( "org.apache.log4j.Logger" ) );
+    assertTrue( hccl.ignoreClass( "org.apache.hadoop.security.rpcauth.MaprAuthMethod" ) );
+    assertTrue( hccl.ignoreClass( "com.mapr.baseutils.BaseUtilsHelper" ) );
+    assertFalse( hccl.ignoreClass( "bogus" ) );
+    assertTrue( hccl.ignoreClass( null ) );
+  }
+
+  @Test
+  public void ignoreClusterClasses_single_class() {
+    String ignoredClusterClasses = "org.apache.hadoop.security.rpcauth.MaprAuthMethod";
+    HadoopConfigurationClassLoader hccl =
+      new HadoopConfigurationClassLoader( ignoredClusterClasses, new URL[ 0 ], getClass().getClassLoader() );
+    assertTrue( hccl.ignoreClass( "org.apache.commons.log" ) );
+    assertTrue( hccl.ignoreClass( "org.apache.log4j" ) );
+    assertTrue( hccl.ignoreClass( "org.apache.log4j.Logger" ) );
+    assertTrue( hccl.ignoreClass( "org.apache.hadoop.security.rpcauth.MaprAuthMethod" ) );
+    assertFalse( hccl.ignoreClass( "bogus" ) );
+    assertTrue( hccl.ignoreClass( null ) );
+  }
+
+  @Test
+  public void ignoreClusterClasses_empty_first_arg() {
+    String ignoredClusterClasses = "";
+    HadoopConfigurationClassLoader hccl =
+      new HadoopConfigurationClassLoader( ignoredClusterClasses, new URL[ 0 ], getClass().getClassLoader() );
+    assertTrue( hccl.ignoreClass( "org.apache.commons.log" ) );
+    assertTrue( hccl.ignoreClass( "org.apache.log4j" ) );
+    assertTrue( hccl.ignoreClass( "org.apache.log4j.Logger" ) );
+    assertFalse( hccl.ignoreClass( "org.apache.hadoop.security.rpcauth.MaprAuthMethod" ) );
+    assertTrue( hccl.ignoreClass( null ) );
+  }
+
+  @Test
+  public void ignoreClusterClasses_null_first_arg() {
+    String ignoredClusterClasses = null;
+    HadoopConfigurationClassLoader hccl =
+      new HadoopConfigurationClassLoader( ignoredClusterClasses, new URL[ 0 ], getClass().getClassLoader() );
+    assertTrue( hccl.ignoreClass( "org.apache.commons.log" ) );
+    assertTrue( hccl.ignoreClass( "org.apache.log4j" ) );
+    assertTrue( hccl.ignoreClass( "org.apache.log4j.Logger" ) );
+    assertFalse( hccl.ignoreClass( "org.apache.hadoop.security.rpcauth.MaprAuthMethod" ) );
+    assertTrue( hccl.ignoreClass( null ) );
+  }
+
 }

--- a/api/src/test/java/org/pentaho/hadoop/shim/HadoopExcludeClusterJarsTest.java
+++ b/api/src/test/java/org/pentaho/hadoop/shim/HadoopExcludeClusterJarsTest.java
@@ -1,0 +1,176 @@
+/*******************************************************************************
+ * Pentaho Big Data
+ * <p>
+ * Copyright (C) 2002-2017 by Pentaho : http://www.pentaho.com
+ * <p>
+ * ******************************************************************************
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ ******************************************************************************/
+
+package org.pentaho.hadoop.shim;
+
+import org.apache.commons.vfs2.AllFileSelector;
+import org.apache.commons.vfs2.FileObject;
+import org.apache.commons.vfs2.FileType;
+import org.apache.commons.vfs2.VFS;
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+import java.io.File;
+import java.io.IOException;
+import java.net.URISyntaxException;
+import java.net.URL;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.util.Iterator;
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+
+public class HadoopExcludeClusterJarsTest {
+
+  private static String HADOOP_CLUSTER_JARS_PATH = System.getProperty( "java.io.tmpdir" ) + "/exclude-cluster-jars";
+  private static String PMR_PROPERTIES = "pmr.properties";
+  private static File pmrFolder;
+  private static URL urlTestResources;
+  private int count;
+
+
+  @ClassRule
+  public static TemporaryFolder tempFolder = new TemporaryFolder();
+
+  @BeforeClass
+  public static void setup() throws Exception {
+    // Create a test hadoop configuration
+    FileObject ramRootCluster = VFS.getManager().resolveFile( HADOOP_CLUSTER_JARS_PATH );
+
+    if ( ramRootCluster.exists() ) {
+      ramRootCluster.delete( new AllFileSelector() );
+    }
+    ramRootCluster.createFolder();
+
+    // Create the implementation jars
+    ramRootCluster.resolveFile( "hadoop-common-2.7.0-mapr-1607.jar" ).createFile();
+    ramRootCluster.resolveFile( "hadoop-mapreduce-client-core-2.7.0-mapr-1506.jar" ).createFile();
+
+    pmrFolder = tempFolder.newFolder( "pmr" );
+    urlTestResources = Thread.currentThread().getContextClassLoader().getResource( PMR_PROPERTIES );
+    Files.copy( Paths.get( urlTestResources.toURI() ), Paths.get( pmrFolder.getAbsolutePath(), PMR_PROPERTIES ) );
+  }
+
+  private void activatePmrFile() throws URISyntaxException, IOException {
+    if ( !Files.exists( Paths.get( urlTestResources.toURI() ) ) ) {
+      Files.copy( Paths.get( pmrFolder.getAbsolutePath(), PMR_PROPERTIES ), Paths.get( urlTestResources.toURI() ) );
+    }
+  }
+
+  private void disablePmrFile() throws URISyntaxException, IOException {
+    Files.deleteIfExists( Paths.get( urlTestResources.toURI() ) );
+  }
+
+  @Test
+  public void filterClusterJars_isPmrTrue_null_args() throws Exception {
+    HadoopConfigurationLocator locator = new HadoopConfigurationLocator();
+
+    activatePmrFile();
+    List<URL> list = locator.filterClusterJars( null, null );
+    assertNull( list );
+  }
+
+  @Test
+  public void filterClusterJars_isPmrTrue_arg_excludedJarsProperty_emptyString() throws Exception {
+    HadoopConfigurationLocator locator = new HadoopConfigurationLocator();
+
+    activatePmrFile();
+    FileObject root = VFS.getManager().resolveFile( HADOOP_CLUSTER_JARS_PATH );
+    List<URL> urls = locator.parseURLs( root, root.toString() );
+
+    count = urls.size();
+    List<URL> list = locator.filterClusterJars( urls, "" );
+    assertEquals( count, list.size() );
+  }
+
+  @Test
+  public void filterClusterJars_isPmrTrue_removeOnlyHadoopCommon() throws Exception {
+    HadoopConfigurationLocator locator = new HadoopConfigurationLocator();
+
+    activatePmrFile();
+    FileObject root = VFS.getManager().resolveFile( HADOOP_CLUSTER_JARS_PATH );
+    List<URL> urls = locator.parseURLs( root, root.toString() );
+    boolean containsJar = false;
+
+    count = urls.size();
+    List<URL> list = locator.filterClusterJars( urls, "hadoop-common" );
+    assertEquals( count - 1, list.size() );
+
+    for ( URL url : list ) {
+      if ( url.getPath().contains( "hadoop-common" ) ) {
+        containsJar = true;
+        break;
+      }
+    }
+    assertEquals( false, containsJar );
+  }
+
+  @Test
+  public void filterClusterJars_isPmrTrue_arg_urls_containsOnlyExcludedJars() throws Exception {
+    HadoopConfigurationLocator locator = new HadoopConfigurationLocator();
+
+    activatePmrFile();
+    FileObject root = VFS.getManager().resolveFile( HADOOP_CLUSTER_JARS_PATH );
+    List<URL> urls = locator.parseURLs( root, root.toString() );
+    Iterator<URL> iterator = urls.listIterator();
+    while ( iterator.hasNext() ) {
+      URL url = iterator.next();
+      if ( FileType.FOLDER.equals( root.resolveFile( url.toString().trim() ).getType() ) ) {
+        iterator.remove();
+      }
+    }
+
+    count = urls.size();
+    List<URL> list =
+      locator.filterClusterJars( urls, "hadoop-common-2.7.0-mapr-1607.jar,hadoop-client-2.7.0-mapr-1607.jar" );
+    assertEquals( 1, list.size() );
+  }
+
+  @Test
+  public void filterClusterJars_isPmrFalse_arg_excludedJarsProperty_emptyString() throws Exception {
+    HadoopConfigurationLocator locator = new HadoopConfigurationLocator();
+
+    try {
+      disablePmrFile();
+      FileObject root = VFS.getManager().resolveFile( HADOOP_CLUSTER_JARS_PATH );
+      List<URL> urls = locator.parseURLs( root, root.toString() );
+
+      count = urls.size();
+      List<URL> list = locator.filterClusterJars( urls, "" );
+      assertEquals( count, list.size() );
+    } finally {
+      activatePmrFile();
+    }
+  }
+
+  @Test
+  public void filterClusterJars_isPmrFalse_null_args() throws Exception {
+    HadoopConfigurationLocator locator = new HadoopConfigurationLocator();
+
+    try {
+      disablePmrFile();
+      List<URL> list = locator.filterClusterJars( null, null );
+      assertNull( list );
+    } finally {
+      activatePmrFile();
+    }
+  }
+}

--- a/api/src/test/java/org/pentaho/hadoop/shim/HadoopIgnoreClusterClassesTest.java
+++ b/api/src/test/java/org/pentaho/hadoop/shim/HadoopIgnoreClusterClassesTest.java
@@ -1,0 +1,86 @@
+/*******************************************************************************
+ * Pentaho Big Data
+ * <p>
+ * Copyright (C) 2002-2017 by Pentaho : http://www.pentaho.com
+ * <p>
+ * ******************************************************************************
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ ******************************************************************************/
+
+package org.pentaho.hadoop.shim;
+
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+import java.io.File;
+import java.io.IOException;
+import java.net.URISyntaxException;
+import java.net.URL;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+
+public class HadoopIgnoreClusterClassesTest {
+
+  private static String PMR_PROPERTIES = "pmr.properties";
+  private static File pmrFolder;
+  private static URL urlTestResources;
+
+
+  @ClassRule
+  public static TemporaryFolder tempFolder = new TemporaryFolder();
+
+  @BeforeClass
+  public static void setup() throws Exception {
+    pmrFolder = tempFolder.newFolder( "pmr" );
+    urlTestResources = Thread.currentThread().getContextClassLoader().getResource( PMR_PROPERTIES );
+    Files.copy( Paths.get( urlTestResources.toURI() ), Paths.get( pmrFolder.getAbsolutePath(), PMR_PROPERTIES ) );
+  }
+
+  private void activatePmrFile() throws URISyntaxException, IOException {
+    if ( !Files.exists( Paths.get( urlTestResources.toURI() ) ) ) {
+      Files.copy( Paths.get( pmrFolder.getAbsolutePath(), PMR_PROPERTIES ), Paths.get( urlTestResources.toURI() ) );
+    }
+  }
+
+  private void disablePmrFile() throws URISyntaxException, IOException {
+    Files.deleteIfExists( Paths.get( urlTestResources.toURI() ) );
+  }
+
+  @Test
+  public void isIgnoreClusterClassesPropertyNotEmpty_isPmrFalse() throws Exception {
+    HadoopConfigurationLocator locator = new HadoopConfigurationLocator();
+
+    try {
+      disablePmrFile();
+      assertFalse( locator.isIgnoreClusterClassesPropertyNotEmpty( null ) );
+      assertFalse( locator.isIgnoreClusterClassesPropertyNotEmpty( "" ) );
+      assertFalse( locator.isIgnoreClusterClassesPropertyNotEmpty( "hadoop-common" ) );
+    } finally {
+      activatePmrFile();
+    }
+  }
+
+  @Test
+  public void isIgnoreClusterClassesPropertyNotEmpty_isPmrTrue() throws Exception {
+    HadoopConfigurationLocator locator = new HadoopConfigurationLocator();
+
+    activatePmrFile();
+
+    assertFalse( locator.isIgnoreClusterClassesPropertyNotEmpty( null ) );
+    assertFalse( locator.isIgnoreClusterClassesPropertyNotEmpty( "" ) );
+    assertEquals( true, locator.isIgnoreClusterClassesPropertyNotEmpty( "hadoop-common" ) );
+  }
+}

--- a/api/src/test/resources/pmr.properties
+++ b/api/src/test/resources/pmr.properties
@@ -1,0 +1,3 @@
+isPmr=true
+maxTimeoutBeforeLoadingShim=300
+notificationsBeforeLoadingShim=1

--- a/shims/mapr520/assemblies/mapr520-shim/src/assembly/assembly.xml
+++ b/shims/mapr520/assemblies/mapr520-shim/src/assembly/assembly.xml
@@ -31,11 +31,6 @@
       <includes>
         <include>dk.brics.automaton:automaton</include>
         <include>pentaho:hadoop2-windows-patch</include>
-        <include>org.apache.hbase:hbase-client</include>
-        <include>org.apache.hbase:hbase-common</include>
-        <include>org.apache.hbase:hbase-hadoop-compat</include>
-        <include>org.apache.hbase:hbase-protocol</include>
-        <include>org.apache.hbase:hbase-server</include>
         <include>org.apache.hive:hive-common</include>
         <include>org.apache.hive:hive-exec</include>
         <include>org.apache.hive:hive-jdbc</include>
@@ -63,6 +58,11 @@
       <includes>
         <include>org.apache.htrace:htrace-core</include>
         <include>org.apache.zookeeper:zookeeper</include>
+        <include>org.apache.hbase:hbase-client</include>
+        <include>org.apache.hbase:hbase-common</include>
+        <include>org.apache.hbase:hbase-hadoop-compat</include>
+        <include>org.apache.hbase:hbase-protocol</include>
+        <include>org.apache.hbase:hbase-server</include>
       </includes>
       <excludes>
         <exclude>*:tests:*</exclude>

--- a/shims/mapr520/assemblies/mapr520-shim/src/main/resources/config.properties
+++ b/shims/mapr520/assemblies/mapr520-shim/src/main/resources/config.properties
@@ -19,6 +19,12 @@ linux.library.path=/opt/mapr/lib
 # Note, the two packages above are automatically included for all configurations
 ignored.classes=
 
+# Comma-separated list of classes or package names to explicitly ignore on the cluster side only when
+# loading classes from the resources within this Hadoop configuration directory
+# or the classpath property
+# e.g.: com.mapr.baseutils.BaseUtilsHelper,org.apache.commons.log
+ignore.cluster.classes=
+
 # Comma-separated list of jars to explicitly ignore when
 # loading classes from the resources within this Hadoop configuration directory
 # or the classpath property
@@ -26,6 +32,15 @@ ignored.classes=
 # with jar extension - xercesImpl-2.9.1.jar,xml-apis-1.3.04.jar
 # Note, the two jars above lead to libraries conflicts on Mapr 5.2 cluster so they are added to exclude.jars property below
 exclude.jars=xercesImpl,xml-apis
+
+# Comma-separated list of jars to explicitly ignore when
+# loading classes from the resources within this Hadoop configuration directory
+# or the classpath property on the cluster side
+# e.g.: without versions - hadoop-common or with versions - hadoop-common-2.7.0-mapr-1607 or
+# with jar extension - hadoop-common-2.7.0-mapr-1607.jar
+# Note, the jar above is excluded to keep HBase-related steps (including HBase Row Decoder Step) working
+#so this one is added to exclude.cluster.jars property below
+exclude.cluster.jars=hadoop-common
 
 # These are Windows-specific classpath and library paths. 
 # Please make sure to update the MapR versions in the paths to match your


### PR DESCRIPTION
To get all HBase-related steps working, including HBase Row decoder Step, I excluded hadoop-common-2.7.0-mapr-1602.jar from HadoopConfigurationClassLoader on the cluster side only and moved hbase-related jars (for HBase Row Decoder Step) from mapr520/lib folder to mapr520/lib/pmr folder.

To get PMR Hive step working on Secure Cluster I added ignore.cluster.classes property to avoid loading 
org.apache.hadoop.security.rpcauth.MaprAuthMethod class by HadoopConfigurationClassLoader.

Updated pentaho-hadoop-shims-api module:
 - added exclude.cluster.jars property to hadoop-shims-api module (HadoopConfigurationLocator class);
 - added ignore.cluster.classes property to hadoop-shims-api module (HadoopConfigurationLocator class);

Updated pentaho-hadoop-shims-mapr520 module:
 - moved hbase artifacts (shims/mapr520 module) from mapr520/lib folder to mapr520/lib/pmr folder;
 - updated config.properties file for mapr520 shim (added exclude.cluster.jars, ignore.cluster.jars properties).

See this PR with https://github.com/pentaho/pentaho-big-data-ee/pull/177