### PR TITLE
[COMP-5866]-update json-smart artifact version property

### DIFF
--- a/shims/hdp25/assemblies/hdp25-shim/pom.xml
+++ b/shims/hdp25/assemblies/hdp25-shim/pom.xml
@@ -26,17 +26,6 @@
       <artifactId>pentaho-hadoop-shims-hdp25-hbase-comparators</artifactId>
       <version>${project.version}</version>
     </dependency>
-    <dependency>
-      <groupId>org.apache.knox</groupId>
-      <artifactId>gateway-shell</artifactId>
-      <version>0.12.0.2.6.0.3-8</version>
-    </dependency> 
-    <dependency>
-      <groupId>org.apache.httpcomponents</groupId>
-      <artifactId>httpclient</artifactId>
-      <version>4.4</version>
-      <scope>runtime</scope>
-    </dependency>  
   </dependencies>
   <build>
     <plugins>

--- a/shims/hdp25/assemblies/hdp25-shim/src/assembly/assembly.xml
+++ b/shims/hdp25/assemblies/hdp25-shim/src/assembly/assembly.xml
@@ -107,6 +107,7 @@
         <include>org.slf4j:slf4j-log4j12</include>
         <include>org.antlr:stringtemplate</include>
         <include>javax.transaction:transaction-api</include>
+        <include>org.apache.knox:gateway-shell</include>
         <!-- Transitive MVN Dependencies -->
         <include>org.apache.hive:hive-jdbc</include>
         <!-- Transitive ANT Dependencies -->
@@ -127,15 +128,6 @@
       <excludes>
         <exclude>*:tests:*</exclude>
       </excludes>
-    </dependencySet>
-    <dependencySet>
-      <outputDirectory>lib</outputDirectory>
-      <useTransitiveDependencies>false</useTransitiveDependencies>
-      <useTransitiveFiltering>false</useTransitiveFiltering>
-      <scope>runtime</scope>
-      <includes>
-        <include>org.apache.knox:gateway-shell</include>
-      </includes>
     </dependencySet>
     <dependencySet>
       <outputDirectory>lib/client</outputDirectory>

--- a/shims/hdp25/impl/pom.xml
+++ b/shims/hdp25/impl/pom.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd" xmlns="http://maven.apache.org/POM/4.0.0"
-    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+<project xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd"
+         xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
   <modelVersion>4.0.0</modelVersion>
   <parent>
     <groupId>org.pentaho</groupId>
@@ -48,6 +49,8 @@
     <org.javassist.version>3.18.1-GA</org.javassist.version>
     <log4j.version>1.2.17</log4j.version>
     <org.apache.derby.version>10.10.2.0</org.apache.derby.version>
+    <gateway-shell>0.12.0.2.6.0.3-8</gateway-shell>
+    <json-smart>1.1.1</json-smart>
   </properties>
   <dependencies>
     <dependency>
@@ -374,6 +377,28 @@
       <artifactId>xstream</artifactId>
       <version>${com.thoughtworks.xstream.version}</version>
       <scope>provided</scope>
+      <exclusions>
+        <exclusion>
+          <artifactId>*</artifactId>
+          <groupId>*</groupId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.knox</groupId>
+      <artifactId>gateway-shell</artifactId>
+      <version>${gateway-shell}</version>
+      <exclusions>
+        <exclusion>
+          <artifactId>*</artifactId>
+          <groupId>*</groupId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+    <dependency>
+      <groupId>net.minidev</groupId>
+      <artifactId>json-smart</artifactId>
+      <version>${json-smart}</version>
       <exclusions>
         <exclusion>
           <artifactId>*</artifactId>

--- a/shims/hdp26/assemblies/default/src/assembly/assembly.xml
+++ b/shims/hdp26/assemblies/default/src/assembly/assembly.xml
@@ -21,6 +21,8 @@
         <include>org.codehaus.jackson:jackson-core-asl</include>
         <include>org.codehaus.jackson:jackson-mapper-asl</include>
         <include>org.apache.avro:avro</include>
+        <include>org.apache.httpcomponents:httpclient</include>
+        <include>org.apache.knox:gateway-shell</include>
       </includes>
       <excludes>
         <exclude>log4j:log4j</exclude>

--- a/shims/hdp26/assemblies/hdp26-shim/pom.xml
+++ b/shims/hdp26/assemblies/hdp26-shim/pom.xml
@@ -44,17 +44,6 @@
       <artifactId>pentaho-hadoop-shims-hdp26-hbase-comparators</artifactId>
       <version>${project.version}</version>                                
     </dependency>
-    <dependency>
-      <groupId>org.apache.httpcomponents</groupId>
-      <artifactId>httpclient</artifactId>
-      <version>4.4</version>
-      <scope>runtime</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.apache.knox</groupId>
-      <artifactId>gateway-shell</artifactId>
-      <version>0.12.0.2.6.0.3-8</version>
-    </dependency>                                                      
   </dependencies>
   <build>
     <plugins>

--- a/shims/hdp26/assemblies/hdp26-shim/src/assembly/assembly.xml
+++ b/shims/hdp26/assemblies/hdp26-shim/src/assembly/assembly.xml
@@ -28,14 +28,5 @@
         <include>org.pentaho:pentaho-hadoop-shims-hdp26-hbase-comparators</include> 
       </includes>
     </dependencySet>
-    <dependencySet>
-      <outputDirectory>lib</outputDirectory>
-      <useTransitiveDependencies>false</useTransitiveDependencies>
-      <scope>runtime</scope>
-      <includes>
-        <include>org.apache.httpcomponents:httpclient</include>
-        <include>org.apache.knox:gateway-shell</include>
-      </includes>
-    </dependencySet>
   </dependencySets>
 </assembly>

--- a/shims/hdp26/default/pom.xml
+++ b/shims/hdp26/default/pom.xml
@@ -97,5 +97,16 @@
       <artifactId>hive-jdbc</artifactId>
       <version>${hive-jdbc.version}</version>
     </dependency>
+    <dependency>
+      <groupId>org.apache.knox</groupId>
+      <artifactId>gateway-shell</artifactId>
+      <version>${gateway-shell}</version>
+      <exclusions>
+        <exclusion>
+          <groupId>*</groupId>
+          <artifactId>*</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
   </dependencies>
 </project>

--- a/shims/hdp26/pom.xml
+++ b/shims/hdp26/pom.xml
@@ -13,6 +13,7 @@
     <!-- default folder -->
     <automaton.version>1.11-8</automaton.version>
     <pig.version>0.16.0.2.6.0.3-8</pig.version>
+    <gateway-shell>0.12.0.2.6.0.3-8</gateway-shell>
     <dependency.pig.classifier>h2</dependency.pig.classifier>
     <org.apache.oozie.version>4.2.0.2.6.0.3-8</org.apache.oozie.version>
     <hadoop2-windows-patch.version>08072014</hadoop2-windows-patch.version>


### PR DESCRIPTION
After this pull request https://github.com/pentaho/pentaho-hadoop-shims/pull/485/files some new additional unwanted components appeared in hdp25 and hdp26 Shims:
 - zookeeper-3.4.6.2.6.0.3-8.jar in assembly archive hdp26/lib folder;
 - apacheds-i18n-2.0.0-M5.jar instead of apacheds-i18n-2.0.0-M15.jar in assembly archive hdp25/lib/client;
 - json-smart-1.2.jar instead of json-smart-1.1.1.jar  in assembly archive hdp25/lib/client.

I updated the pull request to avoid adding these unwanted artifacts to assembly archive.