### PR TITLE
[BACKLOG-23021]-Avro input fails to execute on Ubuntu 16.04 using Map…

### DIFF
--- a/shims/emr511/assemblies/emr511-shim/src/main/resources/config.properties
+++ b/shims/emr511/assemblies/emr511-shim/src/main/resources/config.properties
@@ -2,7 +2,7 @@
 name=Amazon EMR 5.11.x
 # Comma-separated list of directories and files to make available to this
 # configuration. Any resources found here will overwrite ones in lib/.
-classpath=
+classpath=lib/avro-1.8.0.jar
 # Comma-separated list of paths that contain native libraries to load. These
 # could be added to LD_LIBRARY_PATH or set with -Djava.library.path instead.
 library.path=

--- a/shims/emr59/assemblies/emr59-shim/src/main/resources/config.properties
+++ b/shims/emr59/assemblies/emr59-shim/src/main/resources/config.properties
@@ -3,7 +3,7 @@ name=Amazon EMR 5.9.x
 
 # Comma-separated list of directories and files to make available to this
 # configuration. Any resources found here will overwrite ones in lib/.
-classpath=
+classpath=lib/avro-1.8.0.jar
 
 # Comma-separated list of paths that contain native libraries to load. These
 # could be added to LD_LIBRARY_PATH or set with -Djava.library.path instead.

--- a/shims/hdp25/assemblies/hdp25-shim/src/main/resources/config.properties
+++ b/shims/hdp25/assemblies/hdp25-shim/src/main/resources/config.properties
@@ -3,7 +3,7 @@ name=HortonWorks HDP 2.5.x
 
 # Comma-separated list of directories and files to make available to this
 # configuration. Any resources found here will overwrite ones in lib/.
-classpath=lib/hive-service-1.2.1000.2.5.0.0-1245.jar
+classpath=lib/hive-service-1.2.1000.2.5.0.0-1245.jar,lib/avro-1.8.0.jar
 
 # Comma-separated list of paths that contain native libraries to load. These
 # could be added to LD_LIBRARY_PATH or set with -Djava.library.path instead.

--- a/shims/hdp26/assemblies/hdp26-shim/src/main/resources/config.properties
+++ b/shims/hdp26/assemblies/hdp26-shim/src/main/resources/config.properties
@@ -3,7 +3,7 @@ name=HortonWorks HDP 2.6.x
 
 # Comma-separated list of directories and files to make available to this
 # configuration. Any resources found here will overwrite ones in lib/.
-classpath=lib/hive-service-1.2.1000.2.6.0.3-8.jar
+classpath=lib/hive-service-1.2.1000.2.6.0.3-8.jar,lib/avro-1.8.0.jar
 
 # Comma-separated list of paths that contain native libraries to load. These
 # could be added to LD_LIBRARY_PATH or set with -Djava.library.path instead.


### PR DESCRIPTION
…R and HDP Shim

[BACKLOG-23085]-Avro input: NoSuchMethodError while trying to get fields from Avro file using emr511 shim on Linux
put avro-1.8.0 first on classpath