### PR TITLE
[BAD-1107]-exclude hadoop-client from cdh513 archive

### DIFF
--- a/shims/cdh513/assemblies/client/src/assembly/assembly.xml
+++ b/shims/cdh513/assemblies/client/src/assembly/assembly.xml
@@ -12,7 +12,10 @@
       <useTransitiveFiltering>true</useTransitiveFiltering>
       <includes>
 	    <include>org.xerial.snappy:snappy-java</include>
-        <include>org.apache.hadoop:hadoop-client</include>
+        <include>org.apache.hadoop:hadoop-aws</include>
+        <include>org.apache.hadoop:hadoop-hdfs</include>
+        <include>org.apache.hadoop:hadoop-common</include>
+        <include>org.apache.hadoop:hadoop-auth</include>
         <include>org.apache.hadoop:hadoop-mapreduce-client-core</include>
         <include>org.apache.hadoop:hadoop-mapreduce-client-app</include>
         <include>org.apache.hadoop:hadoop-mapreduce-client-common</include>


### PR DESCRIPTION
Excluded hadoop-client as it doesn`t contain any java classes and it needs only for building cdh513 module.
Added hadoop-related jars as they are getting transitively by hadoop-client