### PR TITLE
[BAD-1451]-Remove of vulnerable component hadoop-yarn-server-nodemanager from cdh514 shim

### DIFF
--- a/shims/cdh514/client/src/assembly/assembly.xml
+++ b/shims/cdh514/client/src/assembly/assembly.xml
@@ -11,7 +11,7 @@
       <useTransitiveDependencies>true</useTransitiveDependencies>
       <useTransitiveFiltering>true</useTransitiveFiltering>
       <includes>
-	      <include>org.xerial.snappy:snappy-java</include>
+        <include>org.xerial.snappy:snappy-java</include>
         <include>org.apache.hadoop:hadoop-aws</include>
         <include>org.apache.hadoop:hadoop-hdfs</include>
         <include>org.apache.hadoop:hadoop-common</include>
@@ -31,6 +31,7 @@
       </includes>
       <excludes>
         <exclude>junit:*</exclude>
+        <exclude>org.apache.hadoop:hadoop-yarn-server-nodemanager</exclude>
         <exclude>commons-collections:commons-collections</exclude>
         <exclude>org.apache.zookeeper:zookeeper</exclude>
         <exclude>com.google.guava:*</exclude>


### PR DESCRIPTION
Removed vulnerable component according to https://jira.pentaho.com/browse/BACKLOG-21295