### PR TITLE
[SP-3533][BAD-640] MapR/EMR Shims: incorrect ignored.classes property…

### DIFF
--- a/api/src/org/pentaho/hadoop/shim/HadoopConfigurationLocator.java
+++ b/api/src/org/pentaho/hadoop/shim/HadoopConfigurationLocator.java
@@ -1,7 +1,7 @@
 /*******************************************************************************
  * Pentaho Big Data
  * <p>
- * Copyright (C) 2002-2016 by Pentaho : http://www.pentaho.com
+ * Copyright (C) 2002-2017 by Pentaho : http://www.pentaho.com
  * <p>
  * ******************************************************************************
  * <p>
@@ -34,6 +34,7 @@ import java.util.Map.Entry;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
+import org.apache.commons.lang.StringUtils;
 import org.apache.commons.vfs2.FileObject;
 import org.apache.commons.vfs2.FileSelectInfo;
 import org.apache.commons.vfs2.FileSelector;
@@ -401,7 +402,7 @@ public class HadoopConfigurationLocator implements HadoopConfigurationProvider {
       String ignoredClassesProperty = configurationProperties
         .getProperty( CONFIG_PROPERTY_IGNORE_CLASSES );
       String[] ignoredClasses = null;
-      if ( ignoredClassesProperty != null ) {
+      if ( !StringUtils.isEmpty( ignoredClassesProperty ) ) {
         ignoredClasses = ignoredClassesProperty.split( "," );
       }
 

--- a/api/test-src/org/pentaho/hadoop/shim/HadoopConfigurationLocatorTest.java
+++ b/api/test-src/org/pentaho/hadoop/shim/HadoopConfigurationLocatorTest.java
@@ -2,7 +2,7 @@
  *
  * Pentaho Big Data
  *
- * Copyright (C) 2002-2015 by Pentaho : http://www.pentaho.com
+ * Copyright (C) 2002-2017 by Pentaho : http://www.pentaho.com
  *
  *******************************************************************************
  *
@@ -46,8 +46,6 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Properties;
 
-import static org.junit.Assert.*;
-
 public class HadoopConfigurationLocatorTest {
 
   private static String HADOOP_CONFIGURATIONS_PATH = System.getProperty( "java.io.tmpdir" ) + "/hadoop-configurations";
@@ -63,13 +61,14 @@ public class HadoopConfigurationLocatorTest {
     }
     aConfigFolder.createFolder();
 
-    assertEquals( FileType.FOLDER, aConfigFolder.getType() );
+    Assert.assertEquals( FileType.FOLDER, aConfigFolder.getType() );
 
     // Create the properties file for the configuration as hadoop-configurations/a/config.properties
     configFile = aConfigFolder.resolveFile( "config.properties" );
     Properties p = new Properties();
     p.setProperty( "name", "Test Configuration A" );
     p.setProperty( "classpath", "" );
+    p.setProperty( "ignore.classes", "" );
     p.setProperty( "library.path", "" );
     p.setProperty( "required.classes", HadoopConfigurationLocatorTest.class.getName() );
     p.store( configFile.getContent().getOutputStream(), "Test Configuration A" );
@@ -131,9 +130,9 @@ public class HadoopConfigurationLocatorTest {
         new DefaultFileSystemManager() );
       Assert.fail( "Should have got exception " );
     } catch ( ConfigurationException e ) {
-      assertEquals(
-        "Unable to load class this.class.does.not.Exist that is required to start the Test Configuration A Hadoop Shim"
-        , e.getCause().getMessage() );
+      Assert.assertEquals(
+        "Unable to load class this.class.does.not.Exist that is required to start the Test Configuration A Hadoop Shim",
+        e.getCause().getMessage() );
     } finally {
       properties.setProperty( "required.classes", HadoopConfigurationLocator.class.getName() );
       properties.store( configFile.getContent().getOutputStream(), "Test Configuration A" );
@@ -147,8 +146,8 @@ public class HadoopConfigurationLocatorTest {
       new MockActiveHadoopConfigurationLocator( "a" ),
       new DefaultFileSystemManager() );
 
-    assertEquals( 1, locator.getConfigurations().size() );
-    assertEquals( VFS.getManager().resolveFile( HADOOP_CONFIGURATIONS_PATH ).resolveFile( "a" ),
+    Assert.assertEquals( 1, locator.getConfigurations().size() );
+    Assert.assertEquals( VFS.getManager().resolveFile( HADOOP_CONFIGURATIONS_PATH ).resolveFile( "a" ),
       locator.getConfiguration( "a" ).getLocation() );
   }
 
@@ -159,7 +158,7 @@ public class HadoopConfigurationLocatorTest {
       new MockActiveHadoopConfigurationLocator( "a" ),
       new DefaultFileSystemManager() );
 
-    assertTrue( locator.hasConfiguration( "a" ) );
+    Assert.assertTrue( locator.hasConfiguration( "a" ) );
   }
 
   @Test( expected = RuntimeException.class )
@@ -176,9 +175,9 @@ public class HadoopConfigurationLocatorTest {
       new DefaultFileSystemManager() );
 
     HadoopConfiguration a = locator.getConfiguration( "a" );
-    assertNotNull( a );
-    assertEquals( "a", a.getIdentifier() );
-    assertEquals( "Test Configuration A", a.getName() );
+    Assert.assertNotNull( a );
+    Assert.assertEquals( "a", a.getIdentifier() );
+    Assert.assertEquals( "Test Configuration A", a.getName() );
   }
 
   @Test( expected = ConfigurationException.class )
@@ -211,7 +210,7 @@ public class HadoopConfigurationLocatorTest {
       new DefaultFileSystemManager() );
 
     HadoopConfiguration a = locator.getActiveConfiguration();
-    assertNotNull( a );
+    Assert.assertNotNull( a );
   }
 
 
@@ -239,8 +238,8 @@ public class HadoopConfigurationLocatorTest {
     f.setAccessible( true );
     try {
       String[] usrPaths = (String[]) f.get( null );
-      assertTrue( Arrays.asList( usrPaths ).contains( "test" ) );
-      assertTrue( Arrays.asList( usrPaths ).contains( "ing" ) );
+      Assert.assertTrue( Arrays.asList( usrPaths ).contains( "test" ) );
+      Assert.assertTrue( Arrays.asList( usrPaths ).contains( "ing" ) );
     } finally {
       f.setAccessible( accessible );
     }
@@ -260,9 +259,9 @@ public class HadoopConfigurationLocatorTest {
       int pathCount = usrPaths.length;
       locator.registerNativeLibraryPaths( "ing" );
       usrPaths = (String[]) f.get( null );
-      assertTrue( Arrays.asList( usrPaths ).contains( "test" ) );
-      assertTrue( Arrays.asList( usrPaths ).contains( "ing" ) );
-      assertEquals( pathCount, usrPaths.length );
+      Assert.assertTrue( Arrays.asList( usrPaths ).contains( "test" ) );
+      Assert.assertTrue( Arrays.asList( usrPaths ).contains( "ing" ) );
+      Assert.assertEquals( pathCount, usrPaths.length );
     } finally {
       f.setAccessible( accessible );
     }
@@ -280,8 +279,18 @@ public class HadoopConfigurationLocatorTest {
     // Try to create a configuration based on a file, not a folder
     FileObject buildProperties = VFS.getManager().resolveFile( "ram:///test.file" );
     buildProperties.createFile();
-    assertEquals( FileType.FILE, buildProperties.getType() );
+    Assert.assertEquals( FileType.FILE, buildProperties.getType() );
     locator.createConfigurationLoader( buildProperties, null, null, new ShimProperties() );
+  }
+
+  @Test
+  public void loadHadoopConfiguration_with_ignore_classes() throws Exception {
+    HadoopConfigurationLocator locator = new HadoopConfigurationLocator();
+
+    FileObject root = VFS.getManager().resolveFile( HADOOP_CONFIGURATIONS_PATH + "/a" );
+    HadoopConfiguration configuration = locator.loadHadoopConfiguration( root );
+
+    Assert.assertNotNull( configuration );
   }
 
   @Test
@@ -291,7 +300,7 @@ public class HadoopConfigurationLocatorTest {
     FileObject root = VFS.getManager().resolveFile( HADOOP_CONFIGURATIONS_PATH + "/a" );
     ClassLoader cl = locator.createConfigurationLoader( root, getClass().getClassLoader(), null, new ShimProperties() );
 
-    assertNotNull( cl.getResource( "config.properties" ) );
+    Assert.assertNotNull( cl.getResource( "config.properties" ) );
   }
 
   @Test( expected = ConfigurationException.class )
@@ -311,8 +320,8 @@ public class HadoopConfigurationLocatorTest {
     FileObject root = VFS.getManager().resolveFile( HADOOP_CONFIGURATIONS_PATH );
 
     List<URL> urls = locator.parseURLs( root, "a,b" );
-    assertEquals( 2, urls.size() );
-    assertEquals( root.getURL().toURI().resolve( "hadoop-configurations/a/" ), urls.get( 0 ).toURI() );
-    assertEquals( root.getURL().toURI().resolve( "hadoop-configurations/a/a-config.jar" ), urls.get( 1 ).toURI() );
+    Assert.assertEquals( 2, urls.size() );
+    Assert.assertEquals( root.getURL().toURI().resolve( "hadoop-configurations/a/" ), urls.get( 0 ).toURI() );
+    Assert.assertEquals( root.getURL().toURI().resolve( "hadoop-configurations/a/a-config.jar" ), urls.get( 1 ).toURI() );
   }
 }

--- a/cdh3u4/package-res/config.properties
+++ b/cdh3u4/package-res/config.properties
@@ -14,4 +14,4 @@ library.path=
 # or the classpath property
 # e.g.: org.apache.commons.log,org.apache.log4j
 # Note, the two packages above are automatically included for all configurations
-ignored.classes=
+ignore.classes=

--- a/cdh4/package-res/config.properties
+++ b/cdh4/package-res/config.properties
@@ -14,4 +14,4 @@ library.path=
 # or the classpath property
 # e.g.: org.apache.commons.log,org.apache.log4j
 # Note, the two packages above are automatically included for all configurations
-ignored.classes=
+ignore.classes=

--- a/cdh412/package-res/config.properties
+++ b/cdh412/package-res/config.properties
@@ -14,4 +14,4 @@ library.path=
 # or the classpath property
 # e.g.: org.apache.commons.log,org.apache.log4j
 # Note, the two packages above are automatically included for all configurations
-ignored.classes=
+ignore.classes=

--- a/cdh413/package-res/config.properties
+++ b/cdh413/package-res/config.properties
@@ -14,4 +14,4 @@ library.path=
 # or the classpath property
 # e.g.: org.apache.commons.log,org.apache.log4j
 # Note, the two packages above are automatically included for all configurations
-ignored.classes=
+ignore.classes=

--- a/cdh42/package-res/config.properties
+++ b/cdh42/package-res/config.properties
@@ -14,4 +14,4 @@ library.path=
 # or the classpath property
 # e.g.: org.apache.commons.log,org.apache.log4j
 # Note, the two packages above are automatically included for all configurations
-ignored.classes=
+ignore.classes=

--- a/cdh47/package-res/config.properties
+++ b/cdh47/package-res/config.properties
@@ -14,4 +14,4 @@ library.path=
 # or the classpath property
 # e.g.: org.apache.commons.log,org.apache.log4j
 # Note, the two packages above are automatically included for all configurations
-ignored.classes=
+ignore.classes=

--- a/cdh50beta/package-res/config.properties
+++ b/cdh50beta/package-res/config.properties
@@ -14,7 +14,7 @@ library.path=
 # or the classpath property
 # e.g.: org.apache.commons.log,org.apache.log4j
 # Note, the two packages above are automatically included for all configurations
-ignored.classes=org.apache.derby.iapi.services.monitor
+ignore.classes=org.apache.derby.iapi.services.monitor
 
 shim.current.config=mr2
 

--- a/emr310/package-res/config.properties
+++ b/emr310/package-res/config.properties
@@ -14,5 +14,5 @@ library.path=
 # or the classpath property
 # e.g.: org.apache.commons.log,org.apache.log4j
 # Note, the two packages above are automatically included for all configurations
-ignored.classes=com.ctc.wstx.stax
+ignore.classes=com.ctc.wstx.stax
 

--- a/emr34/package-res/config.properties
+++ b/emr34/package-res/config.properties
@@ -14,5 +14,5 @@ library.path=
 # or the classpath property
 # e.g.: org.apache.commons.log,org.apache.log4j
 # Note, the two packages above are automatically included for all configurations
-ignored.classes=com.ctc.wstx.stax
+ignore.classes=com.ctc.wstx.stax
 

--- a/emr41/package-res/config.properties
+++ b/emr41/package-res/config.properties
@@ -14,5 +14,5 @@ library.path=
 # or the classpath property
 # e.g.: org.apache.commons.log,org.apache.log4j
 # Note, the two packages above are automatically included for all configurations
-ignored.classes=com.ctc.wstx.stax
+ignore.classes=com.ctc.wstx.stax
 

--- a/emr46/package-res/config.properties
+++ b/emr46/package-res/config.properties
@@ -14,5 +14,5 @@ library.path=
 # or the classpath property
 # e.g.: org.apache.commons.log,org.apache.log4j
 # Note, the two packages above are automatically included for all configurations
-ignored.classes=com.ctc.wstx.stax
+ignore.classes=com.ctc.wstx.stax
 

--- a/hadoop-20/package-res/config.properties
+++ b/hadoop-20/package-res/config.properties
@@ -14,4 +14,4 @@ library.path=
 # or the classpath property
 # e.g.: org.apache.commons.log,org.apache.log4j
 # Note, the two packages above are automatically included for all configurations
-ignored.classes=
+ignore.classes=

--- a/idh23/package-res/config.properties
+++ b/idh23/package-res/config.properties
@@ -14,4 +14,4 @@ library.path=
 # or the classpath property
 # e.g.: org.apache.commons.log,org.apache.log4j
 # Note, the two packages above are automatically included for all configurations
-ignored.classes=
+ignore.classes=

--- a/mapr/package-res/config.properties
+++ b/mapr/package-res/config.properties
@@ -14,7 +14,7 @@ library.path=/opt/mapr/lib
 # or the classpath property
 # e.g.: org.apache.commons.log,org.apache.log4j
 # Note, the two packages above are automatically included for all configurations
-ignored.classes=
+ignore.classes=
 
 # These are Windows-specific classpath and library paths. Please
 # remove the above properties and uncomment these if on Windows.

--- a/mapr21/package-res/config.properties
+++ b/mapr21/package-res/config.properties
@@ -14,7 +14,7 @@ library.path=/opt/mapr/lib
 # or the classpath property
 # e.g.: org.apache.commons.log,org.apache.log4j
 # Note, the two packages above are automatically included for all configurations
-ignored.classes=
+ignore.classes=
 
 # These are Windows-specific classpath and library paths. Please
 # remove the above properties and uncomment these if on Windows.

--- a/mapr212/package-res/config.properties
+++ b/mapr212/package-res/config.properties
@@ -14,7 +14,7 @@ library.path=/opt/mapr/lib
 # or the classpath property
 # e.g.: org.apache.commons.log,org.apache.log4j
 # Note, the two packages above are automatically included for all configurations
-ignored.classes=
+ignore.classes=
 
 # These are Windows-specific classpath and library paths. Please
 # remove the above properties and uncomment these if on Windows.

--- a/mapr213/package-res/config.properties
+++ b/mapr213/package-res/config.properties
@@ -14,7 +14,7 @@ library.path=/opt/mapr/lib
 # or the classpath property
 # e.g.: org.apache.commons.log,org.apache.log4j
 # Note, the two packages above are automatically included for all configurations
-ignored.classes=
+ignore.classes=
 
 # These are Windows-specific classpath and library paths. Please
 # remove the above properties and uncomment these if on Windows.

--- a/mapr30/package-res/config.properties
+++ b/mapr30/package-res/config.properties
@@ -14,7 +14,7 @@ library.path=/opt/mapr/lib
 # or the classpath property
 # e.g.: org.apache.commons.log,org.apache.log4j
 # Note, the two packages above are automatically included for all configurations
-ignored.classes=
+ignore.classes=
 
 # These are Windows-specific classpath and library paths. Please
 # remove the above properties and uncomment these if on Windows.

--- a/mapr31/package-res/config.properties
+++ b/mapr31/package-res/config.properties
@@ -15,7 +15,7 @@ linux.library.path=/opt/mapr/lib
 # or the classpath property
 # e.g.: org.apache.commons.log,org.apache.log4j
 # Note, the two packages above are automatically included for all configurations
-ignored.classes=
+ignore.classes=
 
 # These are Windows-specific classpath and library paths. 
 # Please make sure to update the MapR versions in the paths to match your

--- a/mapr401/package-res/config.properties
+++ b/mapr401/package-res/config.properties
@@ -17,7 +17,7 @@ linux.library.path=/opt/mapr/lib
 # or the classpath property
 # e.g.: org.apache.commons.log,org.apache.log4j
 # Note, the two packages above are automatically included for all configurations
-ignored.classes=
+ignore.classes=
 
 # These are Windows-specific classpath and library paths. 
 # Please make sure to update the MapR versions in the paths to match your

--- a/mapr410/package-res/config.properties
+++ b/mapr410/package-res/config.properties
@@ -17,7 +17,7 @@ linux.library.path=/opt/mapr/lib
 # or the classpath property
 # e.g.: org.apache.commons.log,org.apache.log4j
 # Note, the two packages above are automatically included for all configurations
-ignored.classes=
+ignore.classes=
 
 # These are Windows-specific classpath and library paths.
 # Please make sure to update the MapR versions in the paths to match your

--- a/mapr510/package-res/config.properties
+++ b/mapr510/package-res/config.properties
@@ -17,7 +17,7 @@ linux.library.path=/opt/mapr/lib
 # or the classpath property
 # e.g.: org.apache.commons.log,org.apache.log4j
 # Note, the two packages above are automatically included for all configurations
-ignored.classes=
+ignore.classes=
 
 # Comma-separated list of jars without versions to explicitly ignore when
 # loading classes from the resources within this Hadoop configuration directory


### PR DESCRIPTION
… name. Hadoop Cluster Test fails when ignore.classes property exists but is not set

- change ignored.classes property to ignore.classes
- add check for empty property
- add unit test