### PR TITLE
[SP-3591]-Backport of BACKLOG-15823 - MapR 5.1/5.2: ClassNotFoundException when running MapReduce Job with mapper containing Hbase Row Decoder step (7.1 Suite)

### DIFF
--- a/api/src/test/java/org/pentaho/hadoop/shim/HadoopRunningOnClusterTest.java
+++ b/api/src/test/java/org/pentaho/hadoop/shim/HadoopRunningOnClusterTest.java
@@ -1,0 +1,135 @@
+/*******************************************************************************
+ * Pentaho Big Data
+ * <p>
+ * Copyright (C) 2002-2017 by Pentaho : http://www.pentaho.com
+ * <p>
+ * ******************************************************************************
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ ******************************************************************************/
+
+package org.pentaho.hadoop.shim;
+
+import org.apache.commons.vfs2.AllFileSelector;
+import org.apache.commons.vfs2.FileObject;
+import org.apache.commons.vfs2.VFS;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+import java.io.File;
+import java.io.IOException;
+import java.net.URISyntaxException;
+import java.net.URL;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.util.List;
+
+public class HadoopRunningOnClusterTest {
+
+  private static String CONFIG_PROPERTY_CLASSPATH =
+    System.getProperty( "java.io.tmpdir" ) + "/opt/mapr/hadoop/hadoop-2.7.0/share/hadoop/mapreduce";
+  private int count;
+  private static String PMR_PROPERTIES = "pmr.properties";
+  private static File pmrFolder;
+  private static URL urlTestResources;
+
+
+  @ClassRule
+  public static TemporaryFolder tempFolder = new TemporaryFolder();
+
+  @BeforeClass
+  public static void setup() throws Exception {
+    // Create a test hadoop configuration
+    FileObject ramRoot = VFS.getManager().resolveFile( CONFIG_PROPERTY_CLASSPATH );
+    if ( ramRoot.exists() ) {
+      ramRoot.delete( new AllFileSelector() );
+    }
+    ramRoot.createFolder();
+
+    // Create the implementation jars
+    ramRoot.resolveFile( "hadoop-mapreduce-client-app-2.7.0-mapr-1602.jar" ).createFile();
+    ramRoot.resolveFile( "hadoop-mapreduce-client-common-2.7.0-mapr-1602.jar" ).createFile();
+    ramRoot.resolveFile( "hadoop-mapreduce-client-contrib-2.7.0-mapr-1602.jar" ).createFile();
+    ramRoot.resolveFile( "hadoop-mapreduce-client-core-2.7.0-mapr-1602.jar" ).createFile();
+    ramRoot.resolveFile( "hadoop-mapreduce-client-hs-2.7.0-mapr-1602.jar" ).createFile();
+
+    pmrFolder = tempFolder.newFolder( "pmr" );
+    urlTestResources = Thread.currentThread().getContextClassLoader().getResource( PMR_PROPERTIES );
+    Files.copy( Paths.get( urlTestResources.toURI() ), Paths.get( pmrFolder.getAbsolutePath(), PMR_PROPERTIES ) );
+  }
+
+  private void activatePmrFile() throws URISyntaxException, IOException {
+    if ( !Files.exists( Paths.get( urlTestResources.toURI() ) ) ) {
+      Files.copy( Paths.get( pmrFolder.getAbsolutePath(), PMR_PROPERTIES ), Paths.get( urlTestResources.toURI() ) );
+    }
+  }
+
+  private void disablePmrFile() throws URISyntaxException, IOException {
+    Files.deleteIfExists( Paths.get( urlTestResources.toURI() ) );
+  }
+
+  @Test
+  public void isRunningOnCluster_PmrFalse() throws Exception {
+    HadoopConfigurationLocator locator = new HadoopConfigurationLocator();
+
+    try {
+      disablePmrFile();
+      Assert.assertEquals( false, locator.isRunningOnCluster() );
+    } finally {
+      activatePmrFile();
+    }
+  }
+
+  @Test
+  public void isRunningOnCluster_PmrTrue() throws Exception {
+    HadoopConfigurationLocator locator = new HadoopConfigurationLocator();
+
+    activatePmrFile();
+    Assert.assertEquals( true, locator.isRunningOnCluster() );
+  }
+
+
+  @Test
+  public void runningLocally_withLinuxClassPathProperty() throws Exception {
+    HadoopConfigurationLocator locator = new HadoopConfigurationLocator();
+    FileObject folder = VFS.getManager().resolveFile( CONFIG_PROPERTY_CLASSPATH );
+
+    try {
+      disablePmrFile();
+      List<URL> classpathElements = null;
+      if ( !locator.isRunningOnCluster() ) {
+        classpathElements = locator.parseURLs( folder, folder.toString() );
+        count = classpathElements.size();
+      }
+      Assert.assertNotNull( classpathElements );
+      Assert.assertEquals( 6, count );
+    } finally {
+      activatePmrFile();
+    }
+  }
+
+  @Test
+  public void runningOnCluster_ignoreLinuxClassPathProperty() throws Exception {
+    HadoopConfigurationLocator locator = new HadoopConfigurationLocator();
+    FileObject folder = VFS.getManager().resolveFile( CONFIG_PROPERTY_CLASSPATH );
+
+    activatePmrFile();
+    List<URL> classpathElements = null;
+    if ( !locator.isRunningOnCluster() ) {
+      classpathElements = locator.parseURLs( folder, folder.toString() );
+      count = classpathElements.size();
+    }
+    Assert.assertEquals( null, classpathElements );
+    Assert.assertEquals( 0, count );
+  }
+}

--- a/api/src/test/resources/pmr.properties
+++ b/api/src/test/resources/pmr.properties
@@ -1,0 +1,3 @@
+isPmr=true
+maxTimeoutBeforeLoadingShim=300
+notificationsBeforeLoadingShim=1

--- a/shims/mapr510/assemblies/mapr510-shim/src/assembly/assembly.xml
+++ b/shims/mapr510/assemblies/mapr510-shim/src/assembly/assembly.xml
@@ -31,11 +31,6 @@
       <includes>
         <include>dk.brics.automaton:automaton</include>
         <include>pentaho:hadoop2-windows-patch</include>
-        <include>org.apache.hbase:hbase-client</include>
-        <include>org.apache.hbase:hbase-common</include>
-        <include>org.apache.hbase:hbase-hadoop-compat</include>
-        <include>org.apache.hbase:hbase-protocol</include>
-        <include>org.apache.hbase:hbase-server</include>
         <include>org.apache.hive:hive-common</include>
         <include>org.apache.hive:hive-exec</include>
         <include>org.apache.hive:hive-jdbc</include>
@@ -63,6 +58,12 @@
       <includes>
         <include>org.apache.htrace:htrace-core</include>
         <include>org.apache.zookeeper:zookeeper</include>
+        <include>org.apache.hbase:hbase-client</include>
+        <include>org.apache.hbase:hbase-common</include>
+        <include>org.apache.hbase:hbase-hadoop-compat</include>
+        <include>org.apache.hbase:hbase-protocol</include>
+        <include>org.apache.hbase:hbase-server</include>
+        <include>net.sf.flexjson:flexjson</include>
       </includes>
       <excludes>
         <exclude>*:tests:*</exclude>

--- a/shims/mapr510/impl/pom.xml
+++ b/shims/mapr510/impl/pom.xml
@@ -50,6 +50,7 @@
     <com.sun.jersey.version>1.9</com.sun.jersey.version>
     <org.apache.sqoop.version>1.4.6-mapr-1601</org.apache.sqoop.version>
     <org.apache.thrift.version>0.9.2</org.apache.thrift.version>
+    <net.sf.flexjson>2.1</net.sf.flexjson>
   </properties>
   <dependencies>
     <dependency>
@@ -236,6 +237,18 @@
       <groupId>org.apache.hbase</groupId>
       <artifactId>hbase-hadoop-compat</artifactId>
       <version>${org.apache.hbase.version}</version>
+      <scope>compile</scope>
+      <exclusions>
+        <exclusion>
+          <groupId>*</groupId>
+          <artifactId>*</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+    <dependency>
+      <groupId>net.sf.flexjson</groupId>
+      <artifactId>flexjson</artifactId>
+      <version>${net.sf.flexjson}</version>
       <scope>compile</scope>
       <exclusions>
         <exclusion>

--- a/shims/mapr520/assemblies/mapr520-shim/src/assembly/assembly.xml
+++ b/shims/mapr520/assemblies/mapr520-shim/src/assembly/assembly.xml
@@ -31,11 +31,6 @@
       <includes>
         <include>dk.brics.automaton:automaton</include>
         <include>pentaho:hadoop2-windows-patch</include>
-        <include>org.apache.hbase:hbase-client</include>
-        <include>org.apache.hbase:hbase-common</include>
-        <include>org.apache.hbase:hbase-hadoop-compat</include>
-        <include>org.apache.hbase:hbase-protocol</include>
-        <include>org.apache.hbase:hbase-server</include>
         <include>org.apache.hive:hive-common</include>
         <include>org.apache.hive:hive-exec</include>
         <include>org.apache.hive:hive-jdbc</include>
@@ -63,6 +58,12 @@
       <includes>
         <include>org.apache.htrace:htrace-core</include>
         <include>org.apache.zookeeper:zookeeper</include>
+        <include>org.apache.hbase:hbase-client</include>
+        <include>org.apache.hbase:hbase-common</include>
+        <include>org.apache.hbase:hbase-hadoop-compat</include>
+        <include>org.apache.hbase:hbase-protocol</include>
+        <include>org.apache.hbase:hbase-server</include>
+        <include>net.sf.flexjson:flexjson</include>
       </includes>
       <excludes>
         <exclude>*:tests:*</exclude>

--- a/shims/mapr520/impl/pom.xml
+++ b/shims/mapr520/impl/pom.xml
@@ -50,6 +50,7 @@
     <leveldbjni-all.version>1.8</leveldbjni-all.version>
     <jersey-guice.version>1.9</jersey-guice.version>
     <com.sun.jersey.version>1.9</com.sun.jersey.version>
+    <net.sf.flexjson>2.1</net.sf.flexjson>
   </properties>
   <dependencies>
     <dependency>
@@ -236,6 +237,18 @@
       <groupId>org.apache.hbase</groupId>
       <artifactId>hbase-hadoop-compat</artifactId>
       <version>${org.apache.hbase.version}</version>
+      <scope>compile</scope>
+      <exclusions>
+        <exclusion>
+          <groupId>*</groupId>
+          <artifactId>*</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+    <dependency>
+      <groupId>net.sf.flexjson</groupId>
+      <artifactId>flexjson</artifactId>
+      <version>${net.sf.flexjson}</version>
       <scope>compile</scope>
       <exclusions>
         <exclusion>


### PR DESCRIPTION
Added changes to keep HBase Row Decoder step working.
For more details see comments from here: 
 - https://github.com/pentaho/pentaho-hadoop-shims/pull/477
 - https://github.com/pentaho/pentaho-hadoop-shims/pull/478

Merge this pull request along with the https://github.com/pentaho/pentaho-big-data-ee/pull/190