### PR TITLE
[BACKLOG-27566] Remove SLF4J libs from shims

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -37,6 +37,21 @@
 
   <dependencyManagement>
     <dependencies>
+      <!-- marking SLF4J libs as provided because shims are
+           using the ones from the main classloader -->
+      <dependency>
+        <groupId>org.slf4j</groupId>
+        <artifactId>slf4j-api</artifactId>
+        <version>${slf4j.version}</version>
+        <scope>provided</scope>
+      </dependency>
+      <dependency>
+        <groupId>org.slf4j</groupId>
+        <artifactId>slf4j-log4j12</artifactId>
+        <version>${slf4j.version}</version>
+        <scope>provided</scope>
+      </dependency>
+
       <dependency>
         <groupId>pentaho</groupId>
         <artifactId>pentaho-hdfs-vfs</artifactId>

--- a/shims/cdh601/client/pom.xml
+++ b/shims/cdh601/client/pom.xml
@@ -12,18 +12,6 @@
   <packaging>pom</packaging>
   <dependencies>
     <dependency>
-      <groupId>org.slf4j</groupId>
-      <artifactId>slf4j-api</artifactId>
-      <version>${slf4j-api.version}</version>
-      <scope>provided</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.slf4j</groupId>
-      <artifactId>slf4j-log4j12</artifactId>
-      <version>${slf4j-log4j12.version}</version>
-      <scope>provided</scope>
-    </dependency>
-    <dependency>
       <groupId>org.xerial.snappy</groupId>
       <artifactId>snappy-java</artifactId>
       <version>${org.xerial.snappy.version}</version>

--- a/shims/hdp25/assemblies/hdp25-shim/src/assembly/assembly.xml
+++ b/shims/hdp25/assemblies/hdp25-shim/src/assembly/assembly.xml
@@ -104,8 +104,6 @@
         <include>net.sf.opencsv:opencsv</include>
         <include>org.apache.parquet:parquet-hadoop-bundle</include>
         <include>javax.servlet:servlet-api</include>
-        <include>org.slf4j:slf4j-api</include>
-        <include>org.slf4j:slf4j-log4j12</include>
         <include>org.antlr:stringtemplate</include>
         <include>javax.transaction:transaction-api</include>
         <include>org.apache.knox:gateway-shell</include>

--- a/shims/hdp25/impl/pom.xml
+++ b/shims/hdp25/impl/pom.xml
@@ -22,7 +22,6 @@
     <org.apache.curator.version>2.6.0</org.apache.curator.version>
     <commons-net.version>3.1</commons-net.version>
     <org.tukaani.version>1.5</org.tukaani.version>
-    <org.slf4j.version>1.7.5</org.slf4j.version>
     <com.google.protobuf.version>2.5.0</com.google.protobuf.version>
     <commons-pool.version>1.5.4</commons-pool.version>
     <org.apache.oozie.version>4.2.0.2.5.0.0-1245</org.apache.oozie.version>
@@ -594,18 +593,6 @@
       </exclusions>
     </dependency>
     <dependency>
-      <groupId>org.slf4j</groupId>
-      <artifactId>slf4j-log4j12</artifactId>
-      <version>${org.slf4j.version}</version>
-      <scope>compile</scope>
-      <exclusions>
-        <exclusion>
-          <artifactId>*</artifactId>
-          <groupId>*</groupId>
-        </exclusion>
-      </exclusions>
-    </dependency>
-    <dependency>
       <groupId>org.apache.derby</groupId>
       <artifactId>derby</artifactId>
       <version>${org.apache.derby.version}</version>
@@ -669,18 +656,6 @@
       <groupId>org.mortbay.jetty</groupId>
       <artifactId>jetty-util</artifactId>
       <version>${org.mortbay.jetty.version}</version>
-      <scope>compile</scope>
-      <exclusions>
-        <exclusion>
-          <artifactId>*</artifactId>
-          <groupId>*</groupId>
-        </exclusion>
-      </exclusions>
-    </dependency>
-    <dependency>
-      <groupId>org.slf4j</groupId>
-      <artifactId>slf4j-api</artifactId>
-      <version>${org.slf4j.version}</version>
       <scope>compile</scope>
       <exclusions>
         <exclusion>


### PR DESCRIPTION
@graimundo and @Pancho7 please review.

Replaces https://github.com/pentaho/pentaho-hadoop-shims/pull/931.