### PR TITLE
[PPP-4271] - Fixed Use of Vulnerable Component: xercesImpl-2.11.0 and…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -24,7 +24,6 @@
     <commons-beanutils.version>1.9.3</commons-beanutils.version>
     <commons-io.version>2.4</commons-io.version>
     <pentaho-hadoop-shims-api.version>8.3.0.0-SNAPSHOT</pentaho-hadoop-shims-api.version>
-    <xerces.version>2.8.1</xerces.version>
     <oss-licenses.version>8.3.0.0-SNAPSHOT</oss-licenses.version>
     <eula-wrap_create-izpack-installer-jar-phase></eula-wrap_create-izpack-installer-jar-phase>
     <pdi.version>8.3.0.0-SNAPSHOT</pdi.version>

--- a/shims/pom.xml
+++ b/shims/pom.xml
@@ -12,7 +12,6 @@
   <packaging>pom</packaging>
   <properties>
     <oss.license.directory>${project.build.directory}/oss_license</oss.license.directory>
-    <xerces.version>2.8.1</xerces.version>
     <com.yammer.metrics.version>2.2.0</com.yammer.metrics.version>
     <org.safehaus.jug.version>2.0.0</org.safehaus.jug.version>
     <commons-lang.version>2.6</commons-lang.version>


### PR DESCRIPTION
… xercesImpl-2.9.1 (CVE-2013-4002 | CVE-2012-0881 | CVE-2009-2625 | sonatype-2017-0348)

Do not merge before https://github.com/pentaho/maven-parent-poms/pull/120.
This is a series of PRs to update Apache Xerces to version 2.12.0.

@pentaho-lmartins 