### PR TITLE
[BAD-640] MapR/EMR Shims: incorrect ignored.classes property name. Ha…

### DIFF
--- a/api/src/main/java/org/pentaho/hadoop/shim/HadoopConfigurationLocator.java
+++ b/api/src/main/java/org/pentaho/hadoop/shim/HadoopConfigurationLocator.java
@@ -36,6 +36,7 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 import com.google.common.annotations.VisibleForTesting;
+import org.apache.commons.lang.StringUtils;
 import org.apache.commons.vfs2.FileObject;
 import org.apache.commons.vfs2.FileSelectInfo;
 import org.apache.commons.vfs2.FileSelector;
@@ -437,7 +438,7 @@ public class HadoopConfigurationLocator implements HadoopConfigurationProvider {
       String ignoredClassesProperty = configurationProperties
         .getProperty( CONFIG_PROPERTY_IGNORE_CLASSES );
       String[] ignoredClasses = null;
-      if ( ignoredClassesProperty != null ) {
+      if ( !StringUtils.isEmpty( ignoredClassesProperty ) ) {
         ignoredClasses = ignoredClassesProperty.split( "," );
       }
 

--- a/api/src/test/java/org/pentaho/hadoop/shim/HadoopConfigurationLocatorTest.java
+++ b/api/src/test/java/org/pentaho/hadoop/shim/HadoopConfigurationLocatorTest.java
@@ -2,7 +2,7 @@
  *
  * Pentaho Big Data
  *
- * Copyright (C) 2002-2016 by Pentaho : http://www.pentaho.com
+ * Copyright (C) 2002-2017 by Pentaho : http://www.pentaho.com
  *
  *******************************************************************************
  *
@@ -70,6 +70,7 @@ public class HadoopConfigurationLocatorTest {
     Properties p = new Properties();
     p.setProperty( "name", "Test Configuration A" );
     p.setProperty( "classpath", "" );
+    p.setProperty( "ignore.classes", "" );
     p.setProperty( "library.path", "" );
     p.setProperty( "required.classes", HadoopConfigurationLocatorTest.class.getName() );
     p.store( configFile.getContent().getOutputStream(), "Test Configuration A" );
@@ -282,6 +283,16 @@ public class HadoopConfigurationLocatorTest {
     buildProperties.createFile();
     assertEquals( FileType.FILE, buildProperties.getType() );
     locator.createConfigurationLoader( buildProperties, null, null, new ShimProperties() );
+  }
+
+  @Test
+  public void loadHadoopConfiguration_with_ignore_classes() throws Exception {
+    HadoopConfigurationLocator locator = new HadoopConfigurationLocator();
+
+    FileObject root = VFS.getManager().resolveFile( HADOOP_CONFIGURATIONS_PATH + "/a" );
+    HadoopConfiguration configuration = locator.loadHadoopConfiguration( root );
+
+    assertNotNull( configuration );
   }
 
   @Test

--- a/shims/emr52/assemblies/emr52-shim/src/main/resources/config.properties
+++ b/shims/emr52/assemblies/emr52-shim/src/main/resources/config.properties
@@ -14,5 +14,5 @@ library.path=
 # or the classpath property
 # e.g.: org.apache.commons.log,org.apache.log4j
 # Note, the two packages above are automatically included for all configurations
-ignored.classes=com.ctc.wstx.stax
+ignore.classes=com.ctc.wstx.stax
 

--- a/shims/emr531/assemblies/emr531-shim/src/main/resources/config.properties
+++ b/shims/emr531/assemblies/emr531-shim/src/main/resources/config.properties
@@ -14,5 +14,5 @@ library.path=
 # or the classpath property
 # e.g.: org.apache.commons.log,org.apache.log4j
 # Note, the two packages above are automatically included for all configurations
-ignored.classes=com.ctc.wstx.stax
+ignore.classes=com.ctc.wstx.stax
 

--- a/shims/mapr510/assemblies/mapr510-shim/src/main/resources/config.properties
+++ b/shims/mapr510/assemblies/mapr510-shim/src/main/resources/config.properties
@@ -17,7 +17,7 @@ linux.library.path=/opt/mapr/lib
 # or the classpath property
 # e.g.: org.apache.commons.log,org.apache.log4j
 # Note, the two packages above are automatically included for all configurations
-ignored.classes=
+ignore.classes=
 
 # Comma-separated list of jars to explicitly ignore when
 # loading classes from the resources within this Hadoop configuration directory

--- a/shims/mapr520/assemblies/mapr520-shim/src/main/resources/config.properties
+++ b/shims/mapr520/assemblies/mapr520-shim/src/main/resources/config.properties
@@ -17,7 +17,7 @@ linux.library.path=/opt/mapr/lib
 # or the classpath property
 # e.g.: org.apache.commons.log,org.apache.log4j
 # Note, the two packages above are automatically included for all configurations
-ignored.classes=
+ignore.classes=
 
 # Comma-separated list of jars to explicitly ignore when
 # loading classes from the resources within this Hadoop configuration directory


### PR DESCRIPTION
…doop Cluster Test fails when ignore.classes property exists but is not set

- change ignored.classes property to ignore.classes
- add check for empty property
- add unit test