### PR TITLE
[BACKLOG-25619] - HDP30 shim: Hive2 connection cannot be established using hdp30 shim

### DIFF
--- a/shims/hdp30/client/pom.xml
+++ b/shims/hdp30/client/pom.xml
@@ -85,10 +85,6 @@
         </exclusion>
         <exclusion>
           <groupId>org.apache.curator</groupId>
-          <artifactId>curator-client</artifactId>
-        </exclusion>
-        <exclusion>
-          <groupId>org.apache.curator</groupId>
           <artifactId>curator-framework</artifactId>
         </exclusion>
         <exclusion>


### PR DESCRIPTION
@pentaho/moseisley Please review.