### PR TITLE
[PDI-17441] Feature: Add support for ADL as an Hadoop FS

### DIFF
--- a/shims/hdi35/default/pom.xml
+++ b/shims/hdi35/default/pom.xml
@@ -116,6 +116,28 @@
       </exclusions>
     </dependency>
     <dependency>
+      <groupId>org.apache.hadoop</groupId>
+      <artifactId>hadoop-azure-datalake</artifactId>
+      <version>${hadoop-azure-datalake.version}</version>
+      <exclusions>
+        <exclusion>
+          <groupId>*</groupId>
+          <artifactId>*</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+    <dependency>
+      <groupId>com.microsoft.azure</groupId>
+      <artifactId>azure-data-lake-store-sdk</artifactId>
+      <version>${hadoop-azure-datalake-sdk.version}</version>
+      <exclusions>
+        <exclusion>
+          <groupId>*</groupId>
+          <artifactId>*</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+    <dependency>
       <groupId>org.apache.hive</groupId>
       <artifactId>hive-jdbc</artifactId>
       <version>${hive-jdbc.version}</version>

--- a/shims/hdi35/default/src/assembly/assembly.xml
+++ b/shims/hdi35/default/src/assembly/assembly.xml
@@ -20,6 +20,8 @@
         <include>org.apache.oozie:oozie-client</include>
         <include>org.apache.hadoop:hadoop-azure</include>
         <include>com.microsoft.azure:azure-storage</include>
+        <include>org.apache.hadoop:hadoop-azure-datalake</include>
+        <include>com.microsoft.azure:azure-data-lake-store-sdk</include>
         <include>org.apache.avro:avro</include>
         <include>org.apache.orc:orc-core</include>
         <include>io.airlift:aircompressor</include>

--- a/shims/hdi35/pom.xml
+++ b/shims/hdi35/pom.xml
@@ -20,6 +20,8 @@
     <azure-storage.version>2.0.0</azure-storage.version>
     <automaton.version>1.11-8</automaton.version>
     <hadoop-azure.version>2.7.1</hadoop-azure.version>
+    <hadoop-azure-datalake.version>3.0.0-alpha3</hadoop-azure-datalake.version>
+    <hadoop-azure-datalake-sdk.version>2.1.5</hadoop-azure-datalake-sdk.version>
     <hadoop-aws.version>2.7.3</hadoop-aws.version>
     <avro.version>1.8.0</avro.version>
     <org.codehaus.jackson>1.9.13</org.codehaus.jackson>


### PR DESCRIPTION
There is support for the adl scheme in current hadoop. This PR adds support for Azure DataLake storage in PDI. This is part of PRs against the `big-data-shims`, `pentaho-karaf-assembly`, and `pentaho-big-data-plugins` repositories.