### PR TITLE
[BAD-663]-Security reveal of settings in config.properties for cdh shims in 7.0, 7.1

### DIFF
--- a/shims/cdh510/assemblies/cdh510-shim/src/main/resources/config.properties
+++ b/shims/cdh510/assemblies/cdh510-shim/src/main/resources/config.properties
@@ -16,28 +16,3 @@ library.path=
 ignore.classes=org.apache.derby.iapi.services
 mr1.java.system.hadoop.cluster.path.separator=:
 #
-
-#
-# SECURE AUTHENTICATION
-#
-# Kerberos Authentication
-pentaho.authentication.default.kerberos.principal=exampleUser@EXAMPLE.COM
-# Please define one of the following: 
-pentaho.authentication.default.kerberos.keytabLocation=
-pentaho.authentication.default.kerberos.password=
-#
-# Secure Impersonation
-# Please choose one of the following:
-# disabled - when using an unsecured cluster
-# simple - when using a 1 to 1 mapping from the server to your cluster
-pentaho.authentication.default.mapping.impersonation.type=disabled
-pentaho.authentication.default.mapping.server.credentials.kerberos.principal=exampleUser@EXAMPLE.COM
-# Please define one of the following: 
-pentaho.authentication.default.mapping.server.credentials.kerberos.keytabLocation=
-pentaho.authentication.default.mapping.server.credentials.kerberos.password=
-#
-
-#
-#
-# OOZIE
-pentaho.oozie.proxy.user=oozie

--- a/shims/cdh59/assemblies/cdh59-shim/src/main/resources/config.properties
+++ b/shims/cdh59/assemblies/cdh59-shim/src/main/resources/config.properties
@@ -16,28 +16,3 @@ library.path=
 ignore.classes=org.apache.derby.iapi.services
 mr1.java.system.hadoop.cluster.path.separator=:
 #
-
-#
-# SECURE AUTHENTICATION
-#
-# Kerberos Authentication
-pentaho.authentication.default.kerberos.principal=exampleUser@EXAMPLE.COM
-# Please define one of the following: 
-pentaho.authentication.default.kerberos.keytabLocation=
-pentaho.authentication.default.kerberos.password=
-#
-# Secure Impersonation
-# Please choose one of the following:
-# disabled - when using an unsecured cluster
-# simple - when using a 1 to 1 mapping from the server to your cluster
-pentaho.authentication.default.mapping.impersonation.type=disabled
-pentaho.authentication.default.mapping.server.credentials.kerberos.principal=exampleUser@EXAMPLE.COM
-# Please define one of the following: 
-pentaho.authentication.default.mapping.server.credentials.kerberos.keytabLocation=
-pentaho.authentication.default.mapping.server.credentials.kerberos.password=
-#
-
-#
-#
-# OOZIE
-pentaho.oozie.proxy.user=oozie


### PR DESCRIPTION
Removed security properties from config.ptoperties files for both cdh59 and cdh510 CE shims.