### PR TITLE
[BACKLOG-24118] - Parquet Input fails on Secured shims moved to OSGI (EE specific)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,4 @@ release.properties
 pom.xml.releaseBackup
 checkstyle/
 .vscode
+.factorypath

--- a/common-services-api/api/src/main/java/org/pentaho/hadoop/shim/spi/FormatShim.java
+++ b/common-services-api/api/src/main/java/org/pentaho/hadoop/shim/spi/FormatShim.java
@@ -24,9 +24,10 @@ package org.pentaho.hadoop.shim.spi;
 
 import org.pentaho.hadoop.shim.api.format.IPentahoInputFormat;
 import org.pentaho.hadoop.shim.api.format.IPentahoOutputFormat;
+import org.pentaho.big.data.api.cluster.NamedCluster;
 
 public interface FormatShim extends PentahoHadoopShim {
-  <T extends IPentahoInputFormat> T createInputFormat( Class<T> type ) throws Exception;
+  <T extends IPentahoInputFormat> T createInputFormat( Class<T> type, NamedCluster namedCluster ) throws Exception;
 
   <T extends IPentahoOutputFormat> T createOutputFormat( Class<T> type ) throws Exception;
 }

--- a/common-services-api/format/pom.xml
+++ b/common-services-api/format/pom.xml
@@ -21,6 +21,13 @@
       <groupId>org.pentaho</groupId>
       <artifactId>pentaho-hadoop-shims-api</artifactId>
       <version>${pentaho-hadoop-shims-api.version}</version>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.pentaho</groupId>
+      <artifactId>pentaho-big-data-api-cluster</artifactId>
+      <version>${pentaho-big-data-api-cluster.version}</version>
+      <scope>provided</scope>
     </dependency>
   </dependencies>
   <build>

--- a/common-services-api/format/src/main/java/org/pentaho/bigdata/api/format/FormatService.java
+++ b/common-services-api/format/src/main/java/org/pentaho/bigdata/api/format/FormatService.java
@@ -23,10 +23,11 @@ package org.pentaho.bigdata.api.format;
 
 import org.pentaho.hadoop.shim.api.format.IPentahoInputFormat;
 import org.pentaho.hadoop.shim.api.format.IPentahoOutputFormat;
+import org.pentaho.big.data.api.cluster.NamedCluster;
 
 public interface FormatService {
 
-  <T extends IPentahoInputFormat> T createInputFormat( Class<T> type ) throws Exception;
+  <T extends IPentahoInputFormat> T createInputFormat( Class<T> type, NamedCluster namedCluster ) throws Exception;
 
   <T extends IPentahoOutputFormat> T createOutputFormat( Class<T> type ) throws Exception;
 }

--- a/common-services/format/src/main/java/org/pentaho/big/data/impl/shim/format/FormatServiceImpl.java
+++ b/common-services/format/src/main/java/org/pentaho/big/data/impl/shim/format/FormatServiceImpl.java
@@ -38,8 +38,8 @@ public class FormatServiceImpl implements FormatService {
   }
 
   @Override
-  public <T extends IPentahoInputFormat> T createInputFormat( Class<T> type ) throws Exception {
-    return formatShim.createInputFormat( type );
+  public <T extends IPentahoInputFormat> T createInputFormat( Class<T> type, NamedCluster namedCluster ) throws Exception {
+    return formatShim.createInputFormat( type, namedCluster );
   }
 
   @Override

--- a/common/common-format/src/it/java/org/pentaho/hadoop/shim/common/CommonFormatShimTestIT.java
+++ b/common/common-format/src/it/java/org/pentaho/hadoop/shim/common/CommonFormatShimTestIT.java
@@ -29,6 +29,7 @@ import java.util.List;
 
 import org.apache.hadoop.mapreduce.lib.output.FileOutputFormat;
 import org.junit.Test;
+import org.pentaho.big.data.api.cluster.NamedCluster;
 import org.pentaho.di.core.RowMetaAndData;
 import org.pentaho.di.core.row.RowMeta;
 import org.pentaho.di.core.row.ValueMetaInterface;
@@ -48,6 +49,7 @@ import org.pentaho.hadoop.shim.common.format.avro.PentahoAvroInputFormat;
 import org.pentaho.hadoop.shim.common.format.avro.PentahoAvroOutputFormat;
 
 import static org.junit.Assert.*;
+import static org.mockito.Mockito.mock;
 
 /**
  * Created by Vasilina_Terehova on 7/27/2017.
@@ -61,7 +63,7 @@ public class CommonFormatShimTestIT {
     expectedRows.add( "Alex Blum;15" );
     expectedRows.add( "Tom Falls;24" );
 
-    PentahoParquetInputFormat pentahoParquetInputFormat = new PentahoParquetInputFormat();
+    PentahoParquetInputFormat pentahoParquetInputFormat = new PentahoParquetInputFormat( mock( NamedCluster.class ) );
     pentahoParquetInputFormat
       .setInputFile( getClass().getClassLoader().getResource( "sample.pqt" ).toExternalForm() );
     pentahoParquetInputFormat.setSchema( ParquetUtils.createSchema( ValueMetaInterface.TYPE_INTEGER ) );
@@ -118,7 +120,7 @@ public class CommonFormatShimTestIT {
 
   private IPentahoRecordReader readCreatedParquetFile( String parquetFilePath )
     throws Exception {
-    PentahoParquetInputFormat pentahoParquetInputFormat = new PentahoParquetInputFormat();
+    PentahoParquetInputFormat pentahoParquetInputFormat = new PentahoParquetInputFormat( mock( NamedCluster.class ) );
 
     pentahoParquetInputFormat.setInputFile( parquetFilePath );
     List<IParquetInputField> schema = pentahoParquetInputFormat.readSchema( parquetFilePath );
@@ -133,7 +135,7 @@ public class CommonFormatShimTestIT {
   @Test
   public void testAvroReadLocalFileSystem() throws Exception {
     List<String> expectedRows = Arrays.asList( "John;4074549921", "Leslie;4079302194" );
-    PentahoAvroInputFormat avroInputFormat = new PentahoAvroInputFormat();
+    PentahoAvroInputFormat avroInputFormat = new PentahoAvroInputFormat( mock( NamedCluster.class ) );
     avroInputFormat.setInputSchemaFile( getFilePath( "/sample-schema.avro" ) );
     avroInputFormat.setInputFile( getFilePath( "/sample-data.avro" ) );
 
@@ -204,7 +206,7 @@ public class CommonFormatShimTestIT {
     recordWriter.write( row );
     recordWriter.close();
 
-    PentahoAvroInputFormat avroInputFormat = new PentahoAvroInputFormat();
+    PentahoAvroInputFormat avroInputFormat = new PentahoAvroInputFormat( mock( NamedCluster.class ) );
     List<AvroInputField> inputFields = new ArrayList<AvroInputField>();
 
     AvroInputField avroInputField = new AvroInputField();
@@ -266,7 +268,7 @@ public class CommonFormatShimTestIT {
     overwriteTrueRecordWriter.close();
 
 
-    avroInputFormat = new PentahoAvroInputFormat();
+    avroInputFormat = new PentahoAvroInputFormat( mock( NamedCluster.class ) );
     inputFields = new ArrayList<AvroInputField>();
 
     avroInputField = new AvroInputField();

--- a/common/common-format/src/main/java/org/pentaho/hadoop/shim/common/CommonFormatShim.java
+++ b/common/common-format/src/main/java/org/pentaho/hadoop/shim/common/CommonFormatShim.java
@@ -37,17 +37,18 @@ import org.pentaho.hadoop.shim.common.format.parquet.PentahoParquetOutputFormat;
 import org.pentaho.hadoop.shim.common.format.avro.PentahoAvroInputFormat;
 import org.pentaho.hadoop.shim.common.format.avro.PentahoAvroOutputFormat;
 import org.pentaho.hadoop.shim.spi.FormatShim;
+import org.pentaho.big.data.api.cluster.NamedCluster;
 
 public class CommonFormatShim implements FormatShim {
 
   @Override
-  public <T extends IPentahoInputFormat> T createInputFormat( Class<T> type ) throws Exception {
+  public <T extends IPentahoInputFormat> T createInputFormat( Class<T> type, NamedCluster namedCluster ) throws Exception {
     if ( type.isAssignableFrom( IPentahoParquetInputFormat.class ) ) {
-      return (T) new PentahoParquetInputFormat();
+      return (T) new PentahoParquetInputFormat( namedCluster );
     } else if ( type.isAssignableFrom( IPentahoAvroInputFormat.class ) ) {
-      return (T) new PentahoAvroInputFormat();
+      return (T) new PentahoAvroInputFormat( namedCluster );
     } else if ( type.isAssignableFrom( IPentahoOrcInputFormat.class ) ) {
-      return (T) new PentahoOrcInputFormat();
+      return (T) new PentahoOrcInputFormat( namedCluster );
     }
     throw new IllegalArgumentException( "Not supported scheme format" );
   }

--- a/common/common-format/src/main/java/org/pentaho/hadoop/shim/common/format/avro/PentahoAvroInputFormat.java
+++ b/common/common-format/src/main/java/org/pentaho/hadoop/shim/common/format/avro/PentahoAvroInputFormat.java
@@ -40,6 +40,7 @@ import org.pentaho.di.core.vfs.KettleVFS;
 import org.pentaho.hadoop.shim.api.format.AvroSpec;
 import org.pentaho.hadoop.shim.api.format.IAvroInputField;
 import org.pentaho.hadoop.shim.api.format.IPentahoAvroInputFormat;
+import org.pentaho.big.data.api.cluster.NamedCluster;
 
 public class PentahoAvroInputFormat implements IPentahoAvroInputFormat {
 
@@ -49,6 +50,11 @@ public class PentahoAvroInputFormat implements IPentahoAvroInputFormat {
   private String inputStreamFieldName;
   private boolean useFieldAsInputStream;
   private InputStream inputStream;
+  private NamedCluster namedCluster;
+
+  public PentahoAvroInputFormat( NamedCluster namedCluster ) {
+    this.namedCluster = namedCluster;
+  }
 
   @Override
   public List<IPentahoInputSplit> getSplits() throws Exception {

--- a/common/common-format/src/main/java/org/pentaho/hadoop/shim/common/format/orc/PentahoOrcInputFormat.java
+++ b/common/common-format/src/main/java/org/pentaho/hadoop/shim/common/format/orc/PentahoOrcInputFormat.java
@@ -29,12 +29,14 @@ import org.apache.hadoop.fs.PathFilter;
 import org.apache.orc.Reader;
 import org.apache.orc.OrcFile;
 import org.apache.orc.TypeDescription;
+import org.pentaho.hadoop.shim.ShimConfigsLoader;
 import org.pentaho.hadoop.shim.api.format.IOrcInputField;
 import org.pentaho.hadoop.shim.api.format.IOrcMetaData;
 import org.pentaho.hadoop.shim.api.format.IPentahoOrcInputFormat;
 import org.pentaho.hadoop.shim.common.ConfigurationProxy;
 import org.pentaho.hadoop.shim.common.format.HadoopFormatBase;
 import org.pentaho.hadoop.shim.common.format.S3NCredentialUtils;
+import org.pentaho.big.data.api.cluster.NamedCluster;
 
 import java.io.IOException;
 import java.nio.file.NoSuchFileException;
@@ -49,11 +51,11 @@ public class PentahoOrcInputFormat extends HadoopFormatBase implements IPentahoO
   private List<? extends IOrcInputField> inputFields;
   private Configuration conf;
 
-
-  public PentahoOrcInputFormat() throws Exception {
+  public PentahoOrcInputFormat( NamedCluster namedCluster ) throws Exception {
     conf = inClassloader( () -> {
       Configuration conf = new ConfigurationProxy();
       conf.addResource( "hive-site.xml" );
+      ShimConfigsLoader.addConfigsAsResources( namedCluster.getName(), conf::addResource );
       return conf;
     } );
   }

--- a/common/common-format/src/main/java/org/pentaho/hadoop/shim/common/format/parquet/PentahoParquetInputFormat.java
+++ b/common/common-format/src/main/java/org/pentaho/hadoop/shim/common/format/parquet/PentahoParquetInputFormat.java
@@ -34,6 +34,7 @@ import org.apache.hadoop.mapreduce.Job;
 import org.apache.hadoop.mapreduce.TaskAttemptID;
 import org.apache.hadoop.mapreduce.task.TaskAttemptContextImpl;
 import org.apache.log4j.Logger;
+import org.pentaho.big.data.api.cluster.NamedCluster;
 //#if shim_type=="HDP" || shim_type=="EMR" || shim_type=="HDI" || shim_name=="mapr60"
 import org.apache.parquet.hadoop.Footer;
 import org.apache.parquet.hadoop.ParquetFileReader;
@@ -53,6 +54,7 @@ import org.apache.parquet.schema.MessageType;
 //$import parquet.schema.MessageType;
 //#endif
 import org.pentaho.di.core.RowMetaAndData;
+import org.pentaho.hadoop.shim.ShimConfigsLoader;
 import org.pentaho.hadoop.shim.api.format.IParquetInputField;
 import org.pentaho.hadoop.shim.api.format.IPentahoParquetInputFormat;
 import org.pentaho.hadoop.shim.common.ConfigurationProxy;
@@ -70,12 +72,12 @@ public class PentahoParquetInputFormat extends HadoopFormatBase implements IPent
   private ParquetInputFormat<RowMetaAndData> nativeParquetInputFormat;
   private Job job;
 
-  public PentahoParquetInputFormat() throws Exception {
+  public PentahoParquetInputFormat( NamedCluster namedCluster ) throws Exception {
     logger.info( "We are initializing parquet input format" );
 
     inClassloader( () -> {
       ConfigurationProxy conf = new ConfigurationProxy();
-
+      ShimConfigsLoader.addConfigsAsResources( namedCluster.getName(), conf::addResource );
       job = Job.getInstance( conf );
 
       nativeParquetInputFormat = new ParquetInputFormat<>();

--- a/common/common-format/src/test/java/org/pentaho/hadoop/shim/common/format/avro/PentahoAvroInputFormatTest.java
+++ b/common/common-format/src/test/java/org/pentaho/hadoop/shim/common/format/avro/PentahoAvroInputFormatTest.java
@@ -24,6 +24,7 @@ package org.pentaho.hadoop.shim.common.format.avro;
 import org.apache.avro.Schema;
 import org.junit.Before;
 import org.junit.Test;
+import org.pentaho.big.data.api.cluster.NamedCluster;
 import org.pentaho.hadoop.shim.api.format.IAvroInputField;
 import org.pentaho.hadoop.shim.api.format.IPentahoInputFormat;
 
@@ -36,6 +37,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
 
 public class PentahoAvroInputFormatTest {
@@ -48,7 +50,7 @@ public class PentahoAvroInputFormatTest {
 
   @Before
   public void setUp() throws Exception {
-    format = new PentahoAvroInputFormat();
+    format = new PentahoAvroInputFormat( mock( NamedCluster.class ) );
   }
 
   @Test
@@ -85,7 +87,7 @@ public class PentahoAvroInputFormatTest {
 
   @Test
   public void testGetDefaultFields() throws Exception {
-    PentahoAvroInputFormat format = spy( new PentahoAvroInputFormat() );
+    PentahoAvroInputFormat format = spy( new PentahoAvroInputFormat( mock( NamedCluster.class ) ) );
     Schema.Parser parser = new Schema.Parser();
     Schema schema = parser.parse( new File( getFilePath( TYPES_SCHEMA_AVRO ) ) );
     doReturn( schema ).when( format ).readAvroSchema();

--- a/common/common-format/src/test/java/org/pentaho/hadoop/shim/common/format/avro/PentahoAvroReadWriteTest.java
+++ b/common/common-format/src/test/java/org/pentaho/hadoop/shim/common/format/avro/PentahoAvroReadWriteTest.java
@@ -25,6 +25,7 @@ package org.pentaho.hadoop.shim.common.format.avro;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
+import org.pentaho.big.data.api.cluster.NamedCluster;
 import org.pentaho.di.core.RowMetaAndData;
 import org.pentaho.di.core.plugins.PluginRegistry;
 import org.pentaho.di.core.row.RowMeta;
@@ -60,6 +61,7 @@ import java.util.List;
 import static junit.framework.TestCase.fail;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.mock;
 
 public class PentahoAvroReadWriteTest {
   private static InetAddress DEFAULT_INET_ADDR;
@@ -716,7 +718,7 @@ public class PentahoAvroReadWriteTest {
     PluginRegistry.addPluginType( ValueMetaPluginType.getInstance() );
     PluginRegistry.init( true );
 
-    PentahoAvroInputFormat pentahoAvroInputFormat = new PentahoAvroInputFormat();
+    PentahoAvroInputFormat pentahoAvroInputFormat = new PentahoAvroInputFormat( mock( NamedCluster.class ) );
     pentahoAvroInputFormat.setInputFields( avroInputFields );
     pentahoAvroInputFormat.setInputFile( filePath );
     IPentahoInputFormat.IPentahoRecordReader pentahoRecordReader = pentahoAvroInputFormat.createRecordReader( null );

--- a/common/common-format/src/test/java/org/pentaho/hadoop/shim/common/format/avro/StreamingInputTest.java
+++ b/common/common-format/src/test/java/org/pentaho/hadoop/shim/common/format/avro/StreamingInputTest.java
@@ -23,6 +23,7 @@ package org.pentaho.hadoop.shim.common.format.avro;
 
 import org.apache.commons.io.FileUtils;
 import org.junit.Test;
+import org.pentaho.big.data.api.cluster.NamedCluster;
 import org.pentaho.di.core.RowMetaAndData;
 import org.pentaho.di.core.plugins.PluginRegistry;
 import org.pentaho.di.core.row.ValueMetaInterface;
@@ -43,6 +44,7 @@ import java.util.List;
 import java.util.TimeZone;
 
 import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.mock;
 
 public class StreamingInputTest {
   private DateFormat dateFormat = new SimpleDateFormat( "yyyy/MM/dd HH:mm:ss.SSS" );
@@ -98,7 +100,7 @@ public class StreamingInputTest {
 
     ByteArrayInputStream inputStream = fileToByteArrayInputStream( filePath );
 
-    PentahoAvroInputFormat pentahoAvroInputFormat = new PentahoAvroInputFormat();
+    PentahoAvroInputFormat pentahoAvroInputFormat = new PentahoAvroInputFormat( mock( NamedCluster.class) );
 
     pentahoAvroInputFormat.setInputFields( avroInputFields );
     pentahoAvroInputFormat.setInputStreamFieldName( "stream" );

--- a/common/common-format/src/test/java/org/pentaho/hadoop/shim/common/format/orc/PentahoOrcInputFormatTest.java
+++ b/common/common-format/src/test/java/org/pentaho/hadoop/shim/common/format/orc/PentahoOrcInputFormatTest.java
@@ -23,10 +23,13 @@ package org.pentaho.hadoop.shim.common.format.orc;
 
 import org.junit.Before;
 import org.junit.Test;
+import org.pentaho.big.data.api.cluster.NamedCluster;
 import org.pentaho.hadoop.shim.api.format.IOrcInputField;
 
 import java.util.ArrayList;
 import java.util.List;
+
+import static org.mockito.Mockito.mock;
 
 /**
  * Created by tkafalas on 11/20/2017.
@@ -38,7 +41,7 @@ public class PentahoOrcInputFormatTest {
 
   @Before
   public void setup() throws Exception {
-    pentahoOrcInputFormat = new PentahoOrcInputFormat();
+    pentahoOrcInputFormat = new PentahoOrcInputFormat( mock( NamedCluster.class ) );
     mockSchemaDescription = new ArrayList<IOrcInputField>();
   }
 

--- a/common/common-format/src/test/java/org/pentaho/hadoop/shim/common/format/orc/PentahoOrcReadWriteTest.java
+++ b/common/common-format/src/test/java/org/pentaho/hadoop/shim/common/format/orc/PentahoOrcReadWriteTest.java
@@ -24,6 +24,7 @@ package org.pentaho.hadoop.shim.common.format.orc;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
+import org.pentaho.big.data.api.cluster.NamedCluster;
 import org.pentaho.di.core.RowMetaAndData;
 import org.pentaho.di.core.plugins.PluginRegistry;
 import org.pentaho.di.core.row.RowMeta;
@@ -61,6 +62,7 @@ import java.util.List;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import static org.junit.Assert.*;
+import static org.mockito.Mockito.mock;
 
 
 /**
@@ -314,7 +316,7 @@ public class PentahoOrcReadWriteTest {
     PluginRegistry.addPluginType( ValueMetaPluginType.getInstance() );
     PluginRegistry.init( true );
 
-    PentahoOrcInputFormat pentahoOrcInputFormat = new PentahoOrcInputFormat();
+    PentahoOrcInputFormat pentahoOrcInputFormat = new PentahoOrcInputFormat( mock( NamedCluster.class ) );
     pentahoOrcInputFormat.setSchema( orcInputFields );
     pentahoOrcInputFormat.setInputFile( filePath );
     IPentahoInputFormat.IPentahoRecordReader pentahoRecordReader = pentahoOrcInputFormat.createRecordReader( null );
@@ -327,7 +329,7 @@ public class PentahoOrcReadWriteTest {
   }
 
   private void testGetSchema() throws Exception {
-    PentahoOrcInputFormat pentahoOrcInputFormat = new PentahoOrcInputFormat();
+    PentahoOrcInputFormat pentahoOrcInputFormat = new PentahoOrcInputFormat( mock( NamedCluster.class ) );
     pentahoOrcInputFormat.setInputFile( filePath );
 
     assertNotNull( "Schema Description should be populated", orcInputFields );

--- a/common/common-format/src/test/java/org/pentaho/hadoop/shim/common/format/parquet/PentahoParquetInputFormatTest.java
+++ b/common/common-format/src/test/java/org/pentaho/hadoop/shim/common/format/parquet/PentahoParquetInputFormatTest.java
@@ -44,6 +44,7 @@ import org.junit.Test;
 import org.junit.Assert;
 import org.mockito.Mockito;
 import org.mockito.internal.util.reflection.Whitebox;
+import org.pentaho.big.data.api.cluster.NamedCluster;
 import org.pentaho.di.core.RowMetaAndData;
 import org.pentaho.di.core.row.RowMeta;
 import org.pentaho.di.core.row.ValueMetaInterface;
@@ -58,6 +59,8 @@ import org.pentaho.hadoop.shim.api.format.IPentahoInputFormat;
 import org.pentaho.hadoop.shim.api.format.IPentahoInputFormat.IPentahoInputSplit;
 import org.pentaho.hadoop.shim.api.format.IPentahoInputFormat.IPentahoRecordReader;
 
+import static org.mockito.Mockito.mock;
+
 public class PentahoParquetInputFormatTest {
 
   @Test
@@ -65,7 +68,7 @@ public class PentahoParquetInputFormatTest {
 
     String parquetFilePath = getClass().getClassLoader().getResource( "sample.pqt" ).toExternalForm();
 
-    PentahoParquetInputFormat pentahoParquetInputFormat = new PentahoParquetInputFormat();
+    PentahoParquetInputFormat pentahoParquetInputFormat = new PentahoParquetInputFormat( mock( NamedCluster.class ) );
     pentahoParquetInputFormat.setInputFile( getClass().getClassLoader().getResource( "sample.pqt" ).toExternalForm() );
     List<IParquetInputField> schema = pentahoParquetInputFormat.readSchema( parquetFilePath );
 
@@ -106,7 +109,7 @@ public class PentahoParquetInputFormatTest {
   public void testSpacesInFilePath() throws Exception {
     Exception exception = null;
     try {
-      PentahoParquetInputFormat in = new PentahoParquetInputFormat();
+      PentahoParquetInputFormat in = new PentahoParquetInputFormat( mock( NamedCluster.class ) );
       in.setInputFile( "/test test/out.txt" );
     } catch (  Exception e ) {
       exception = e;
@@ -146,7 +149,7 @@ public class PentahoParquetInputFormatTest {
       new Timestamp( df.parse( "2018-05-01 13:00:00" ).getTime() ),
       new Timestamp( df.parse( "2018-05-01 13:00:00" ).getTime() ) } );
 
-    PentahoParquetInputFormat inSchema = new PentahoParquetInputFormat();
+    PentahoParquetInputFormat inSchema = new PentahoParquetInputFormat( mock( NamedCluster.class ) );
     List<? extends IParquetInputField> fileFields =
       inSchema.readSchema( getClass().getClassLoader().getResource( file ).toExternalForm() );
 
@@ -201,7 +204,7 @@ public class PentahoParquetInputFormatTest {
 
   private List<RowMetaAndData> readFile( String file, List<IParquetInputField> readSchema ) throws Exception {
     System.out.println( "Read '" + file + "' as schema: " + readSchema );
-    PentahoParquetInputFormat in = new PentahoParquetInputFormat();
+    PentahoParquetInputFormat in = new PentahoParquetInputFormat( mock( NamedCluster.class ) );
     in.setInputFile( getClass().getClassLoader().getResource( file ).toExternalForm() );
     in.setSchema( readSchema );
 

--- a/common/common-format/src/test/java/org/pentaho/hadoop/shim/common/format/parquet/PentahoParquetRecordWriterTest.java
+++ b/common/common-format/src/test/java/org/pentaho/hadoop/shim/common/format/parquet/PentahoParquetRecordWriterTest.java
@@ -46,6 +46,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mockito;
 import org.mockito.internal.util.reflection.Whitebox;
+import org.pentaho.big.data.api.cluster.NamedCluster;
 import org.pentaho.di.core.RowMetaAndData;
 import org.pentaho.di.core.row.RowMeta;
 import org.pentaho.di.core.row.value.ValueMetaString;
@@ -60,6 +61,8 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.List;
+
+import static org.mockito.Mockito.mock;
 
 
 public class PentahoParquetRecordWriterTest {
@@ -172,7 +175,7 @@ public class PentahoParquetRecordWriterTest {
 
     IPentahoInputFormat.IPentahoRecordReader recordReader = null;
     try {
-      PentahoParquetInputFormat pentahoParquetInputFormat = new PentahoParquetInputFormat();
+      PentahoParquetInputFormat pentahoParquetInputFormat = new PentahoParquetInputFormat( mock( NamedCluster.class ) );
       pentahoParquetInputFormat.setInputFile( parquetFilePath );
       List<IParquetInputField> schema = pentahoParquetInputFormat.readSchema( parquetFilePath );
       pentahoParquetInputFormat.setSchema( schema );

--- a/common/modern/src/main/java/org/pentaho/hadoop/shim/common/delegating/DelegatingFormatShim.java
+++ b/common/modern/src/main/java/org/pentaho/hadoop/shim/common/delegating/DelegatingFormatShim.java
@@ -30,6 +30,7 @@ import org.pentaho.hadoop.shim.common.CommonFormatShim;
 import org.pentaho.hadoop.shim.common.authorization.HadoopAuthorizationService;
 import org.pentaho.hadoop.shim.common.authorization.HasHadoopAuthorizationService;
 import org.pentaho.hadoop.shim.spi.FormatShim;
+import org.pentaho.big.data.api.cluster.NamedCluster;
 
 public class DelegatingFormatShim extends CommonFormatShim implements HasHadoopAuthorizationService, FormatShim,
     Processable {
@@ -46,8 +47,8 @@ public class DelegatingFormatShim extends CommonFormatShim implements HasHadoopA
   }
 
   @Override
-  public <T extends IPentahoInputFormat> T createInputFormat( Class<T> type ) throws Exception {
-    return delegate.createInputFormat( type );
+  public <T extends IPentahoInputFormat> T createInputFormat( Class<T> type, NamedCluster namedCluster ) throws Exception {
+    return delegate.createInputFormat( type, namedCluster );
   }
 
   @Override

--- a/pom.xml
+++ b/pom.xml
@@ -24,6 +24,7 @@
     <commons-beanutils.version>1.9.3</commons-beanutils.version>
     <commons-io.version>2.4</commons-io.version>
     <pentaho-hadoop-shims-api.version>9.0.0.0-SNAPSHOT</pentaho-hadoop-shims-api.version>
+    <pentaho-big-data-api-cluster.version>9.0.0.0-SNAPSHOT</pentaho-big-data-api-cluster.version>
     <xerces.version>2.8.1</xerces.version>
     <oss-licenses.version>9.0.0.0-SNAPSHOT</oss-licenses.version>
     <eula-wrap_create-izpack-installer-jar-phase></eula-wrap_create-izpack-installer-jar-phase>


### PR DESCRIPTION
@pentaho/moseisley Please review.
https://github.com/pentaho/big-data-plugin/pull/1455