### PR TITLE
[BAD-1549] EMR 5.11 shim contains conflicting JARs

### DIFF
--- a/common/common-shim/pom.xml
+++ b/common/common-shim/pom.xml
@@ -15,8 +15,6 @@
     <httpcore.version>4.4.6</httpcore.version>
     <org.apache.parquet.version>1.8.1</org.apache.parquet.version>
     <org.apache.avro.version>1.8.1</org.apache.avro.version>
-    <jackson.version>2.6.5</jackson.version>
-    <aws-java-sdk.version>1.11.275</aws-java-sdk.version>
     <integration-test.src>src/it/java</integration-test.src>
   </properties>
   <dependencies>
@@ -108,7 +106,11 @@
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-databind</artifactId>
-      <version>${jackson.version}</version>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-core</artifactId>
       <scope>provided</scope>
     </dependency>
     <dependency>
@@ -125,13 +127,6 @@
     <dependency>
       <groupId>com.amazonaws</groupId>
       <artifactId>aws-java-sdk-core</artifactId>
-      <version>${aws-java-sdk.version}</version>
-      <exclusions>
-        <exclusion>
-          <groupId>*</groupId>
-          <artifactId>*</artifactId>
-        </exclusion>
-      </exclusions>
     </dependency>
     <dependency>
       <groupId>org.powermock</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -32,6 +32,7 @@
     <eula-wrap_assign-deps-to-properties-phase></eula-wrap_assign-deps-to-properties-phase>
     <org.apache.orc.version>1.2.3</org.apache.orc.version>
     <jets3t.version>0.9.4</jets3t.version>
+    <aws-java-sdk.version>1.11.275</aws-java-sdk.version>
   </properties>
 
   <dependencyManagement>
@@ -130,6 +131,39 @@
         <version>${oss-licenses.version}</version>
         <type>zip</type>
         <optional>true</optional>
+      </dependency>
+      <dependency>
+        <groupId>com.amazonaws</groupId>
+        <artifactId>aws-java-sdk-core</artifactId>
+        <version>${aws-java-sdk.version}</version>
+        <exclusions>
+          <exclusion>
+            <groupId>*</groupId>
+            <artifactId>*</artifactId>
+          </exclusion>
+        </exclusions>
+      </dependency>
+      <dependency>
+        <groupId>com.amazonaws</groupId>
+        <artifactId>aws-java-sdk-s3</artifactId>
+        <version>${aws-java-sdk.version}</version>
+        <exclusions>
+          <exclusion>
+            <groupId>*</groupId>
+            <artifactId>*</artifactId>
+          </exclusion>
+        </exclusions>
+      </dependency>
+      <dependency>
+        <groupId>com.amazonaws</groupId>
+        <artifactId>aws-java-sdk-bundle</artifactId>
+        <version>${aws-java-sdk.version}</version>
+        <exclusions>
+          <exclusion>
+            <groupId>*</groupId>
+            <artifactId>*</artifactId>
+          </exclusion>
+        </exclusions>
       </dependency>
       <dependency>
         <groupId>org.hamcrest</groupId>

--- a/shims/cdh512/impl/pom.xml
+++ b/shims/cdh512/impl/pom.xml
@@ -18,6 +18,20 @@
   </properties>
   <dependencies>
     <dependency>
+      <groupId>com.amazonaws</groupId>
+      <artifactId>aws-java-sdk-bundle</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-core</artifactId>
+      <scope>compile</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-databind</artifactId>
+      <scope>compile</scope>
+    </dependency>
+    <dependency>
       <groupId>org.pentaho</groupId>
       <artifactId>pentaho-hadoop-shims-cdh512-scope-client</artifactId>
       <version>${project.version}</version>

--- a/shims/cdh513/impl/pom.xml
+++ b/shims/cdh513/impl/pom.xml
@@ -18,6 +18,20 @@
   </properties>
   <dependencies>
     <dependency>
+      <groupId>com.amazonaws</groupId>
+      <artifactId>aws-java-sdk-bundle</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-core</artifactId>
+      <scope>compile</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-databind</artifactId>
+      <scope>compile</scope>
+    </dependency>
+    <dependency>
       <groupId>org.pentaho</groupId>
       <artifactId>pentaho-hadoop-shims-cdh513-scope-client</artifactId>
       <version>${project.version}</version>

--- a/shims/cdh514/impl/pom.xml
+++ b/shims/cdh514/impl/pom.xml
@@ -18,6 +18,20 @@
   </properties>
   <dependencies>
     <dependency>
+      <groupId>com.amazonaws</groupId>
+      <artifactId>aws-java-sdk-bundle</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-core</artifactId>
+      <scope>compile</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-databind</artifactId>
+      <scope>compile</scope>
+    </dependency>
+    <dependency>
       <groupId>org.pentaho</groupId>
       <artifactId>pentaho-hadoop-shims-cdh514-scope-client</artifactId>
       <version>${project.version}</version>

--- a/shims/cdh601/impl/pom.xml
+++ b/shims/cdh601/impl/pom.xml
@@ -18,6 +18,20 @@
   </properties>
   <dependencies>
     <dependency>
+      <groupId>com.amazonaws</groupId>
+      <artifactId>aws-java-sdk-core</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-core</artifactId>
+      <scope>compile</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-databind</artifactId>
+      <scope>compile</scope>
+    </dependency>
+    <dependency>
       <groupId>org.pentaho</groupId>
       <artifactId>pentaho-hadoop-shims-cdh601-scope-client</artifactId>
       <version>${project.version}</version>

--- a/shims/emr511/client/pom.xml
+++ b/shims/emr511/client/pom.xml
@@ -61,13 +61,6 @@
     <dependency>
       <groupId>com.amazonaws</groupId>
       <artifactId>aws-java-sdk-core</artifactId>
-      <version>${aws-java-sdk.version}</version>
-      <exclusions>
-        <exclusion>
-          <groupId>*</groupId>
-          <artifactId>*</artifactId>
-        </exclusion>
-      </exclusions>
     </dependency>
     <dependency>
       <groupId>org.apache.hadoop</groupId>

--- a/shims/emr511/client/src/assembly/assembly.xml
+++ b/shims/emr511/client/src/assembly/assembly.xml
@@ -17,14 +17,6 @@
         <include>joda-time:joda-time</include>
         <include>commons-configuration:commons-configuration</include>
       </includes>
-      <excludes>
-        <exclude>org.apache.hadoop:hadoop-yarn-server-nodemanager</exclude>
-        <exclude>xml-apis:*</exclude>
-        <exclude>commons-collections:*</exclude>
-        <exclude>javax.xml.stream:*</exclude>
-        <exclude>org.apache.calcite:*</exclude>
-        <exclude>*:tests:*</exclude>
-      </excludes>
     </dependencySet>
     <dependencySet>
       <outputDirectory>lib/client</outputDirectory>
@@ -44,13 +36,11 @@
         <include>org.apache.hadoop:hadoop-mapreduce-client-shuffle</include>
       </includes>
       <excludes>
+        <exclude>com.amazonaws:aws-java-sdk:*</exclude>
         <exclude>org.apache.hadoop:hadoop-yarn-server-nodemanager</exclude>
         <exclude>xml-apis:*</exclude>
         <exclude>*:stax-api:*</exclude>
         <exclude>commons-collections:*</exclude>
-        <exclude>javax.xml.stream:*</exclude>
-        <exclude>org.apache.calcite:*</exclude>
-        <exclude>*:tests:*</exclude>
       </excludes>
     </dependencySet>
   </dependencySets>

--- a/shims/emr511/impl/pom.xml
+++ b/shims/emr511/impl/pom.xml
@@ -14,8 +14,6 @@
     <log4j.version>1.2.17</log4j.version>
     <commons-io.version>2.4</commons-io.version>
     <xstream.version>1.4.9</xstream.version>
-    <aws-java-sdk.version>1.11.275</aws-java-sdk.version>
-    <jackson.version>2.6.5</jackson.version>
     <shim.type>EMR</shim.type>
   </properties>
   <dependencies>
@@ -27,7 +25,11 @@
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-databind</artifactId>
-      <version>${jackson.version}</version>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-core</artifactId>
       <scope>provided</scope>
     </dependency>
     <dependency>
@@ -123,13 +125,6 @@
     <dependency>
       <groupId>com.amazonaws</groupId>
       <artifactId>aws-java-sdk-core</artifactId>
-      <version>${aws-java-sdk.version}</version>
-      <exclusions>
-        <exclusion>
-          <groupId>*</groupId>
-          <artifactId>*</artifactId>
-        </exclusion>
-      </exclusions>
     </dependency>
   </dependencies>
   <build>

--- a/shims/emr511/pom.xml
+++ b/shims/emr511/pom.xml
@@ -22,7 +22,6 @@
     <org.apache.oozie.version>4.3.0</org.apache.oozie.version>
     <sqoop.version>1.4.6-pentaho-hbase120</sqoop.version>
     <org.apache.avro.version>1.8.0</org.apache.avro.version>
-    <aws-java-sdk.version>1.11.275</aws-java-sdk.version>
     <!-- client folder -->
     <org.apache.hadoop.version>2.7.3</org.apache.hadoop.version>
     <automaton.version>1.11-8</automaton.version>

--- a/shims/emr59/client/pom.xml
+++ b/shims/emr59/client/pom.xml
@@ -61,13 +61,6 @@
     <dependency>
       <groupId>com.amazonaws</groupId>
       <artifactId>aws-java-sdk-core</artifactId>
-      <version>${aws-java-sdk.version}</version>
-      <exclusions>
-        <exclusion>
-          <groupId>*</groupId>
-          <artifactId>*</artifactId>
-        </exclusion>
-      </exclusions>
     </dependency>
     <dependency>
       <groupId>org.apache.hadoop</groupId>

--- a/shims/emr59/impl/pom.xml
+++ b/shims/emr59/impl/pom.xml
@@ -14,8 +14,6 @@
     <log4j.version>1.2.17</log4j.version>
     <commons-io.version>2.4</commons-io.version>
     <xstream.version>1.4.9</xstream.version>
-    <aws-java-sdk.version>1.11.275</aws-java-sdk.version>
-    <jackson.version>2.6.5</jackson.version>
     <shim.type>EMR</shim.type>
   </properties>
   <dependencies>
@@ -27,7 +25,11 @@
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-databind</artifactId>
-      <version>${jackson.version}</version>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-core</artifactId>
       <scope>provided</scope>
     </dependency>
     <dependency>
@@ -123,13 +125,6 @@
     <dependency>
       <groupId>com.amazonaws</groupId>
       <artifactId>aws-java-sdk-core</artifactId>
-      <version>${aws-java-sdk.version}</version>
-      <exclusions>
-        <exclusion>
-          <groupId>*</groupId>
-          <artifactId>*</artifactId>
-        </exclusion>
-      </exclusions>
     </dependency>
   </dependencies>
   <build>

--- a/shims/emr59/pom.xml
+++ b/shims/emr59/pom.xml
@@ -20,7 +20,6 @@
     <sqoop.version>1.4.6-pentaho-hbase120</sqoop.version>
 	<org.apache.avro.version>1.8.0</org.apache.avro.version>
     <hadoop-aws.version>2.7.3</hadoop-aws.version>
-    <aws-java-sdk.version>1.11.275</aws-java-sdk.version>
     <!-- client folder -->
     <org.apache.hadoop.version>2.7.3</org.apache.hadoop.version>
     <com.amazonaws.version>1.11.160</com.amazonaws.version>

--- a/shims/hdi35/client/pom.xml
+++ b/shims/hdi35/client/pom.xml
@@ -136,12 +136,10 @@
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-databind</artifactId>
-      <version>2.2.3</version>
     </dependency>
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-annotations</artifactId>
-      <version>2.9.4</version>
     </dependency>
   </dependencies>
   <build>

--- a/shims/hdi35/default/pom.xml
+++ b/shims/hdi35/default/pom.xml
@@ -150,24 +150,10 @@
     <dependency>
       <groupId>org.codehaus.jackson</groupId>
       <artifactId>jackson-core-asl</artifactId>
-      <version>${org.codehaus.jackson}</version>
-      <exclusions>
-        <exclusion>
-          <groupId>*</groupId>
-          <artifactId>*</artifactId>
-        </exclusion>
-      </exclusions>
     </dependency>
     <dependency>
       <groupId>org.codehaus.jackson</groupId>
       <artifactId>jackson-mapper-asl</artifactId>
-      <version>${org.codehaus.jackson}</version>
-      <exclusions>
-        <exclusion>
-          <groupId>*</groupId>
-          <artifactId>*</artifactId>
-        </exclusion>
-      </exclusions>
     </dependency>
   </dependencies>
   <build>

--- a/shims/hdi35/impl/pom.xml
+++ b/shims/hdi35/impl/pom.xml
@@ -14,8 +14,6 @@
     <log4j.version>1.2.14</log4j.version>
     <xstream.version>1.4.9</xstream.version>
     <commons-io.version>2.4</commons-io.version>
-    <com.fasterxml.jackson.core.version>2.5.3</com.fasterxml.jackson.core.version>
-    <aws-java-sdk.version>1.11.275</aws-java-sdk.version>
     <shim.type>HDI</shim.type>
   </properties>
   <dependencies>
@@ -130,26 +128,17 @@
     </dependency>
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
-      <artifactId>jackson-core</artifactId>
-      <version>${com.fasterxml.jackson.core.version}</version>
+      <artifactId>jackson-databind</artifactId>
       <scope>compile</scope>
-      <exclusions>
-        <exclusion>
-          <artifactId>*</artifactId>
-          <groupId>*</groupId>
-        </exclusion>
-      </exclusions>
+    </dependency>
+    <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-core</artifactId>
+      <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>com.amazonaws</groupId>
       <artifactId>aws-java-sdk-core</artifactId>
-      <version>${aws-java-sdk.version}</version>
-      <exclusions>
-        <exclusion>
-          <groupId>*</groupId>
-          <artifactId>*</artifactId>
-        </exclusion>
-      </exclusions>
     </dependency>
   </dependencies>
   <build>

--- a/shims/hdi35/pom.xml
+++ b/shims/hdi35/pom.xml
@@ -22,7 +22,6 @@
     <hadoop-azure.version>2.7.1</hadoop-azure.version>
     <hadoop-aws.version>2.7.3</hadoop-aws.version>
     <avro.version>1.8.0</avro.version>
-    <org.codehaus.jackson>1.9.13</org.codehaus.jackson>
     <org.apache.httpcomponents.version>4.4</org.apache.httpcomponents.version>
     <!-- client folder -->
     <hadoop-client.version>2.7.3.2.5.0.0-1245</hadoop-client.version>

--- a/shims/hdp25/impl/pom.xml
+++ b/shims/hdp25/impl/pom.xml
@@ -12,8 +12,6 @@
   <version>8.3.0.0-SNAPSHOT</version>
   <properties>
     <org.xerial.snappy.version>1.1.1.3</org.xerial.snappy.version>
-    <com.fasterxml.jackson.core2.version>2.4.0</com.fasterxml.jackson.core2.version>
-    <org.codehaus.jackson.version>1.9.2</org.codehaus.jackson.version>
     <com.google.code.findbugs.version>3.0.0</com.google.code.findbugs.version>
     <org.apache.pig.version>0.16.0.2.5.0.0-1245</org.apache.pig.version>
     <joda-time.version>2.5</joda-time.version>
@@ -25,10 +23,8 @@
     <commons-net.version>3.1</commons-net.version>
     <org.tukaani.version>1.5</org.tukaani.version>
     <org.slf4j.version>1.7.5</org.slf4j.version>
-    <org.xerial.snappy.version>1.1.1.3</org.xerial.snappy.version>
     <com.google.protobuf.version>2.5.0</com.google.protobuf.version>
     <commons-pool.version>1.5.4</commons-pool.version>
-    <com.fasterxml.jackson.core.version>2.4.2</com.fasterxml.jackson.core.version>
     <org.apache.oozie.version>4.2.0.2.5.0.0-1245</org.apache.oozie.version>
     <org.apache.sqoop.version>1.4.6.2.5.0.0-1245</org.apache.sqoop.version>
     <dk.brics.automaton.version>1.11-8</dk.brics.automaton.version>
@@ -54,6 +50,10 @@
     <shim.type>HDP</shim.type>
   </properties>
   <dependencies>
+    <dependency>
+      <groupId>com.amazonaws</groupId>
+      <artifactId>aws-java-sdk-core</artifactId>
+    </dependency>
     <dependency>
       <groupId>org.pentaho</groupId>
       <artifactId>pentaho-hadoop-shims-api</artifactId>
@@ -149,14 +149,6 @@
           <groupId>org.apache.httpcomponents</groupId>
         </exclusion>
         <exclusion>
-          <artifactId>jackson-core-asl</artifactId>
-          <groupId>org.codehaus.jackson</groupId>
-        </exclusion>
-        <exclusion>
-          <artifactId>jackson-mapper-asl</artifactId>
-          <groupId>org.codehaus.jackson</groupId>
-        </exclusion>
-        <exclusion>
           <artifactId>slf4j-api</artifactId>
           <groupId>org.slf4j</groupId>
         </exclusion>
@@ -175,17 +167,6 @@
         <exclusion>
           <artifactId>commons-beanutils-core</artifactId>
           <groupId>commons-beanutils</groupId>
-        </exclusion>
-      </exclusions>
-    </dependency>
-	<dependency>
-      <groupId>org.xerial.snappy</groupId>
-      <artifactId>snappy-java</artifactId>
-      <version>${org.xerial.snappy.version}</version>
-      <exclusions>
-        <exclusion>
-          <groupId>*</groupId>
-          <artifactId>*</artifactId>
         </exclusion>
       </exclusions>
     </dependency>
@@ -507,28 +488,14 @@
       </exclusions>
     </dependency>
     <dependency>
-      <groupId>org.codehaus.jackson</groupId>
-      <artifactId>jackson-core-asl</artifactId>
-      <version>${org.codehaus.jackson.version}</version>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-databind</artifactId>
       <scope>compile</scope>
-      <exclusions>
-        <exclusion>
-          <artifactId>*</artifactId>
-          <groupId>*</groupId>
-        </exclusion>
-      </exclusions>
     </dependency>
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-core</artifactId>
-      <version>${com.fasterxml.jackson.core.version}</version>
       <scope>compile</scope>
-      <exclusions>
-        <exclusion>
-          <artifactId>*</artifactId>
-          <groupId>*</groupId>
-        </exclusion>
-      </exclusions>
     </dependency>
     <dependency>
       <groupId>commons-logging</groupId>
@@ -615,33 +582,9 @@
       </exclusions>
     </dependency>
     <dependency>
-      <groupId>org.codehaus.jackson</groupId>
-      <artifactId>jackson-mapper-asl</artifactId>
-      <version>${org.codehaus.jackson.version}</version>
-      <scope>compile</scope>
-      <exclusions>
-        <exclusion>
-          <artifactId>*</artifactId>
-          <groupId>*</groupId>
-        </exclusion>
-      </exclusions>
-    </dependency>
-    <dependency>
       <groupId>joda-time</groupId>
       <artifactId>joda-time</artifactId>
       <version>${joda-time.version}</version>
-      <scope>compile</scope>
-      <exclusions>
-        <exclusion>
-          <artifactId>*</artifactId>
-          <groupId>*</groupId>
-        </exclusion>
-      </exclusions>
-    </dependency>
-    <dependency>
-      <groupId>com.fasterxml.jackson.core</groupId>
-      <artifactId>jackson-annotations</artifactId>
-      <version>${com.fasterxml.jackson.core2.version}</version>
       <scope>compile</scope>
       <exclusions>
         <exclusion>
@@ -750,18 +693,6 @@
       <groupId>commons-net</groupId>
       <artifactId>commons-net</artifactId>
       <version>${commons-net.version}</version>
-      <scope>compile</scope>
-      <exclusions>
-        <exclusion>
-          <artifactId>*</artifactId>
-          <groupId>*</groupId>
-        </exclusion>
-      </exclusions>
-    </dependency>
-    <dependency>
-      <groupId>com.fasterxml.jackson.core</groupId>
-      <artifactId>jackson-databind</artifactId>
-      <version>${com.fasterxml.jackson.core.version}</version>
       <scope>compile</scope>
       <exclusions>
         <exclusion>

--- a/shims/hdp26/impl/pom.xml
+++ b/shims/hdp26/impl/pom.xml
@@ -12,10 +12,19 @@
   <version>8.3.0.0-SNAPSHOT</version>
   <properties>
     <xstream.version>1.4.9</xstream.version>
-    <aws-java-sdk.version>1.11.275</aws-java-sdk.version>
     <shim.type>HDP</shim.type>
   </properties>
   <dependencies>
+    <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-core</artifactId>
+      <scope>compile</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-databind</artifactId>
+      <scope>compile</scope>
+    </dependency>
     <dependency>
       <groupId>org.apache.hadoop</groupId>
       <artifactId>hadoop-common</artifactId>
@@ -104,13 +113,6 @@
     <dependency>
       <groupId>com.amazonaws</groupId>
       <artifactId>aws-java-sdk-core</artifactId>
-      <version>${aws-java-sdk.version}</version>
-      <exclusions>
-        <exclusion>
-          <groupId>*</groupId>
-          <artifactId>*</artifactId>
-        </exclusion>
-      </exclusions>
     </dependency>
   </dependencies>
   <build>

--- a/shims/hdp30/impl/pom.xml
+++ b/shims/hdp30/impl/pom.xml
@@ -12,10 +12,19 @@
   <version>8.3.0.0-SNAPSHOT</version>
   <properties>
     <xstream.version>1.4.9</xstream.version>
-    <aws-java-sdk.version>1.11.275</aws-java-sdk.version>
     <shim.type>HDP</shim.type>
   </properties>
   <dependencies>
+    <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-core</artifactId>
+      <scope>compile</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-databind</artifactId>
+      <scope>compile</scope>
+    </dependency>
     <dependency>
       <groupId>org.apache.hadoop</groupId>
       <artifactId>hadoop-common</artifactId>
@@ -104,13 +113,6 @@
     <dependency>
       <groupId>com.amazonaws</groupId>
       <artifactId>aws-java-sdk-core</artifactId>
-      <version>${aws-java-sdk.version}</version>
-      <exclusions>
-        <exclusion>
-          <groupId>*</groupId>
-          <artifactId>*</artifactId>
-        </exclusion>
-      </exclusions>
     </dependency>
   </dependencies>
   <build>

--- a/shims/mapr520/impl/pom.xml
+++ b/shims/mapr520/impl/pom.xml
@@ -12,12 +12,9 @@
   <version>8.3.0.0-SNAPSHOT</version>
   <properties>
     <log4j.version>1.2.15</log4j.version>
-    <com.fasterxml.jackson.core.version>2.5.3</com.fasterxml.jackson.core.version>
     <xstream.version>1.4.9</xstream.version>
     <maprfs.version>5.2.0-mapr</maprfs.version>
     <commons-configuration.version>1.6</commons-configuration.version>
-    <aws-java-sdk-core.version>1.11.275</aws-java-sdk-core.version>
-    <aws-java-sdk.version>1.7.4</aws-java-sdk.version>
     <shim.type>MAPR</shim.type>
   </properties>
   <dependencies>
@@ -41,38 +38,12 @@
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-databind</artifactId>
-      <version>${com.fasterxml.jackson.core.version}</version>
       <scope>compile</scope>
-      <exclusions>
-        <exclusion>
-          <artifactId>*</artifactId>
-          <groupId>*</groupId>
-        </exclusion>
-      </exclusions>
     </dependency>
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-core</artifactId>
-      <version>${com.fasterxml.jackson.core.version}</version>
       <scope>compile</scope>
-      <exclusions>
-        <exclusion>
-          <artifactId>*</artifactId>
-          <groupId>*</groupId>
-        </exclusion>
-      </exclusions>
-    </dependency>
-    <dependency>
-      <groupId>com.fasterxml.jackson.core</groupId>
-      <artifactId>jackson-annotations</artifactId>
-      <version>${com.fasterxml.jackson.core.version}</version>
-      <scope>compile</scope>
-      <exclusions>
-        <exclusion>
-          <artifactId>*</artifactId>
-          <groupId>*</groupId>
-        </exclusion>
-      </exclusions>
     </dependency>
     <!--here test dependencies-->
     <dependency>
@@ -228,20 +199,12 @@
     </dependency>
     <dependency>
       <groupId>com.amazonaws</groupId>
-      <artifactId>aws-java-sdk</artifactId>
-      <version>${aws-java-sdk.version}</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>com.amazonaws</groupId>
       <artifactId>aws-java-sdk-core</artifactId>
-      <version>${aws-java-sdk-core.version}</version>
-      <exclusions>
-        <exclusion>
-          <groupId>*</groupId>
-          <artifactId>*</artifactId>
-        </exclusion>
-      </exclusions>
+    </dependency>
+    <dependency> <!-- required to run tests -->
+      <groupId>com.amazonaws</groupId>
+      <artifactId>aws-java-sdk-s3</artifactId>
+      <scope>test</scope>
     </dependency>
   </dependencies>
   <build>

--- a/shims/mapr60/impl/pom.xml
+++ b/shims/mapr60/impl/pom.xml
@@ -12,12 +12,9 @@
   <version>8.3.0.0-SNAPSHOT</version>
   <properties>
     <log4j.version>1.2.15</log4j.version>
-    <com.fasterxml.jackson.core.version>2.5.3</com.fasterxml.jackson.core.version>
     <xstream.version>1.4.9</xstream.version>
     <maprfs.version>6.0.0-mapr</maprfs.version>
     <commons-configuration.version>1.6</commons-configuration.version>
-    <aws-java-sdk-core.version>1.11.275</aws-java-sdk-core.version>
-    <aws-java-sdk.version>1.7.4</aws-java-sdk.version>
     <shim.type>MAPR</shim.type>
   </properties>
 
@@ -42,38 +39,12 @@
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-databind</artifactId>
-      <version>${com.fasterxml.jackson.core.version}</version>
       <scope>compile</scope>
-      <exclusions>
-        <exclusion>
-          <artifactId>*</artifactId>
-          <groupId>*</groupId>
-        </exclusion>
-      </exclusions>
     </dependency>
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-core</artifactId>
-      <version>${com.fasterxml.jackson.core.version}</version>
       <scope>compile</scope>
-      <exclusions>
-        <exclusion>
-          <artifactId>*</artifactId>
-          <groupId>*</groupId>
-        </exclusion>
-      </exclusions>
-    </dependency>
-    <dependency>
-      <groupId>com.fasterxml.jackson.core</groupId>
-      <artifactId>jackson-annotations</artifactId>
-      <version>${com.fasterxml.jackson.core.version}</version>
-      <scope>compile</scope>
-      <exclusions>
-        <exclusion>
-          <artifactId>*</artifactId>
-          <groupId>*</groupId>
-        </exclusion>
-      </exclusions>
     </dependency>
     <!--here test dependencies-->
     <dependency>
@@ -229,20 +200,12 @@
     </dependency>
     <dependency>
       <groupId>com.amazonaws</groupId>
-      <artifactId>aws-java-sdk</artifactId>
-      <version>${aws-java-sdk.version}</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>com.amazonaws</groupId>
       <artifactId>aws-java-sdk-core</artifactId>
-      <version>${aws-java-sdk-core.version}</version>
-      <exclusions>
-        <exclusion>
-          <groupId>*</groupId>
-          <artifactId>*</artifactId>
-        </exclusion>
-      </exclusions>
+    </dependency>
+    <dependency> <!-- required to run tests -->
+      <groupId>com.amazonaws</groupId>
+      <artifactId>aws-java-sdk-s3</artifactId>
+      <scope>test</scope>
     </dependency>
   </dependencies>
   <build>


### PR DESCRIPTION
Starting with version 1.9, the `aws-java-sdk` was split into multiple JAR files. Because we were importing both `aws-java-sdk` and `aws-java-sdk-core`, multiple implementations of the same class were found.

This was fixed, as well as a major cleanup of the dependencies for `aws-java-sdk-*` and also for jackson dependencies that were still referencing old versions and are now managed in the parent POM.

Moved dependency management of `aws-java-sdk-*` into the root pom of this project.

@pentaho/tatooine please review and merge.