### PR TITLE
[BACKLOG-25703] - HDP 3.0 - Added missing dependency for com/codahale/metrics/Metric

### DIFF
--- a/shims/hdp30/default/src/assembly/assembly.xml
+++ b/shims/hdp30/default/src/assembly/assembly.xml
@@ -28,6 +28,7 @@
         <include>org.apache.httpcomponents:httpclient</include>
         <include>org.apache.knox:gateway-shell</include>
         <include>org.apache.hadoop:hadoop-aws</include>
+        <include>com.codahale.metrics:metrics-core</include>
       </includes>
       <excludes>
         <exclude>log4j:log4j</exclude>


### PR DESCRIPTION
@pentaho/moseisley Please review.