### PR TITLE
[BACKLOG-30640] Removing the "DefaultShim" in favor of internal shim

### DIFF
--- a/common-services-api/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/common-services-api/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -4,9 +4,9 @@
     xmlns:cm="http://aries.apache.org/blueprint/xmlns/blueprint-cm/v1.1.0"
     xsi:schemaLocation="http://www.osgi.org/xmlns/blueprint/v1.0.0 http://www.osgi.org/xmlns/blueprint/v1.0.0/blueprint.xsd">
     
-    <cm:property-placeholder persistent-id="pentaho.default.shim" update-strategy="reload">
+    <cm:property-placeholder persistent-id="pentaho.shim" update-strategy="reload">
     <cm:default-properties>
-      <cm:property name="default.shim" value="hdp26" />
+      <cm:property name="internal.shim" value="apache" />
       <cm:property name="orderedModules" value="Hadoop Configuration,Hadoop File System,Map Reduce,Oozie,Zookeeper"/>
       <cm:property name="pentaho.jdbc.lazydrivers.num" value="5"/>
     </cm:default-properties>
@@ -15,7 +15,7 @@
   <reference id="namedClusterManager" interface="org.pentaho.hadoop.shim.api.cluster.NamedClusterService"/>
 
   <bean id="serviceLocatorImpl" class="org.pentaho.big.data.api.cluster.service.locator.impl.NamedClusterServiceLocatorImpl" scope="singleton">
-    <argument value="${default.shim}"/>
+    <argument value="${internal.shim}"/>
     <argument ref="metastoreLocator"/>
     <argument ref="namedClusterManager"/>
   </bean>

--- a/common-services-api/src/test/java/org/pentaho/big/data/api/cluster/service/locator/impl/NamedClusterServiceLocatorImplTest.java
+++ b/common-services-api/src/test/java/org/pentaho/big/data/api/cluster/service/locator/impl/NamedClusterServiceLocatorImplTest.java
@@ -97,7 +97,7 @@ public class NamedClusterServiceLocatorImplTest {
   public void testNoArgConstructor() {
     assertNull( new NamedClusterServiceLocatorImpl( SHIM_A, mockMetastoreLocator, namedClusterManager )
       .getService( namedCluster, Object.class ) );
-    assertEquals( SHIM_A, serviceLocator.getDefaultShim() );
+    assertEquals( SHIM_A, serviceLocator.internalShim );
     serviceLocator.getVendorShimList();
   }
 
@@ -178,11 +178,5 @@ public class NamedClusterServiceLocatorImplTest {
     assertNull( service );
   }
 
-  @Test
-  public void testDefaultShim() {
-    assertEquals( SHIM_A, serviceLocator.getDefaultShim() );
-    serviceLocator.setDefaultShim( SHIM_B );
-    assertEquals( SHIM_B, serviceLocator.getDefaultShim() );
-  }
 
 }

--- a/shim-api/src/main/java/org/pentaho/hadoop/shim/api/cluster/NamedClusterServiceLocator.java
+++ b/shim-api/src/main/java/org/pentaho/hadoop/shim/api/cluster/NamedClusterServiceLocator.java
@@ -34,6 +34,4 @@ public interface NamedClusterServiceLocator {
   List<String> getVendorShimList();
 
   String getDefaultShim();
-
-  void setDefaultShim( String defaultShim );
 }


### PR DESCRIPTION
Configuration managed by osgi, rather than metastore.  Can be overriden
by setting the internal.shim property in `karaf/etc/pentaho.shim.cfg`

https://jira.pentaho.com/browse/BACKLOG-30640