### PR TITLE
[BACKLOG-15823]-MapR 5.1/5.2: ClassNotFoundException when running MapReduce Job with mapper containing Hbase Row Decoder step

### DIFF
--- a/api/src/main/java/org/pentaho/hadoop/shim/HadoopConfigurationLocator.java
+++ b/api/src/main/java/org/pentaho/hadoop/shim/HadoopConfigurationLocator.java
@@ -1,7 +1,7 @@
 /*******************************************************************************
  * Pentaho Big Data
  * <p>
- * Copyright (C) 2002-2016 by Pentaho : http://www.pentaho.com
+ * Copyright (C) 2002-2017 by Pentaho : http://www.pentaho.com
  * <p>
  * ******************************************************************************
  * <p>
@@ -18,6 +18,7 @@
 package org.pentaho.hadoop.shim;
 
 import java.io.IOException;
+import java.io.InputStream;
 import java.lang.reflect.Field;
 import java.net.URL;
 import java.util.ArrayList;
@@ -34,6 +35,7 @@ import java.util.Map.Entry;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
+import com.google.common.annotations.VisibleForTesting;
 import org.apache.commons.vfs2.FileObject;
 import org.apache.commons.vfs2.FileSelectInfo;
 import org.apache.commons.vfs2.FileSelector;
@@ -75,6 +77,8 @@ public class HadoopConfigurationLocator implements HadoopConfigurationProvider {
   private static final String CONFIG_PROPERTY_LIBRARY_PATH = "library.path";
 
   private static final String CONFIG_PROPERTY_NAME = "name";
+
+  private static final String PMR_PROPERTIES = "pmr.properties";
 
   private static final URL[] EMPTY_URL_ARRAY = new URL[ 0 ];
 
@@ -333,6 +337,35 @@ public class HadoopConfigurationLocator implements HadoopConfigurationProvider {
     }
   }
 
+  private Properties getPmrProperties() {
+    InputStream pmrProperties = getClass().getClassLoader().getResourceAsStream(
+      PMR_PROPERTIES );
+    Properties properties = new Properties();
+    if ( pmrProperties != null ) {
+      try {
+        properties.load( pmrProperties );
+      } catch ( IOException ioe ) {
+        // pmr.properties not available
+      } finally {
+        if ( pmrProperties != null ) {
+          try {
+            pmrProperties.close();
+          } catch ( IOException e ) {
+            // pmr.properties not available
+          }
+        }
+      }
+    }
+    return properties;
+  }
+
+  @VisibleForTesting
+  boolean isRunningOnCluster() {
+    Properties pmrProperties = getPmrProperties();
+    String isPmr = pmrProperties.getProperty( "isPmr", "false" );
+    return ( "true".equals( isPmr ) );
+  }
+
   /**
    * Parse a set of URLs from a comma-separated list of URLs. If the URL points to a directory all jar files within that
    * directory will be returned as well.
@@ -393,9 +426,12 @@ public class HadoopConfigurationLocator implements HadoopConfigurationProvider {
     }
 
     try {
-      // Parse all URLs from an optional classpath from the configuration file
-      List<URL> classpathElements = parseURLs( folder,
-        configurationProperties.getProperty( CONFIG_PROPERTY_CLASSPATH ) );
+      List<URL> classpathElements = null;
+      if ( !isRunningOnCluster() ) {
+        // Parse all URLs from an optional classpath from the configuration file
+        classpathElements = parseURLs( folder,
+          configurationProperties.getProperty( CONFIG_PROPERTY_CLASSPATH ) );
+      }
 
       // Allow external configuration of classes to ignore
       String ignoredClassesProperty = configurationProperties

--- a/api/src/test/java/org/pentaho/hadoop/shim/HadoopRunningOnClusterTest.java
+++ b/api/src/test/java/org/pentaho/hadoop/shim/HadoopRunningOnClusterTest.java
@@ -1,0 +1,135 @@
+/*******************************************************************************
+ * Pentaho Big Data
+ * <p>
+ * Copyright (C) 2002-2017 by Pentaho : http://www.pentaho.com
+ * <p>
+ * ******************************************************************************
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ ******************************************************************************/
+
+package org.pentaho.hadoop.shim;
+
+import org.apache.commons.vfs2.AllFileSelector;
+import org.apache.commons.vfs2.FileObject;
+import org.apache.commons.vfs2.VFS;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+import java.io.File;
+import java.io.IOException;
+import java.net.URISyntaxException;
+import java.net.URL;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.util.List;
+
+public class HadoopRunningOnClusterTest {
+
+  private static String CONFIG_PROPERTY_CLASSPATH =
+    System.getProperty( "java.io.tmpdir" ) + "/opt/mapr/hadoop/hadoop-2.7.0/share/hadoop/mapreduce";
+  private int count;
+  private static String PMR_PROPERTIES = "pmr.properties";
+  private static File pmrFolder;
+  private static URL urlTestResources;
+
+
+  @ClassRule
+  public static TemporaryFolder tempFolder = new TemporaryFolder();
+
+  @BeforeClass
+  public static void setup() throws Exception {
+    // Create a test hadoop configuration
+    FileObject ramRoot = VFS.getManager().resolveFile( CONFIG_PROPERTY_CLASSPATH );
+    if ( ramRoot.exists() ) {
+      ramRoot.delete( new AllFileSelector() );
+    }
+    ramRoot.createFolder();
+
+    // Create the implementation jars
+    ramRoot.resolveFile( "hadoop-mapreduce-client-app-2.7.0-mapr-1602.jar" ).createFile();
+    ramRoot.resolveFile( "hadoop-mapreduce-client-common-2.7.0-mapr-1602.jar" ).createFile();
+    ramRoot.resolveFile( "hadoop-mapreduce-client-contrib-2.7.0-mapr-1602.jar" ).createFile();
+    ramRoot.resolveFile( "hadoop-mapreduce-client-core-2.7.0-mapr-1602.jar" ).createFile();
+    ramRoot.resolveFile( "hadoop-mapreduce-client-hs-2.7.0-mapr-1602.jar" ).createFile();
+
+    pmrFolder = tempFolder.newFolder( "pmr" );
+    urlTestResources = Thread.currentThread().getContextClassLoader().getResource( PMR_PROPERTIES );
+    Files.copy( Paths.get( urlTestResources.toURI() ), Paths.get( pmrFolder.getAbsolutePath(), PMR_PROPERTIES ) );
+  }
+
+  private void activatePmrFile() throws URISyntaxException, IOException {
+    if ( !Files.exists( Paths.get( urlTestResources.toURI() ) ) ) {
+      Files.copy( Paths.get( pmrFolder.getAbsolutePath(), PMR_PROPERTIES ), Paths.get( urlTestResources.toURI() ) );
+    }
+  }
+
+  private void disablePmrFile() throws URISyntaxException, IOException {
+    Files.deleteIfExists( Paths.get( urlTestResources.toURI() ) );
+  }
+
+  @Test
+  public void isRunningOnCluster_PmrFalse() throws Exception {
+    HadoopConfigurationLocator locator = new HadoopConfigurationLocator();
+
+    try {
+      disablePmrFile();
+      Assert.assertEquals( false, locator.isRunningOnCluster() );
+    } finally {
+      activatePmrFile();
+    }
+  }
+
+  @Test
+  public void isRunningOnCluster_PmrTrue() throws Exception {
+    HadoopConfigurationLocator locator = new HadoopConfigurationLocator();
+
+    activatePmrFile();
+    Assert.assertEquals( true, locator.isRunningOnCluster() );
+  }
+
+
+  @Test
+  public void runningLocally_withLinuxClassPathProperty() throws Exception {
+    HadoopConfigurationLocator locator = new HadoopConfigurationLocator();
+    FileObject folder = VFS.getManager().resolveFile( CONFIG_PROPERTY_CLASSPATH );
+
+    try {
+      disablePmrFile();
+      List<URL> classpathElements = null;
+      if ( !locator.isRunningOnCluster() ) {
+        classpathElements = locator.parseURLs( folder, folder.toString() );
+        count = classpathElements.size();
+      }
+      Assert.assertNotNull( classpathElements );
+      Assert.assertEquals( 6, count );
+    } finally {
+      activatePmrFile();
+    }
+  }
+
+  @Test
+  public void runningOnCluster_ignoreLinuxClassPathProperty() throws Exception {
+    HadoopConfigurationLocator locator = new HadoopConfigurationLocator();
+    FileObject folder = VFS.getManager().resolveFile( CONFIG_PROPERTY_CLASSPATH );
+
+    activatePmrFile();
+    List<URL> classpathElements = null;
+    if ( !locator.isRunningOnCluster() ) {
+      classpathElements = locator.parseURLs( folder, folder.toString() );
+      count = classpathElements.size();
+    }
+    Assert.assertEquals( null, classpathElements );
+    Assert.assertEquals( 0, count );
+  }
+}

--- a/api/src/test/resources/pmr.properties
+++ b/api/src/test/resources/pmr.properties
@@ -1,0 +1,3 @@
+isPmr=true
+maxTimeoutBeforeLoadingShim=300
+notificationsBeforeLoadingShim=1

--- a/shims/mapr520/assemblies/mapr520-shim/src/assembly/assembly.xml
+++ b/shims/mapr520/assemblies/mapr520-shim/src/assembly/assembly.xml
@@ -31,11 +31,6 @@
       <includes>
         <include>dk.brics.automaton:automaton</include>
         <include>pentaho:hadoop2-windows-patch</include>
-        <include>org.apache.hbase:hbase-client</include>
-        <include>org.apache.hbase:hbase-common</include>
-        <include>org.apache.hbase:hbase-hadoop-compat</include>
-        <include>org.apache.hbase:hbase-protocol</include>
-        <include>org.apache.hbase:hbase-server</include>
         <include>org.apache.hive:hive-common</include>
         <include>org.apache.hive:hive-exec</include>
         <include>org.apache.hive:hive-jdbc</include>
@@ -63,6 +58,12 @@
       <includes>
         <include>org.apache.htrace:htrace-core</include>
         <include>org.apache.zookeeper:zookeeper</include>
+        <include>org.apache.hbase:hbase-client</include>
+        <include>org.apache.hbase:hbase-common</include>
+        <include>org.apache.hbase:hbase-hadoop-compat</include>
+        <include>org.apache.hbase:hbase-protocol</include>
+        <include>org.apache.hbase:hbase-server</include>
+        <include>net.sf.flexjson:flexjson</include>
       </includes>
       <excludes>
         <exclude>*:tests:*</exclude>

--- a/shims/mapr520/impl/pom.xml
+++ b/shims/mapr520/impl/pom.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd" xmlns="http://maven.apache.org/POM/4.0.0"
-    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+<project xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd"
+         xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
   <modelVersion>4.0.0</modelVersion>
   <parent>
     <groupId>org.pentaho</groupId>
@@ -41,6 +42,7 @@
     <htrace-core.version>3.1.0-incubating</htrace-core.version>
     <org.apache.hive.shims.version>1.2.0-mapr-1609</org.apache.hive.shims.version>
     <org.apache.hbase.version>1.1.1-mapr-1602</org.apache.hbase.version>
+    <net.sf.flexjson>2.1</net.sf.flexjson>
     <jettison.version>1.1</jettison.version>
     <protobuf-java.version>2.5.0</protobuf-java.version>
     <org.apache.hive.version>1.2.0-mapr-1609</org.apache.hive.version>
@@ -236,6 +238,17 @@
       <artifactId>hbase-hadoop-compat</artifactId>
       <version>${org.apache.hbase.version}</version>
       <scope>compile</scope>
+      <exclusions>
+        <exclusion>
+          <artifactId>*</artifactId>
+          <groupId>*</groupId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+    <dependency>
+      <groupId>net.sf.flexjson</groupId>
+      <artifactId>flexjson</artifactId>
+      <version>${net.sf.flexjson}</version>
       <exclusions>
         <exclusion>
           <artifactId>*</artifactId>


### PR DESCRIPTION
To get all HBase-related steps working, including HBase Row decoder Step:
 - added isRunningOnCluster method to the HadoopConfigurationLocator class to avoid using linux.class.path  (from config.properties file) on the cluster side;

- moved hbase-related jars (for HBase Row Decoder Step) from mapr520/lib folder to mapr520/lib/pmr folder.

To get PMR-related steps working after previous changes I added new flexjson jar to mapr520/lib/pmr folder.

See this PR with https://github.com/pentaho/pentaho-big-data-ee/pull/177