### PR TITLE
[COMP-9652] Adds org:glassfish:javax.el:3.0.0 to the dependency manag…

### DIFF
--- a/shims/hdp30/pom.xml
+++ b/shims/hdp30/pom.xml
@@ -33,7 +33,19 @@
     <commons-configuration2.version>2.1.1</commons-configuration2.version>
     <geronimo-servlet_3.0_spec.version>1.0</geronimo-servlet_3.0_spec.version>
     <org.apache.hive.version>3.1.0.3.0.0.0-1634</org.apache.hive.version>
+    <javax.el.version>3.0.0</javax.el.version>
   </properties>
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <!-- This dependency is explicitly put here to set the version at 3.0.0
+        because hive-jdbc has it as a transitive with an unbound version. -->
+        <groupId>org.glassfish</groupId>
+        <artifactId>javax.el</artifactId>
+        <version>${javax.el.version}</version>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
   <modules>
     <module>client</module>
     <module>pmr</module>


### PR DESCRIPTION
…ement section to override the transitive version which is unbound in org:glassfish:servlet.jsp (hdp30/default)