### PR TITLE
[BACKLOG-24253] HDP 26 Secured: "Hadoop Job Executor", "Pig" and "Sqo…

### DIFF
--- a/common-services-api/api/src/main/java/org/pentaho/hadoop/shim/ShimConfigsLoader.java
+++ b/common-services-api/api/src/main/java/org/pentaho/hadoop/shim/ShimConfigsLoader.java
@@ -61,6 +61,16 @@ public class ShimConfigsLoader {
 
   public static void addConfigsAsResources( String additionalPath, Consumer<? super URL> configurationConsumer,
                                             ClusterConfigNames... fileNames ) {
+    Properties properties = loadConfigProperties( additionalPath );
+    if ( properties != null ) {
+      for ( String propertyName : properties.stringPropertyNames() ) {
+        if ( propertyName.startsWith( "java.system." ) ) {
+          System.setProperty( propertyName.substring( "java.system.".length() ),
+              properties.get( propertyName ).toString() );
+        }
+      }
+    }
+
     addConfigsAsResources( additionalPath, configurationConsumer,
       Arrays.stream( fileNames ).map( ClusterConfigNames::toString ).collect( Collectors.toList() ) );
   }


### PR DESCRIPTION
…op" steps failed with "Illegal character in path" on shim moved to OSGI