### PR TITLE
[BACKLOG-17014]-As an ETL developer after defining a “Named Cluster”, I

### DIFF
--- a/api/src/main/java/org/pentaho/hadoop/shim/api/DistributedCacheUtil.java
+++ b/api/src/main/java/org/pentaho/hadoop/shim/api/DistributedCacheUtil.java
@@ -27,6 +27,8 @@ import org.pentaho.hadoop.shim.api.fs.FileSystem;
 import org.pentaho.hadoop.shim.api.fs.Path;
 
 import java.io.IOException;
+import java.util.List;
+import java.util.regex.Pattern;
 
 /**
  * A collection of methods for working with Hadoop's Distributed Cache mechanism.
@@ -69,5 +71,41 @@ public interface DistributedCacheUtil {
    */
   void installKettleEnvironment( FileObject pmrLibArchive, FileSystem fs, Path destination,
                                  FileObject bigDataPluginFolder, String additionalPlugins ) throws Exception;
+
+  /**
+   * Stages the source file or folder to a Hadoop file system and sets their permission and replication value
+   * appropriately to be used with the Distributed Cache. WARNING: This will delete the contents of dest before staging
+   * the archive.
+   *
+   * @param source    File or folder to copy to the file system. If it is a folder all contents will be copied into
+   *                  dest.
+   * @param fs        Hadoop file system to store the contents of the archive in
+   * @param dest      Destination to copy source into. If source is a file, the new file name will be exactly dest. If
+   *                  source is a folder its contents will be copied into dest. For more info see {@link
+   *                  org.apache.hadoop.fs.FileSystem#copyFromLocalFile(org.apache.hadoop.fs.Path,
+   *                  org.apache.hadoop.fs.Path)}.
+   * @param overwrite Should an existing file or folder be overwritten? If not an exception will be thrown.
+   * @throws IOException Destination exists is not a directory, Source does not exist or destination exists and
+   *                     overwrite is false.
+   */
+  void stageForCache( FileObject source, FileSystem fs, Path dest, boolean overwrite, boolean isPublic ) throws IOException;
+
+  /**
+   * Register a list of files from a Hadoop file system to be available and placed on the classpath when the
+   * configuration is used to submit Hadoop jobs
+   *
+   * @param conf  Configuration to modify
+   * @throws IOException
+   */
+  void addCachedFilesToClasspath( Configuration conf, FileSystem fs, Path source, Pattern fileNamePattern ) throws IOException;
+
+  /**
+   * Register a list of paths from a Hadoop file system to be available when the configuration is used to submit Hadoop
+   * jobs
+   *
+   * @param conf  Configuration to modify
+   * @throws IOException
+   */
+  void addCachedFiles( Configuration conf, FileSystem fs, Path source, Pattern fileNamePattern ) throws IOException;
 
 }

--- a/api/src/main/java/org/pentaho/hadoop/shim/api/DistributedCacheUtil.java
+++ b/api/src/main/java/org/pentaho/hadoop/shim/api/DistributedCacheUtil.java
@@ -2,7 +2,7 @@
  *
  * Pentaho Big Data
  *
- * Copyright (C) 2002-2015 by Pentaho : http://www.pentaho.com
+ * Copyright (C) 2002-2017 by Pentaho : http://www.pentaho.com
  *
  *******************************************************************************
  *
@@ -22,13 +22,12 @@
 
 package org.pentaho.hadoop.shim.api;
 
+import java.io.IOException;
+import java.util.regex.Pattern;
+
 import org.apache.commons.vfs2.FileObject;
 import org.pentaho.hadoop.shim.api.fs.FileSystem;
 import org.pentaho.hadoop.shim.api.fs.Path;
-
-import java.io.IOException;
-import java.util.List;
-import java.util.regex.Pattern;
 
 /**
  * A collection of methods for working with Hadoop's Distributed Cache mechanism.

--- a/common/mapred/src/main/java/org/pentaho/hadoop/mapreduce/MRUtil.java
+++ b/common/mapred/src/main/java/org/pentaho/hadoop/mapreduce/MRUtil.java
@@ -2,7 +2,7 @@
  *
  * Pentaho Big Data
  *
- * Copyright (C) 2002-2016 by Pentaho : http://www.pentaho.com
+ * Copyright (C) 2002-2017 by Pentaho : http://www.pentaho.com
  *
  *******************************************************************************
  *

--- a/common/mapred/src/main/java/org/pentaho/hadoop/mapreduce/MRUtil.java
+++ b/common/mapred/src/main/java/org/pentaho/hadoop/mapreduce/MRUtil.java
@@ -50,6 +50,11 @@ public class MRUtil {
   public static final String PROPERTY_PENTAHO_KETTLE_PLUGINS_DIR = "pentaho.kettle.plugins.dir";
 
   /**
+   * Path to the directory to load plugins from. This must be accessible from all TaskTracker nodes.
+   */
+  public static final String PROPERTY_PENTAHO_KETTLE_METASTORE_DIR = "pentaho.kettle.metastore.dir";
+
+  /**
    * Hadoop Configuration for setting KETTLE_HOME. See {@link Const#getKettleDirectory()} for usage.
    */
   public static final String PROPERTY_PENTAHO_KETTLE_HOME = "pentaho.kettle.home";
@@ -93,11 +98,14 @@ public class MRUtil {
     if ( !KettleEnvironment.isInitialized() ) {
       String kettleHome = getKettleHomeProperty( conf );
       String pluginDir = getPluginDirProperty( conf );
+      String metaStoreDir = getMetastoreDirProperty( conf );
       System.setProperty( "KETTLE_HOME", kettleHome );
       System.setProperty( Const.PLUGIN_BASE_FOLDERS_PROP, pluginDir );
+      System.setProperty( Const.PENTAHO_METASTORE_FOLDER, metaStoreDir );
 
       System.out.println( BaseMessages.getString( MRUtil.class, "KettleHome.Info", kettleHome ) );
       System.out.println( BaseMessages.getString( MRUtil.class, "PluginDirectory.Info", pluginDir ) );
+      System.out.println( BaseMessages.getString( MRUtil.class, "MetasStoreDirectory.Info", metaStoreDir ) );
 
       KettleEnvironment.init();
     }
@@ -151,6 +159,14 @@ public class MRUtil {
    */
   public static String getKettleHomeProperty( Configuration conf ) {
     String kettleHome = conf.get( PROPERTY_PENTAHO_KETTLE_HOME );
+    if ( StringUtils.isEmpty( kettleHome ) ) {
+      return getWorkingDir();
+    }
+    return kettleHome;
+  }
+
+  public static String getMetastoreDirProperty( Configuration conf ) {
+    String kettleHome = conf.get( PROPERTY_PENTAHO_KETTLE_METASTORE_DIR );
     if ( StringUtils.isEmpty( kettleHome ) ) {
       return getWorkingDir();
     }


### PR DESCRIPTION
want all my transformations and jobs to use the defined cluster name as
the reference to the cluster so   I only need to update any of the cluster
information from one place. (hdfs)