### PR TITLE
[BACKLOG-30615] Set classloader when accessing Hadoop VersionInfo class

### DIFF
--- a/common-fragment-V1/src/main/java/org/pentaho/hadoop/shim/common/CommonHadoopShim.java
+++ b/common-fragment-V1/src/main/java/org/pentaho/hadoop/shim/common/CommonHadoopShim.java
@@ -133,7 +133,13 @@ public class CommonHadoopShim implements HadoopShim {
 
   @Override
   public String getHadoopVersion() {
-    return VersionInfo.getVersion();
+    ClassLoader originalClassLoader = Thread.currentThread().getContextClassLoader();
+    try {
+      Thread.currentThread().setContextClassLoader( getClass().getClassLoader() );
+      return VersionInfo.getVersion();
+    } finally {
+      Thread.currentThread().setContextClassLoader( originalClassLoader );
+    }
   }
 
   @Override


### PR DESCRIPTION
to ensure it finds the correct .properties file.