### PR TITLE
[BACKLOG-24170] - Added missing ORC format dependencies for hdp26.

### DIFF
--- a/shims/hdp26/hive/pom.xml
+++ b/shims/hdp26/hive/pom.xml
@@ -63,8 +63,8 @@
     </dependency>
     <dependency>
       <groupId>org.apache.hive</groupId>
-      <artifactId>hive-metastore</artifactId>
-      <version>${org.apache.hive.version}</version>
+      <artifactId>hive-storage-api</artifactId>
+      <version>${hive-storage-api.version}</version>
     </dependency>
     <dependency>
       <groupId>org.apache.hive</groupId>

--- a/shims/hdp26/pom.xml
+++ b/shims/hdp26/pom.xml
@@ -25,6 +25,7 @@
     <org.apache.oozie.version>4.2.0.2.6.0.3-8</org.apache.oozie.version>
     <sqoop.version>1.4.6.2.6.0.3-8</sqoop.version>
     <org.apache.hive.version>1.2.1000.2.6.0.3-8</org.apache.hive.version>
+    <hive-storage-api.version>2.1.1.3-pre-orc</hive-storage-api.version>
     <org.apache.avro.version>1.8.0</org.apache.avro.version>
     <hadoop-aws.version>2.7.3</hadoop-aws.version>
     <!-- client and default folders -->

--- a/shims/pom.xml
+++ b/shims/pom.xml
@@ -51,6 +51,10 @@
       org.apache.hadoop.gateway.shell;version=${bundle.export.version},
       io.netty;version=${bundle.export.version},
       io.netty.channel;version=${bundle.export.version},
+      io.airlift.compress;version=${bundle.export.version},
+      io.airlift.compress.snappy;version=${bundle.export.version},
+      io.airlift.compress.lzo;version=${bundle.export.version},
+      io.airlift.compress.lz4;version=${bundle.export.version},
       com.yammer.metrics;version=${bundle.export.version},
       org.pentaho.hdfs.vfs;version=${bundle.export.version}</bundle.karaf.export.packages>
   </properties>


### PR DESCRIPTION
@pentaho/moseisley Please review.

hive-metastore was defined twice as a dependency.
Removed the redundant dependency and replaced it with the missing hive-storage-api dependency.