### PR TITLE
[BACKLOG-17592]-hdp26 shim pmr jobs don't work starting with 8.0-QAT-…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -64,6 +64,18 @@
         <scope>provided</scope>
         <exclusions>
           <exclusion>
+            <groupId>com.sun.jersey</groupId>
+            <artifactId>jersey-client</artifactId>
+          </exclusion>
+          <exclusion>
+            <groupId>com.sun.jersey</groupId>
+            <artifactId>jersey-core</artifactId>
+          </exclusion>
+          <exclusion>
+            <groupId>org.codehaus.jackson</groupId>
+            <artifactId>jackson-jaxrs</artifactId>
+          </exclusion>
+          <exclusion>
             <artifactId>*</artifactId>
             <groupId>*</groupId>
           </exclusion>


### PR DESCRIPTION
…168, kettle begin influence jersey version after mavenization