### PR TITLE
[BACKLOG-31555] Fixed InputStream not getting closed and leaving the config.properties locked and unable to be deleted during NamedCluster editing.

### DIFF
--- a/common-fragment-V1/src/main/java/org/pentaho/hadoop/shim/ShimConfigsLoader.java
+++ b/common-fragment-V1/src/main/java/org/pentaho/hadoop/shim/ShimConfigsLoader.java
@@ -105,7 +105,9 @@ public class ShimConfigsLoader {
 
     try {
       if ( pathToConfigProperties != null ) {
-        properties.load( new FileInputStream( pathToConfigProperties.getFile() ) );
+        FileInputStream fis = new FileInputStream( pathToConfigProperties.getFile() );
+        properties.load( fis );
+        fis.close();
       }
     } catch ( IOException ex ) {
       ex.printStackTrace();


### PR DESCRIPTION
Fixed InputStream not getting closed and leaving the config.properties locked and unable to be deleted during NamedCluster editing.