### PR TITLE
[BACKLOG-30640] Generic Apache Shim

### DIFF
--- a/shims/apache/driver/pom.xml
+++ b/shims/apache/driver/pom.xml
@@ -1,0 +1,280 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>org.pentaho.hadoop.shims</groupId>
+    <artifactId>pentaho-hadoop-shims-apache-reactor</artifactId>
+    <version>9.0.0.0-SNAPSHOT</version>
+  </parent>
+  <artifactId>pentaho-hadoop-shims-apache-driver</artifactId>
+  <version>9.0.0.0-SNAPSHOT</version>
+  <packaging>bundle</packaging>
+  <properties>
+    <vendor-driver.version>3.0.0.0.apache</vendor-driver.version>
+    <pentaho-code.version>11.0.0.0</pentaho-code.version>
+
+    <shim.name>apache</shim.name>
+    <!-- default folder -->
+    <automaton.version>1.11-8</automaton.version>
+    <org.apache.avro.version>1.8.0</org.apache.avro.version>
+    <hadoop-aws.version>3.1.0.3.0.0.0-1634</hadoop-aws.version>
+    <!-- client and default folders -->
+    <hadoop.version>3.1.0.3.0.0.0-1634</hadoop.version>
+    <!-- pmr folder -->
+    <protobuf-java.version>2.5.0</protobuf-java.version>
+    <commons-configuration.version>1.6</commons-configuration.version>
+    <commons-configuration2.version>2.1.1</commons-configuration2.version>
+    <geronimo-servlet_3.0_spec.version>1.0</geronimo-servlet_3.0_spec.version>
+    <org.apache.hadoop.version>3.1.0.3.0.0.0-1634</org.apache.hadoop.version>
+    <org.apache.orc.version>1.2.3</org.apache.orc.version>
+    <parquet.version>1.10.0.3.0.0.0-1634</parquet.version>
+    <org.antlr.version>3.5.2</org.antlr.version>
+    <joda-time.version>2.9.9</joda-time.version>
+
+    <shim-bundle-plugin.version>1.0</shim-bundle-plugin.version>
+    <org.apache.thrift.version>0.9.3</org.apache.thrift.version>
+
+    <!-- Guarantee the proper version for Jetty artifacts -->
+    <!-- Note the difference between \lib and \lib\client -->
+    <jetty.lib-folder.version>9.3.20.v20170531</jetty.lib-folder.version>
+    <jetty.client-folder.version>9.3.19.v20170502</jetty.client-folder.version>
+  </properties>
+
+  <dependencies>
+
+    <!-- Guarantee the proper version for Jetty artifacts -->
+    <dependency>
+      <groupId>org.eclipse.jetty</groupId>
+      <artifactId>jetty-annotations</artifactId>
+      <version>${jetty.lib-folder.version}</version>
+      <scope>runtime</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.eclipse.jetty</groupId>
+      <artifactId>jetty-client</artifactId>
+      <version>${jetty.lib-folder.version}</version>
+      <scope>runtime</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.eclipse.jetty</groupId>
+      <artifactId>jetty-jaas</artifactId>
+      <version>${jetty.lib-folder.version}</version>
+      <scope>runtime</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.eclipse.jetty</groupId>
+      <artifactId>jetty-jndi</artifactId>
+      <version>${jetty.lib-folder.version}</version>
+      <scope>runtime</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.eclipse.jetty</groupId>
+      <artifactId>jetty-plus</artifactId>
+      <version>${jetty.lib-folder.version}</version>
+      <scope>runtime</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.eclipse.jetty</groupId>
+      <artifactId>jetty-rewrite</artifactId>
+      <version>${jetty.lib-folder.version}</version>
+      <scope>runtime</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.eclipse.jetty</groupId>
+      <artifactId>jetty-runner</artifactId>
+      <version>${jetty.lib-folder.version}</version>
+      <scope>runtime</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.eclipse.jetty</groupId>
+      <artifactId>jetty-security</artifactId>
+      <version>${jetty.client-folder.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.eclipse.jetty</groupId>
+      <artifactId>jetty-servlet</artifactId>
+      <version>${jetty.client-folder.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.eclipse.jetty</groupId>
+      <artifactId>jetty-webapp</artifactId>
+      <version>${jetty.client-folder.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.eclipse.jetty</groupId>
+      <artifactId>jetty-xml</artifactId>
+      <version>${jetty.client-folder.version}</version>
+    </dependency>
+
+    <dependency>
+      <groupId>org.pentaho</groupId>
+      <artifactId>pentaho-hadoop-shims-common-fragment-V1</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>com.pentaho</groupId>
+      <artifactId>shim-bundle-plugin</artifactId>
+      <version>${shim-bundle-plugin.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.pentaho</groupId>
+      <artifactId>shim-api</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.hadoop</groupId>
+      <artifactId>hadoop-mapreduce-client-core</artifactId>
+      <version>${org.apache.hadoop.version}</version>
+    </dependency>
+
+    <dependency>
+      <groupId>org.apache.hadoop</groupId>
+      <artifactId>hadoop-common</artifactId>
+      <version>${org.apache.hadoop.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.orc</groupId>
+      <artifactId>orc-core</artifactId>
+      <version>${org.apache.orc.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.avro</groupId>
+      <artifactId>avro</artifactId>
+      <version>${org.apache.avro.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.avro</groupId>
+      <artifactId>avro-mapred</artifactId>
+      <version>${org.apache.avro.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.parquet</groupId>
+      <artifactId>parquet-hadoop-bundle</artifactId>
+      <version>${parquet.version}</version>
+    </dependency>
+
+    <dependency>
+      <groupId>org.apache.hadoop</groupId>
+      <artifactId>hadoop-hdfs</artifactId>
+      <version>${org.apache.hadoop.version}</version>
+    </dependency>
+
+    <dependency>
+      <groupId>com.amazonaws</groupId>
+      <artifactId>aws-java-sdk-bundle</artifactId>
+      <version>1.11.271</version>
+    </dependency>
+    <dependency>
+      <groupId>com.fasterxml.jackson.dataformat</groupId>
+      <artifactId>jackson-dataformat-cbor</artifactId>
+      <version>2.9.10</version>
+    </dependency>
+
+    <dependency>
+      <groupId>org.apache.hadoop</groupId>
+      <artifactId>hadoop-aws</artifactId>
+      <version>${hadoop-aws.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>joda-time</groupId>
+      <artifactId>joda-time</artifactId>
+      <version>${joda-time.version}</version>
+      <exclusions>
+        <exclusion>
+          <groupId>*</groupId>
+          <artifactId>*</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+    <!--- End dependencies for Pig -->
+    <dependency>
+      <groupId>org.apache.thrift</groupId>
+      <artifactId>libthrift</artifactId>
+      <version>${org.apache.thrift.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>commons-configuration</groupId>
+      <artifactId>commons-configuration</artifactId>
+      <version>${commons-configuration.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.commons</groupId>
+      <artifactId>commons-configuration2</artifactId>
+      <version>${commons-configuration2.version}</version>
+    </dependency>
+
+
+  </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>com.pentaho</groupId>
+        <artifactId>shim-bundle-plugin</artifactId>
+        <version>${shim-bundle-plugin.version}</version>
+        <configuration>
+          <resolverFilters>
+            <resolverFilter>
+              <include>
+                *:com.fasterxml.jackson.dataformat,*:hadoop-mapreduce-client-core,*:hadoop-common,*:orc-core,*:avro,
+                *:hadoop-aws,
+                com.amazonaws:*,
+                *:parquet-hadoop-bundle,*:hadoop-hdfs,
+                *:avro-mapred,
+                org.eclipse.jetty:*,
+                <!--Needed for Hive-->
+                *:commons-configuration,*:commons-configuration2
+              </include>
+              <exclude>
+                org.slf4j:*,
+                *:jersey*:jar:2.25.1,
+                *:*log4j*,*:xml-apis,*:xercesImpl,*:tests:*,
+                <!--Needed for hive-->
+                org.apache.hadoop:hadoop-yarn-registry
+              </exclude>
+              <transitive>true</transitive>
+            </resolverFilter>
+            <resolverFilter>
+              <include>
+                *:libthrift,
+              </include>
+              <exclude>
+                *:tests:*
+              </exclude>
+              <transitive>false</transitive>
+            </resolverFilter>
+          </resolverFilters>
+        </configuration>
+        <executions>
+          <execution>
+            <phase>prepare-package</phase>
+            <goals>
+              <goal>resolve</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+
+      <plugin>
+        <groupId>org.apache.felix</groupId>
+        <artifactId>maven-bundle-plugin</artifactId>
+        <version>${dependency.maven-bundle-plugin.version}</version>
+        <extensions>true</extensions>
+        <configuration>
+          <instructions>
+            <Bundle-SymbolicName>pentaho-hadoop-driver-V1</Bundle-SymbolicName>
+            <Bundle-Version>3.0.apache</Bundle-Version>
+            <Pentaho-Code-Version>${pentaho-code.version}</Pentaho-Code-Version>
+            <DynamicImport-Package>*</DynamicImport-Package>
+            <Import-Package>
+            </Import-Package>
+            <_exportcontents>
+            </_exportcontents>
+            <Embed-Dependency>*</Embed-Dependency>
+          </instructions>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/shims/apache/driver/src/main/java/org/pentaho/hadoop/shim/HadoopShim.java
+++ b/shims/apache/driver/src/main/java/org/pentaho/hadoop/shim/HadoopShim.java
@@ -1,0 +1,46 @@
+/*******************************************************************************
+ *
+ * Pentaho Big Data
+ *
+ * Copyright (C) 2002-2019 by Hitachi Vantara : http://www.pentaho.com
+ *
+ *******************************************************************************
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ******************************************************************************/
+
+package org.pentaho.hadoop.shim;
+
+import org.pentaho.hadoop.shim.common.ConfigurationProxyV2;
+import org.pentaho.hadoop.shim.common.HadoopShimImpl;
+
+public class HadoopShim extends HadoopShimImpl {
+
+  public HadoopShim() {
+    super();
+  }
+
+  @Override
+  public Class[] getHbaseDependencyClasses() {
+    return new Class[0];
+  }
+
+  @Override
+  public org.pentaho.hadoop.shim.api.internal.Configuration createConfiguration( String namedClusterConfigId ) {
+    ConfigurationProxyV2 conf = (ConfigurationProxyV2) super.createConfiguration( namedClusterConfigId );
+    conf.getJob().getConfiguration().setRestrictSystemProperties( false );
+    return conf;
+  }
+
+}

--- a/shims/apache/driver/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/shims/apache/driver/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -1,0 +1,58 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<blueprint xmlns="http://www.osgi.org/xmlns/blueprint/v1.0.0"
+           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+           xsi:schemaLocation="
+            http://www.osgi.org/xmlns/blueprint/v1.0.0 http://www.osgi.org/xmlns/blueprint/v1.0.0/blueprint.xsd">
+
+  <bean id="apacheShimIdentifier" class="org.pentaho.hadoop.shim.api.internal.ShimIdentifier" scope="singleton">
+    <argument value="apache"/>
+    <argument value="Apache"/>
+    <argument value="3.0"/>
+    <argument value="COMMUNITY"/>
+  </bean>
+
+  <service ref="apacheShimIdentifier" interface="org.pentaho.hadoop.shim.api.ShimIdentifierInterface"/>
+
+  <bean id="apacheHadoop" class="org.pentaho.hadoop.shim.HadoopShim" scope="singleton"/>
+
+  <service ref="apacheHadoop" interface="org.pentaho.hadoop.shim.spi.HadoopShim">
+    <service-properties>
+      <entry key="shim">
+        <value type="java.lang.String">apache</value>
+      </entry>
+    </service-properties>
+  </service>
+
+
+  <bean id="apacheFormatShim" class="org.pentaho.hadoop.shim.common.CommonFormatShim">
+  </bean>
+
+  <service ref="apacheFormatShim" auto-export="interfaces">
+    <service-properties>
+      <entry key="shim">
+        <value type="java.lang.String">apache</value>
+      </entry>
+      <entry key="service">
+        <value type="java.lang.String">format</value>
+      </entry>
+    </service-properties>
+  </service>
+
+  <bean id="apacheFormatServiceFactory" class="org.pentaho.big.data.impl.shim.format.FormatServiceFactory">
+    <argument ref="apacheFormatShim"/>
+  </bean>
+
+  <service ref="apacheFormatServiceFactory"
+           interface="org.pentaho.hadoop.shim.api.cluster.NamedClusterServiceFactory">
+    <service-properties>
+      <entry key="shim">
+        <value type="java.lang.String">apache</value>
+      </entry>
+      <entry key="service">
+        <value type="java.lang.String">format</value>
+      </entry>
+    </service-properties>
+  </service>
+
+
+</blueprint>

--- a/shims/apache/kar/pom.xml
+++ b/shims/apache/kar/pom.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>org.pentaho.hadoop.shims</groupId>
+    <artifactId>pentaho-hadoop-shims-apache-reactor</artifactId>
+    <version>9.0.0.0-SNAPSHOT</version>
+  </parent>
+
+  <artifactId>pentaho-hadoop-shims-apache-kar</artifactId>
+  <version>9.0.0.0-SNAPSHOT</version>
+  <packaging>kar</packaging>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.pentaho.hadoop.shims</groupId>
+      <artifactId>pentaho-hadoop-shims-common-dependencies-V1</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.pentaho.hadoop.shims</groupId>
+      <artifactId>pentaho-hadoop-shims-common-fragment-V1</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.pentaho.hadoop.shims</groupId>
+      <artifactId>pentaho-hadoop-shims-apache-driver</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+  </dependencies>
+
+</project>

--- a/shims/apache/kar/src/main/feature/feature.xml
+++ b/shims/apache/kar/src/main/feature/feature.xml
@@ -1,0 +1,7 @@
+<features name="${project.artifactId}-repo" xmlns="http://karaf.apache.org/xmlns/features/v1.2.1">
+  <feature name="${project.artifactId}" version="${project.version}">
+
+    <details>${project.description}</details>
+
+  </feature>
+</features>

--- a/shims/apache/pom.xml
+++ b/shims/apache/pom.xml
@@ -1,0 +1,15 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>org.pentaho.hadoop.shims</groupId>
+    <artifactId>pentaho-hadoop-shims-list</artifactId>
+    <version>9.0.0.0-SNAPSHOT</version>
+  </parent>
+  <artifactId>pentaho-hadoop-shims-apache-reactor</artifactId>
+  <packaging>pom</packaging>
+  <modules>
+    <module>driver</module>
+    <module>kar</module>
+  </modules>
+</project>

--- a/shims/pom.xml
+++ b/shims/pom.xml
@@ -314,6 +314,7 @@
         <module>hdp30</module>
         <module>emr521</module>
         <module>mapr60</module>
+        <module>apache</module>
       </modules>
     </profile>
 


### PR DESCRIPTION
Will serve as an internal fallback shim to be used in cases
where a vendor shim is not applicable, e.g. Avro->HCP