### PR TITLE
[BACKLOG-30638][BACKLOG-30731] Parquet In/Out support with S3/HCP

### DIFF
--- a/shims/apache/driver/src/main/java/org/pentaho/hadoop/shim/pvfs/PvfsHadoopBridge.java
+++ b/shims/apache/driver/src/main/java/org/pentaho/hadoop/shim/pvfs/PvfsHadoopBridge.java
@@ -23,6 +23,8 @@
 package org.pentaho.hadoop.shim.pvfs;
 
 import com.google.common.annotations.VisibleForTesting;
+import com.google.common.cache.CacheBuilder;
+import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FSDataInputStream;
 import org.apache.hadoop.fs.FSDataOutputStream;
 import org.apache.hadoop.fs.FileStatus;
@@ -41,6 +43,10 @@ import java.net.URI;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Objects;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+
+import com.google.common.cache.Cache;
 
 public class PvfsHadoopBridge extends FileSystem {
 
@@ -49,6 +55,14 @@ public class PvfsHadoopBridge extends FileSystem {
   private final List<PvfsConf.ConfFactory> confFactories;
   private final ConnectionManager connMgr;
 
+  @SuppressWarnings( "UnstableApiUsage" )
+  // Cache was beta in version 11, which is the version hadoop 3.1 uses.
+  // the Cache api we use is unchanged with guava 19+, no longer beta.
+  private final Cache<PvfsConf, FileSystem> fsCache = CacheBuilder.newBuilder()
+    .expireAfterAccess( 1, TimeUnit.HOURS )
+    .build();
+
+  @SuppressWarnings( "unused" )
   public PvfsHadoopBridge() {
     confFactories = Arrays.asList( S3Conf::new, HCPConf::new );
     connMgr = ConnectionManager.getInstance();
@@ -63,9 +77,15 @@ public class PvfsHadoopBridge extends FileSystem {
     return "pvfs";
   }
 
+  @Override protected void checkPath( Path path ) {
+    if ( getFs( path ) == null ) {
+      throw new IllegalArgumentException( "Cannot find a supported filesystem for " + path );
+    }
+  }
+
   @Override public Path makeQualified( Path path ) {
     getFs( path );
-    return super.makeQualified( updatePath( path ) );
+    return super.makeQualified( path );
   }
 
   @Override public URI getUri() {
@@ -94,10 +114,6 @@ public class PvfsHadoopBridge extends FileSystem {
     return getFs( path ).delete( updatePath( path ), b );
   }
 
-  @Override public FileStatus[] listStatus( Path path ) throws IOException {
-    return getFs( path ).listStatus( updatePath( path ) );
-  }
-
   @Override public void setWorkingDirectory( Path path ) {
     getFs( path ).setWorkingDirectory( updatePath( path ) );
   }
@@ -112,44 +128,93 @@ public class PvfsHadoopBridge extends FileSystem {
   }
 
   @Override public FileStatus getFileStatus( Path path ) throws IOException {
-    return getFs( path ).getFileStatus( updatePath( path ) );
+    FileStatus fileStatus = getFs( path ).getFileStatus( updatePath( path ) );
+    fileStatus.setPath( path );
+    return fileStatus;
+  }
+
+  @Override public FileStatus[] listStatus( Path path ) throws IOException {
+    FileStatus[] fileStatuses = getFs( path ).listStatus( updatePath( path ) );
+    Arrays.stream( fileStatuses )
+      .forEach( status -> status.setPath(
+        getPvfsConf( path ).mapPath( path, status.getPath() ) ) );
+    return fileStatuses;
   }
 
   private Path updatePath( Path path ) {
-    if ( !getScheme().equals( path.toUri().getScheme() ) ) {
+    if ( schemeIsNotPvfs( path ) ) {
       return path;
     }
-    ConnectionDetails details = connMgr.getConnectionDetails( path.toUri().getHost() );
-    if ( details == null ) {
-      throw new IllegalStateException( "Could not find named connection " + path.toUri().getHost() );
-    }
-    return getPvfsConf( details ).mapPath( path );
+
+    Path updatedPath = getPvfsConf( path ).mapPath( path );
+
+    return new Path( updatedPath.toUri() ) {
+      @Override public FileSystem getFileSystem( Configuration conf ) {
+        return getCachedFs( path );
+      }
+    };
+  }
+
+  private boolean schemeIsNotPvfs( Path path ) {
+    return !getScheme().equals( path.toUri().getScheme() );
   }
 
 
   private FileSystem getFs( Path path ) {
-    if ( fs != null ) {
-      return fs;
+    if ( schemeIsNotPvfs( path ) ) {
+      // if path does not have a pvfs schema than we assume it's the scheme of the underlying
+      // filesystem.  It's required that fs has already been initialized, since we need
+      // connection details to map to the correct filesystem.
+      return Objects.requireNonNull( fs, "File system not initialized for " + path.toString() );
     }
-    ConnectionDetails details = connMgr.getConnectionDetails( path.toUri().getHost() );
-    PvfsConf confHandler = getPvfsConf( details );
+    return getCachedFs( path );
+  }
 
+  /**
+   * Retrieve the fs from the local cache, read-through if not present.
+   * <p>
+   * We use our own cache because the {@link org.apache.hadoop.fs.FileSystem} cache only uses the Schema, Authority, and
+   * UGI for key definition.  This can cause inconsistencies in PDI if 1)  The connection details have been modified. 2)
+   * More than one connection details definition uses the same Scheme, Authority, and UGI.
+   * <p>
+   * `Authority` in the scope of PVFS can mean the bucket in S3, for example, or the namespace for HCP.
+   * <p>
+   * PvfsConf implementations should disable the FileSystem cache with
+   * <p>
+   * fs.s3a.impl.disable.cache=true
+   * <p>
+   * where `s3a` is appropriate to the underlying filesystem.
+   */
+  private FileSystem getCachedFs( Path path ) {
+    PvfsConf pvfsConf = getPvfsConf( path );
     try {
-      fs = FileSystem.get( confHandler.mapPath( path ).toUri(),
-        confHandler.conf( path ) );
-      this.setConf( confHandler.conf( path ) );
+      fs = fsCache.get( pvfsConf, () -> getRealFileSystem( path, pvfsConf ) );
+      return fs;
+    } catch ( ExecutionException e ) {
+      throw new IllegalStateException( e );
+    }
+  }
+
+  private FileSystem getRealFileSystem( Path path, PvfsConf pvfsConf ) {
+    try {
+      Configuration conf = pvfsConf.conf( path );
+      fs = FileSystem.get( pvfsConf.mapPath( path ).toUri(), conf );
+      this.setConf( conf );
       return fs;
     } catch ( IOException e ) {
       throw new IllegalStateException( e );
     }
   }
 
-  private PvfsConf getPvfsConf( ConnectionDetails details ) {
+  private PvfsConf getPvfsConf( Path path ) {
+    ConnectionDetails details = connMgr.getConnectionDetails( path.toUri().getHost() );
+    if ( details == null ) {
+      throw new IllegalStateException( "Could not find named connection " + path.toUri().getHost() );
+    }
     return confFactories.stream()
       .map( f -> f.get( details ) )
       .filter( PvfsConf::supportsConnection )
       .findFirst()
       .orElseThrow( () -> new IllegalStateException( "Unsupported VFS connection type:  " + details.getType() ) );
   }
-
 }

--- a/shims/apache/driver/src/main/java/org/pentaho/hadoop/shim/pvfs/conf/HCPConf.java
+++ b/shims/apache/driver/src/main/java/org/pentaho/hadoop/shim/pvfs/conf/HCPConf.java
@@ -58,6 +58,12 @@ public class HCPConf extends PvfsConf {
     }
   }
 
+  @Override public Path mapPath( Path pvfsPath, Path realFsPath ) {
+    URI uri = realFsPath.toUri();
+    return new Path( pvfsPath.toUri().getScheme(),
+      pvfsPath.toUri().getHost(), "/" + uri.getPath() );
+  }
+
   @Override public Configuration conf( Path pvfsPath ) {
     validatePath( pvfsPath );
     Configuration conf = new Configuration();
@@ -82,6 +88,8 @@ public class HCPConf extends PvfsConf {
     conf.set( "fs.s3a.impl", "org.apache.hadoop.fs.s3a.S3AFileSystem" );
     conf.set( "fs.s3a.connection.ssl.enabled", "true" );
     conf.set( "fs.s3a.attempts.maximum", "3" );
+
+    conf.set( "fs.s3a.impl.disable.cache", "true" ); // caching managed by PvfsHadoopBridge
 
     if ( acceptSelfSignedCertificates ) {
       conf.set( Constants.S3_CLIENT_FACTORY_IMPL, "org.pentaho.hadoop.shim.pvfs.SelfSignedS3ClientFactory" );

--- a/shims/apache/driver/src/main/java/org/pentaho/hadoop/shim/pvfs/conf/PvfsConf.java
+++ b/shims/apache/driver/src/main/java/org/pentaho/hadoop/shim/pvfs/conf/PvfsConf.java
@@ -26,20 +26,50 @@ import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.Path;
 import org.pentaho.di.connections.ConnectionDetails;
 
+import java.util.Objects;
 
+/**
+ * Base class for filesystem configuration classes.  Implementations
+ * will handle population of hadoop Configuration objects based on
+ * named vfs ConnectionDetails, as well as mapping paths to/from
+ * pvfs:// schemes.
+ */
 public abstract class PvfsConf {
 
-  final ConnectionDetails details;
+  protected final ConnectionDetails details;
 
   PvfsConf( ConnectionDetails details ) {
     this.details = details;
   }
 
+  /**
+   * Tests whether this PvfsConf can be used for the connection
+   * details provided.  HCP connection details, for example, cannot
+   * be used with S3Conf.
+   */
   public abstract boolean supportsConnection();
 
+  /**
+   * Maps a given path with scheme 'pvfs:' to the appropriate
+   * "real" filesystem path by looking up the connection details from
+   * the named vfs connection.
+   */
   public abstract Path mapPath( Path pvfsPath );
 
+  /**
+   * Maps a "real" filesystem path to the pvfs:// form.
+   * For example, given pvfsPath 'pvfs://s3Conn/path' and
+   * realFsPath 's3://bucket/somedir/somefile.txt', this
+   * method will determine the correct pvfs path for 'somefile.txt':
+   *   'pvfs://s3Conn/bucket/somedir/somefile.txt'
+   *
+   * Different PvfsConf implementations will have different rules
+   * for mapping a realFsPath back to a pvfsPath.
+   */
+  public abstract Path mapPath( Path pvfsPath, Path realFsPath );
+
   public abstract Configuration conf( Path pvfsPath );
+
 
   void validatePath( Path pvfsPath ) {
     if ( !supportsConnection() || !pvfsPath.toUri().getScheme().equals( "pvfs" ) ) {
@@ -50,5 +80,31 @@ public abstract class PvfsConf {
   @FunctionalInterface
   public interface ConfFactory {
     PvfsConf get( ConnectionDetails details );
+  }
+
+  @Override public boolean equals( Object o ) {
+    if ( this == o ) {
+      return true;
+    }
+    if ( o == null || getClass() != o.getClass() ) {
+      return false;
+    }
+
+    PvfsConf pvfsConf = (PvfsConf) o;
+    if ( details == null && pvfsConf.details == null ) {
+      return true;
+    }
+    if ( details == null || pvfsConf.details == null ) {
+      // one but not the other is null
+      return false;
+    }
+    return Objects.equals( details.getProperties(), pvfsConf.details.getProperties() );
+  }
+
+  @Override public int hashCode() {
+    if ( details == null ) {
+      return Objects.hash( this );
+    }
+    return Objects.hash( details.getProperties() );
   }
 }

--- a/shims/apache/driver/src/test/java/org/pentaho/hadoop/shim/pvfs/conf/HCPConfTest.java
+++ b/shims/apache/driver/src/test/java/org/pentaho/hadoop/shim/pvfs/conf/HCPConfTest.java
@@ -77,6 +77,9 @@ public class HCPConfTest {
   @Test public void mapPath() {
     Path result = hcpConf.mapPath( path );
     assertThat( result.toString(), equalTo( "s3a://nstest/somedir/somechild" ) );
+    assertThat( hcpConf.mapPath( path, new Path( "s3a://nstest/dir/file" ) ).toString(),
+      equalTo( "pvfs://namedConn/dir/file" ) );
+
   }
 
   @Test public void testConf() {

--- a/shims/apache/driver/src/test/java/org/pentaho/hadoop/shim/pvfs/conf/S3ConfTest.java
+++ b/shims/apache/driver/src/test/java/org/pentaho/hadoop/shim/pvfs/conf/S3ConfTest.java
@@ -20,9 +20,7 @@
  *
  ******************************************************************************/
 
-
 package org.pentaho.hadoop.shim.pvfs.conf;
-
 
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.Path;
@@ -38,7 +36,9 @@ import java.util.Map;
 
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.when;
 
@@ -50,9 +50,11 @@ public class S3ConfTest {
   private Path path;
   @Mock private ConnectionDetails hcpConn;
   @Mock private ConnectionDetails s3Conn;
+  @Mock private ConnectionDetails otherS3Conn;
+  private Map<String, String> props = new HashMap<>();
 
   @Before public void before() {
-    Map<String, String> props = new HashMap<>();
+
     props.put( "accessKey", "ACCESSKEY" );
     props.put( "secretKey", "SECRETKEY" );
     props.put( "sessionToken", ":LKJL:KJJL" );
@@ -76,6 +78,9 @@ public class S3ConfTest {
   @Test public void mapPath() {
     Path result = s3Conf.mapPath( path );
     assertThat( result.toString(), equalTo( "s3a://bucket/somedir/somechild" ) );
+
+    assertThat( s3Conf.mapPath( path, new Path( "s3a://bucket/dir/file" ) ).toString(),
+      equalTo( "pvfs://namedConn/bucket/dir/file" ) );
   }
 
   @Test public void testConf() {
@@ -85,4 +90,22 @@ public class S3ConfTest {
     assertThat( conf.get( "fs.s3a.access.key" ), equalTo( "ACCESSKEY" ) );
     assertThat( conf.get( "fs.s3a.secret.key" ), equalTo( "SECRETKEY" ) );
   }
+
+  @Test public void testEquals() {
+    assertNotEquals( null, s3Conf );
+    assertEquals( s3Conf, s3Conf );
+    assertNotEquals( s3Conf, hcpConn );
+    when( otherS3Conn.getProperties() ).thenReturn( new HashMap<>( props ) );
+    when( otherS3Conn.getType() ).thenReturn( "s3" );
+
+    S3Conf otherS3Conf = new S3Conf( otherS3Conn );
+
+    assertEquals( otherS3Conf, s3Conf );
+    // change sessiontoken
+    otherS3Conn.getProperties().put( "sessionToken", "otherSessionToken" );
+    assertNotEquals( otherS3Conf, s3Conf );
+
+    assertNotEquals( s3Conf.hashCode(), hcpConn.hashCode() );
+  }
+
 }


### PR DESCRIPTION
Disabling FileSystem caching in the static FileSystem cache,
handling in the PvfsHadoopBridge.  This avoids reusing cached
filesystems that were created with different credentials in effect.

As part of this change, updated the bridge getFileStatus and listStatus
to return FileStatus with the pvfs paths set, rather than the path
of the underlying fs.  Formerly we were able to return the underlying
fs path, since those paths would be resolved against the cached fs.
Now we need to make sure actions on those paths still comes through
the pvfs bridge.

https://jira.pentaho.com/browse/BACKLOG-30638
https://jira.pentaho.com/browse/BACKLOG-30731