### PR TITLE
[BACKLOG-20291] Add overwrite existing flag in Orc Output step

### DIFF
--- a/common/common-shim/src/test/java/org/pentaho/hadoop/shim/common/format/orc/PentahoOrcReadWriteTest.java
+++ b/common/common-shim/src/test/java/org/pentaho/hadoop/shim/common/format/orc/PentahoOrcReadWriteTest.java
@@ -144,7 +144,7 @@ public class PentahoOrcReadWriteTest {
     doReadWrite( IPentahoOrcOutputFormat.COMPRESSION.SNAPPY, "orcOutputSnappy.orc", false );
     doReadWrite( IPentahoOrcOutputFormat.COMPRESSION.ZLIB, "orcOutputZlib.orc", false );
     //#if shim_type!="EMR"
-    //$doReadWrite( IPentahoOrcOutputFormat.COMPRESSION.LZO, "orcOutputLzo.orc" );
+    //$doReadWrite( IPentahoOrcOutputFormat.COMPRESSION.LZO, "orcOutputLzo.orc", false );
     //#endif
 
   }


### PR DESCRIPTION
@pentaho/moseisley Please review.
Fixes a compilation error in the hadoop common shim hidden by a preprocess error.