### PR TITLE
[SP-3533][BAD-640] MapR/EMR Shims: incorrect ignored.classes property…

### DIFF
--- a/api/src/org/pentaho/hadoop/shim/HadoopConfigurationLocator.java
+++ b/api/src/org/pentaho/hadoop/shim/HadoopConfigurationLocator.java
@@ -42,6 +42,7 @@ import org.apache.commons.vfs2.FileType;
 import org.apache.commons.vfs2.impl.DefaultFileSystemManager;
 import org.apache.log4j.Logger;
 import org.pentaho.di.core.Const;
+import org.pentaho.di.core.util.StringUtil;
 import org.pentaho.di.i18n.BaseMessages;
 import org.pentaho.hadoop.shim.api.ActiveHadoopConfigurationLocator;
 import org.pentaho.hadoop.shim.api.Required;
@@ -401,7 +402,7 @@ public class HadoopConfigurationLocator implements HadoopConfigurationProvider {
       String ignoredClassesProperty = configurationProperties
         .getProperty( CONFIG_PROPERTY_IGNORE_CLASSES );
       String[] ignoredClasses = null;
-      if ( ignoredClassesProperty != null ) {
+      if ( !StringUtil.isEmpty( ignoredClassesProperty ) ) {
         ignoredClasses = ignoredClassesProperty.split( "," );
       }
 

--- a/api/test-src/org/pentaho/hadoop/shim/HadoopConfigurationLocatorTest.java
+++ b/api/test-src/org/pentaho/hadoop/shim/HadoopConfigurationLocatorTest.java
@@ -68,6 +68,7 @@ public class HadoopConfigurationLocatorTest {
     Properties p = new Properties();
     p.setProperty( "name", "Test Configuration A" );
     p.setProperty( "classpath", "" );
+    p.setProperty( "ignore.classes", "" );
     p.setProperty( "library.path", "" );
     p.setProperty( "required.classes", HadoopConfigurationLocatorTest.class.getName() );
     p.store( configFile.getContent().getOutputStream(), "Test Configuration A" );
@@ -280,6 +281,16 @@ public class HadoopConfigurationLocatorTest {
     buildProperties.createFile();
     Assert.assertEquals( FileType.FILE, buildProperties.getType() );
     locator.createConfigurationLoader( buildProperties, null, null, new ShimProperties() );
+  }
+
+  @Test
+  public void loadHadoopConfiguration_with_ignore_classes() throws Exception {
+    HadoopConfigurationLocator locator = new HadoopConfigurationLocator();
+
+    FileObject root = VFS.getManager().resolveFile( HADOOP_CONFIGURATIONS_PATH + "/a" );
+    HadoopConfiguration configuration = locator.loadHadoopConfiguration( root );
+
+    Assert.assertNotNull( configuration );
   }
 
   @Test

--- a/cdh3u4/ivy.xml
+++ b/cdh3u4/ivy.xml
@@ -46,6 +46,7 @@
     <dependency org="org.apache.pig" name="pig" rev="${dependency.pig.revision}" transitive="false" />
 
     <dependency conf="test->default" org="junit" name="junit" rev="4.5"/>
+    <dependency conf="test->default" org="org.mockito" name="mockito-all" rev="1.9.5" transitive="false" />
     <dependency conf="test->default" org="org.safehaus.jug" name="jug-lgpl" rev="2.0.0" />
     <dependency conf="test->default" org="pentaho" name="pentaho-hadoop-shims-api-test" rev="${project.revision}" changing="true"/>
 

--- a/cdh3u4/package-res/config.properties
+++ b/cdh3u4/package-res/config.properties
@@ -14,4 +14,4 @@ library.path=
 # or the classpath property
 # e.g.: org.apache.commons.log,org.apache.log4j
 # Note, the two packages above are automatically included for all configurations
-ignored.classes=
+ignore.classes=

--- a/cdh4/package-res/config.properties
+++ b/cdh4/package-res/config.properties
@@ -14,4 +14,4 @@ library.path=
 # or the classpath property
 # e.g.: org.apache.commons.log,org.apache.log4j
 # Note, the two packages above are automatically included for all configurations
-ignored.classes=
+ignore.classes=

--- a/cdh412/package-res/config.properties
+++ b/cdh412/package-res/config.properties
@@ -14,4 +14,4 @@ library.path=
 # or the classpath property
 # e.g.: org.apache.commons.log,org.apache.log4j
 # Note, the two packages above are automatically included for all configurations
-ignored.classes=
+ignore.classes=

--- a/cdh413/package-res/config.properties
+++ b/cdh413/package-res/config.properties
@@ -14,4 +14,4 @@ library.path=
 # or the classpath property
 # e.g.: org.apache.commons.log,org.apache.log4j
 # Note, the two packages above are automatically included for all configurations
-ignored.classes=
+ignore.classes=

--- a/cdh42/package-res/config.properties
+++ b/cdh42/package-res/config.properties
@@ -14,4 +14,4 @@ library.path=
 # or the classpath property
 # e.g.: org.apache.commons.log,org.apache.log4j
 # Note, the two packages above are automatically included for all configurations
-ignored.classes=
+ignore.classes=

--- a/cdh47/package-res/config.properties
+++ b/cdh47/package-res/config.properties
@@ -14,4 +14,4 @@ library.path=
 # or the classpath property
 # e.g.: org.apache.commons.log,org.apache.log4j
 # Note, the two packages above are automatically included for all configurations
-ignored.classes=
+ignore.classes=

--- a/cdh50beta/package-res/config.properties
+++ b/cdh50beta/package-res/config.properties
@@ -14,7 +14,7 @@ library.path=
 # or the classpath property
 # e.g.: org.apache.commons.log,org.apache.log4j
 # Note, the two packages above are automatically included for all configurations
-ignored.classes=org.apache.derby.iapi.services.monitor
+ignore.classes=org.apache.derby.iapi.services.monitor
 
 shim.current.config=mr2
 

--- a/emr310/package-res/config.properties
+++ b/emr310/package-res/config.properties
@@ -14,5 +14,5 @@ library.path=
 # or the classpath property
 # e.g.: org.apache.commons.log,org.apache.log4j
 # Note, the two packages above are automatically included for all configurations
-ignored.classes=com.ctc.wstx.stax
+ignore.classes=com.ctc.wstx.stax
 

--- a/emr34/package-res/config.properties
+++ b/emr34/package-res/config.properties
@@ -14,5 +14,5 @@ library.path=
 # or the classpath property
 # e.g.: org.apache.commons.log,org.apache.log4j
 # Note, the two packages above are automatically included for all configurations
-ignored.classes=com.ctc.wstx.stax
+ignore.classes=com.ctc.wstx.stax
 

--- a/emr41/package-res/config.properties
+++ b/emr41/package-res/config.properties
@@ -14,5 +14,5 @@ library.path=
 # or the classpath property
 # e.g.: org.apache.commons.log,org.apache.log4j
 # Note, the two packages above are automatically included for all configurations
-ignored.classes=com.ctc.wstx.stax
+ignore.classes=com.ctc.wstx.stax
 

--- a/emr46/package-res/config.properties
+++ b/emr46/package-res/config.properties
@@ -14,5 +14,5 @@ library.path=
 # or the classpath property
 # e.g.: org.apache.commons.log,org.apache.log4j
 # Note, the two packages above are automatically included for all configurations
-ignored.classes=com.ctc.wstx.stax
+ignore.classes=com.ctc.wstx.stax
 

--- a/hadoop-20/package-res/config.properties
+++ b/hadoop-20/package-res/config.properties
@@ -14,4 +14,4 @@ library.path=
 # or the classpath property
 # e.g.: org.apache.commons.log,org.apache.log4j
 # Note, the two packages above are automatically included for all configurations
-ignored.classes=
+ignore.classes=

--- a/idh23/package-res/config.properties
+++ b/idh23/package-res/config.properties
@@ -14,4 +14,4 @@ library.path=
 # or the classpath property
 # e.g.: org.apache.commons.log,org.apache.log4j
 # Note, the two packages above are automatically included for all configurations
-ignored.classes=
+ignore.classes=

--- a/mapr/package-res/config.properties
+++ b/mapr/package-res/config.properties
@@ -14,7 +14,7 @@ library.path=/opt/mapr/lib
 # or the classpath property
 # e.g.: org.apache.commons.log,org.apache.log4j
 # Note, the two packages above are automatically included for all configurations
-ignored.classes=
+ignore.classes=
 
 # These are Windows-specific classpath and library paths. Please
 # remove the above properties and uncomment these if on Windows.

--- a/mapr21/package-res/config.properties
+++ b/mapr21/package-res/config.properties
@@ -14,7 +14,7 @@ library.path=/opt/mapr/lib
 # or the classpath property
 # e.g.: org.apache.commons.log,org.apache.log4j
 # Note, the two packages above are automatically included for all configurations
-ignored.classes=
+ignore.classes=
 
 # These are Windows-specific classpath and library paths. Please
 # remove the above properties and uncomment these if on Windows.

--- a/mapr212/package-res/config.properties
+++ b/mapr212/package-res/config.properties
@@ -14,7 +14,7 @@ library.path=/opt/mapr/lib
 # or the classpath property
 # e.g.: org.apache.commons.log,org.apache.log4j
 # Note, the two packages above are automatically included for all configurations
-ignored.classes=
+ignore.classes=
 
 # These are Windows-specific classpath and library paths. Please
 # remove the above properties and uncomment these if on Windows.

--- a/mapr213/package-res/config.properties
+++ b/mapr213/package-res/config.properties
@@ -14,7 +14,7 @@ library.path=/opt/mapr/lib
 # or the classpath property
 # e.g.: org.apache.commons.log,org.apache.log4j
 # Note, the two packages above are automatically included for all configurations
-ignored.classes=
+ignore.classes=
 
 # These are Windows-specific classpath and library paths. Please
 # remove the above properties and uncomment these if on Windows.

--- a/mapr30/package-res/config.properties
+++ b/mapr30/package-res/config.properties
@@ -14,7 +14,7 @@ library.path=/opt/mapr/lib
 # or the classpath property
 # e.g.: org.apache.commons.log,org.apache.log4j
 # Note, the two packages above are automatically included for all configurations
-ignored.classes=
+ignore.classes=
 
 # These are Windows-specific classpath and library paths. Please
 # remove the above properties and uncomment these if on Windows.

--- a/mapr31/package-res/config.properties
+++ b/mapr31/package-res/config.properties
@@ -15,7 +15,7 @@ linux.library.path=/opt/mapr/lib
 # or the classpath property
 # e.g.: org.apache.commons.log,org.apache.log4j
 # Note, the two packages above are automatically included for all configurations
-ignored.classes=
+ignore.classes=
 
 # These are Windows-specific classpath and library paths. 
 # Please make sure to update the MapR versions in the paths to match your

--- a/mapr401/package-res/config.properties
+++ b/mapr401/package-res/config.properties
@@ -17,7 +17,7 @@ linux.library.path=/opt/mapr/lib
 # or the classpath property
 # e.g.: org.apache.commons.log,org.apache.log4j
 # Note, the two packages above are automatically included for all configurations
-ignored.classes=
+ignore.classes=
 
 # These are Windows-specific classpath and library paths. 
 # Please make sure to update the MapR versions in the paths to match your

--- a/mapr410/package-res/config.properties
+++ b/mapr410/package-res/config.properties
@@ -17,7 +17,7 @@ linux.library.path=/opt/mapr/lib
 # or the classpath property
 # e.g.: org.apache.commons.log,org.apache.log4j
 # Note, the two packages above are automatically included for all configurations
-ignored.classes=
+ignore.classes=
 
 # These are Windows-specific classpath and library paths.
 # Please make sure to update the MapR versions in the paths to match your

--- a/mapr510/package-res/config.properties
+++ b/mapr510/package-res/config.properties
@@ -17,7 +17,7 @@ linux.library.path=/opt/mapr/lib
 # or the classpath property
 # e.g.: org.apache.commons.log,org.apache.log4j
 # Note, the two packages above are automatically included for all configurations
-ignored.classes=
+ignore.classes=
 
 # Comma-separated list of jars without versions to explicitly ignore when
 # loading classes from the resources within this Hadoop configuration directory


### PR DESCRIPTION
… name. Hadoop Cluster Test fails when ignore.classes property exists but is not set

- change ignored.classes property to ignore.classes
- add check for empty property
- add unit test