### PR TITLE
[CLEANUP] Fix compilation error due to incorrect pentaho-metastore-locator-api version.

### DIFF
--- a/common-services-api/jdbc/pom.xml
+++ b/common-services-api/jdbc/pom.xml
@@ -24,7 +24,7 @@
     <dependency>
       <groupId>pentaho</groupId>
       <artifactId>pentaho-metastore-locator-api</artifactId>
-      <version>${pentaho-osgi-bundles.version}</version>
+      <version>${project.version}</version>
     </dependency>
     <dependency>
       <groupId>org.osgi</groupId>


### PR DESCRIPTION
@smaring @rmansoor Please review.