### PR TITLE
[BACKLOG-15823]-MapR 5.1/5.2: ClassNotFoundException when running MapReduce Job with mapper containing Hbase Row Decoder step

### DIFF
--- a/shims/mapr510/assemblies/mapr510-shim/src/assembly/assembly.xml
+++ b/shims/mapr510/assemblies/mapr510-shim/src/assembly/assembly.xml
@@ -31,11 +31,6 @@
       <includes>
         <include>dk.brics.automaton:automaton</include>
         <include>pentaho:hadoop2-windows-patch</include>
-        <include>org.apache.hbase:hbase-client</include>
-        <include>org.apache.hbase:hbase-common</include>
-        <include>org.apache.hbase:hbase-hadoop-compat</include>
-        <include>org.apache.hbase:hbase-protocol</include>
-        <include>org.apache.hbase:hbase-server</include>
         <include>org.apache.hive:hive-common</include>
         <include>org.apache.hive:hive-exec</include>
         <include>org.apache.hive:hive-jdbc</include>
@@ -63,6 +58,12 @@
       <includes>
         <include>org.apache.htrace:htrace-core</include>
         <include>org.apache.zookeeper:zookeeper</include>
+        <include>org.apache.hbase:hbase-client</include>
+        <include>org.apache.hbase:hbase-common</include>
+        <include>org.apache.hbase:hbase-hadoop-compat</include>
+        <include>org.apache.hbase:hbase-protocol</include>
+        <include>org.apache.hbase:hbase-server</include>
+        <include>net.sf.flexjson:flexjson</include>
       </includes>
       <excludes>
         <exclude>*:tests:*</exclude>

--- a/shims/mapr510/impl/pom.xml
+++ b/shims/mapr510/impl/pom.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd" xmlns="http://maven.apache.org/POM/4.0.0"
-    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+<project xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd"
+         xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
   <modelVersion>4.0.0</modelVersion>
   <parent>
     <groupId>org.pentaho</groupId>
@@ -41,6 +42,7 @@
     <javax.xml.stream.version>1.0-2</javax.xml.stream.version>
     <org.mortbay.jetty.version>6.1.26</org.mortbay.jetty.version>
     <org.apache.hbase.version>1.1.1-mapr-1602</org.apache.hbase.version>
+    <net.sf.flexjson>2.1</net.sf.flexjson>
     <com.google.inject.extensions.version>3.0</com.google.inject.extensions.version>
     <com.google.inject.version>3.0</com.google.inject.version>
     <org.fusesource.leveldbjni.version>1.8</org.fusesource.leveldbjni.version>
@@ -236,6 +238,17 @@
       <artifactId>hbase-hadoop-compat</artifactId>
       <version>${org.apache.hbase.version}</version>
       <scope>compile</scope>
+      <exclusions>
+        <exclusion>
+          <artifactId>*</artifactId>
+          <groupId>*</groupId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+    <dependency>
+      <groupId>net.sf.flexjson</groupId>
+      <artifactId>flexjson</artifactId>
+      <version>${net.sf.flexjson}</version>
       <exclusions>
         <exclusion>
           <artifactId>*</artifactId>


### PR DESCRIPTION
As pentaho-hadoop-shims-api module was changed to keep HBase Row Decoder Step and PMR-related jobs working on mapr52 Shim (https://github.com/pentaho/pentaho-hadoop-shims/pull/477), and these changes affect mapr510 shim, so the same changes are added to mapr510 shim to keep PMR-related steps and HBase Row Decoder Step working.

Moved hbase-related jars (for HBase Row Decoder Step) from mapr510/lib folder to mapr510/lib/pmr folder.

To get PMR-related steps working after previous changes I added new flexjson jar to mapr510/lib/pmr folder.

See this PR with https://github.com/pentaho/pentaho-big-data-ee/pull/181