### PR TITLE
[BACKLOG-30732][BACKLOG-30639] Orc Input/Output with no named cluster

### DIFF
--- a/common-fragment-V1/src/main/java/org/pentaho/hadoop/shim/common/format/HadoopFormatBase.java
+++ b/common-fragment-V1/src/main/java/org/pentaho/hadoop/shim/common/format/HadoopFormatBase.java
@@ -28,37 +28,44 @@ package org.pentaho.hadoop.shim.common.format;
  */
 public class HadoopFormatBase {
 
-  protected <R> R inClassloader( SupplierWithException<R> action ) throws Exception {
+  protected <R> R inClassloader( SupplierWithException<R> action ) {
     ClassLoader cl = Thread.currentThread().getContextClassLoader();
     try {
       Thread.currentThread().setContextClassLoader( getClass().getClassLoader() );
-
-      return action.get();
-
+      try {
+        return action.get();
+      } catch ( Exception e ) {
+        throw new IllegalStateException( e );
+      }
     } finally {
       Thread.currentThread().setContextClassLoader( cl );
     }
   }
 
-  protected <R> void inClassloader( RunnableWithException<R> action ) throws Exception {
+  protected void inClassloader( RunnableWithException action ) {
     ClassLoader cl = Thread.currentThread().getContextClassLoader();
     try {
       Thread.currentThread().setContextClassLoader( getClass().getClassLoader() );
-
-      action.get();
-
+      try {
+        action.get();
+      } catch ( Exception e ) {
+        throw new IllegalStateException( e );
+      }
     } finally {
       Thread.currentThread().setContextClassLoader( cl );
     }
   }
 
+  // we should rethink this design.  I believe this was a
+  // convenience to allow actions in lambdas that may thrown checked
+  // exceptions.
   @FunctionalInterface
   public interface SupplierWithException<T> {
-    public T get() throws Exception;
+    T get() throws Exception;
   }
 
   @FunctionalInterface
-  public interface RunnableWithException<T> {
-    public void get() throws Exception;
+  public interface RunnableWithException {
+    void get() throws Exception;
   }
 }

--- a/common-fragment-V1/src/main/java/org/pentaho/hadoop/shim/common/format/avro/PentahoAvroInputFormat.java
+++ b/common-fragment-V1/src/main/java/org/pentaho/hadoop/shim/common/format/avro/PentahoAvroInputFormat.java
@@ -70,11 +70,6 @@ public class PentahoAvroInputFormat implements IPentahoAvroInputFormat {
   }
 
   @Override
-  public List<IPentahoInputSplit> getSplits() throws Exception {
-    return null;
-  }
-
-  @Override
   public IPentahoRecordReader createRecordReader( IPentahoInputSplit split ) throws Exception {
 
     DataFileStream<Object> nestedDfs = null;

--- a/common-fragment-V1/src/main/java/org/pentaho/hadoop/shim/common/format/parquet/delegate/apache/PentahoApacheInputFormat.java
+++ b/common-fragment-V1/src/main/java/org/pentaho/hadoop/shim/common/format/parquet/delegate/apache/PentahoApacheInputFormat.java
@@ -131,7 +131,7 @@ public class PentahoApacheInputFormat extends HadoopFormatBase implements IPenta
   }
 
   @Override
-  public List<IPentahoInputSplit> getSplits() throws Exception {
+  public List<IPentahoInputSplit> getSplits() {
     return inClassloader( () -> {
       List<InputSplit> splits = nativeParquetInputFormat.getSplits( job );
       return splits.stream().map( PentahoInputSplitImpl::new ).collect( Collectors.toList() );

--- a/common-fragment-V1/src/main/java/org/pentaho/hadoop/shim/common/format/parquet/delegate/twitter/PentahoTwitterInputFormat.java
+++ b/common-fragment-V1/src/main/java/org/pentaho/hadoop/shim/common/format/parquet/delegate/twitter/PentahoTwitterInputFormat.java
@@ -126,7 +126,7 @@ public class PentahoTwitterInputFormat extends HadoopFormatBase implements IPent
   }
 
   @Override
-  public List<IPentahoInputSplit> getSplits() throws Exception {
+  public List<IPentahoInputSplit> getSplits() {
     return inClassloader( () -> {
       List<InputSplit> splits = nativeParquetInputFormat.getSplits( job );
       return splits.stream().map( PentahoInputSplitImpl::new ).collect( Collectors.toList() );

--- a/common-fragment-V1/src/test/java/org/pentaho/hadoop/shim/common/format/avro/PentahoAvroInputFormatTest.java
+++ b/common-fragment-V1/src/test/java/org/pentaho/hadoop/shim/common/format/avro/PentahoAvroInputFormatTest.java
@@ -35,11 +35,9 @@ import java.util.List;
 import java.util.stream.Collectors;
 
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.spy;
 
 public class PentahoAvroInputFormatTest {
 
@@ -55,8 +53,8 @@ public class PentahoAvroInputFormatTest {
   }
 
   @Test
-  public void getSplits() throws Exception {
-    assertNull( format.getSplits() );
+  public void getSplits() {
+    assertTrue( format.getSplits().isEmpty() );
   }
 
   @Test( expected = Exception.class )

--- a/common-fragment-V1/src/test/java/org/pentaho/hadoop/shim/common/format/orc/PentahoOrcInputFormatTest.java
+++ b/common-fragment-V1/src/test/java/org/pentaho/hadoop/shim/common/format/orc/PentahoOrcInputFormatTest.java
@@ -24,6 +24,7 @@ package org.pentaho.hadoop.shim.common.format.orc;
 import org.junit.Before;
 import org.junit.Test;
 import org.pentaho.di.core.logging.KettleLogStore;
+import org.pentaho.di.core.util.Assert;
 import org.pentaho.hadoop.shim.api.cluster.NamedCluster;
 import org.pentaho.hadoop.shim.api.format.IOrcInputField;
 
@@ -36,26 +37,31 @@ import static org.mockito.Mockito.mock;
  * Created by tkafalas on 11/20/2017.
  */
 public class PentahoOrcInputFormatTest {
-  PentahoOrcInputFormat pentahoOrcInputFormat;
-  List<IOrcInputField> mockSchemaDescription;
-  String fileName = "testFile";
+  private PentahoOrcInputFormat pentahoOrcInputFormat;
+  private List<IOrcInputField> mockSchemaDescription;
 
   @Before
   public void setup() throws Exception {
     KettleLogStore.init();
     pentahoOrcInputFormat = new PentahoOrcInputFormat( mock( NamedCluster.class ) );
-    mockSchemaDescription = new ArrayList<IOrcInputField>();
+    mockSchemaDescription = new ArrayList<>();
   }
 
-  @Test( expected = IllegalStateException.class )
-  public void testCreateRecordReaderWithNoFile() throws Exception {
+  @Test( expected = NullPointerException.class )
+  public void testCreateRecordReaderWithNoFile() {
     pentahoOrcInputFormat.setSchema( mockSchemaDescription );
     pentahoOrcInputFormat.createRecordReader( null );
   }
 
-  @Test( expected = IllegalStateException.class )
-  public void testCreateRecordReaderWithNoSchema() throws Exception {
-    pentahoOrcInputFormat.setInputFile( fileName );
+  @Test( expected = NullPointerException.class )
+  public void testCreateRecordReaderWithNoSchema() {
+    pentahoOrcInputFormat.setInputFile( "testFile" );
     pentahoOrcInputFormat.createRecordReader( null );
+  }
+
+  @Test
+  public void nullNamedClusterIsAllowed() {
+    Assert.assertNotNull( new PentahoOrcInputFormat( null ),
+      "null named cluster is allowed for non-hadoop filesystems." );
   }
 }

--- a/common-fragment-V1/src/test/java/org/pentaho/hadoop/shim/common/format/orc/PentahoOrcReadWriteTest.java
+++ b/common-fragment-V1/src/test/java/org/pentaho/hadoop/shim/common/format/orc/PentahoOrcReadWriteTest.java
@@ -62,7 +62,10 @@ import java.util.Date;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicInteger;
 
-import static org.junit.Assert.*;
+import static junit.framework.TestCase.assertTrue;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.fail;
 import static org.mockito.Mockito.mock;
 
 
@@ -70,7 +73,7 @@ import static org.mockito.Mockito.mock;
  * Created by tkafalas on 11/3/2017.
  */
 public class PentahoOrcReadWriteTest {
-  private List<? extends IOrcInputField> orcInputFields;
+  private List<IOrcInputField> orcInputFields;
   private RowMeta rowMeta;
   private Object[][] rowData;
   private PentahoOrcOutputFormat orcOutputFormat;

--- a/common-fragment-V1/src/test/java/org/pentaho/hadoop/shim/common/format/parquet/PentahoParquetInputFormatTest.java
+++ b/common-fragment-V1/src/test/java/org/pentaho/hadoop/shim/common/format/parquet/PentahoParquetInputFormatTest.java
@@ -26,7 +26,13 @@ import java.nio.file.NoSuchFileException;
 import java.math.BigDecimal;
 import java.sql.Timestamp;
 import java.text.SimpleDateFormat;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Random;
+import java.util.Set;
+import java.util.TimeZone;
+import java.util.TreeSet;
 
 import org.apache.hadoop.fs.Path;
 import org.junit.Before;
@@ -55,6 +61,7 @@ import org.pentaho.hadoop.shim.common.format.parquet.delegate.apache.PentahoApac
 import org.pentaho.hadoop.shim.common.format.parquet.delegate.twitter.PentahoTwitterInputFormat;
 
 
+import static org.junit.Assert.fail;
 import static org.mockito.Mockito.mock;
 
 @RunWith( Parameterized.class )
@@ -84,7 +91,7 @@ public class PentahoParquetInputFormatTest {
         pentahoParquetInputFormat = new PentahoTwitterInputFormat( namedCluster );
         break;
       default:
-        Assert.fail( "Invalid provider name used." );
+        fail( "Invalid provider name used." );
     }
   }
 
@@ -113,7 +120,7 @@ public class PentahoParquetInputFormatTest {
         pentahoInputSplit = new PentahoInputSplitImpl( twitterParquetInputSplit );
         break;
       default:
-        Assert.fail( "Invalid provider name used." );
+        fail( "Invalid provider name used." );
     }
 
     IPentahoRecordReader recordReader =
@@ -146,11 +153,14 @@ public class PentahoParquetInputFormatTest {
     Exception exception = null;
     try {
       pentahoParquetInputFormat.setInputFile( "/test test/out.txt" );
+      fail( "Expected exception.  No such file." );
     } catch ( Exception e ) {
       exception = e;
     }
     //BACKLOG-19435: NoSuchFileException or IOException (mapr) is expected after this change not URISyntaxException
-    Assert.assertTrue( exception instanceof NoSuchFileException || exception instanceof IOException );
+    Assert
+      .assertTrue( exception.getCause() instanceof NoSuchFileException
+        || exception.getCause() instanceof IOException );
   }
 
   private void readData( String file ) throws Exception {

--- a/shim-api/src/main/java/org/pentaho/hadoop/shim/api/format/IPentahoInputFormat.java
+++ b/shim-api/src/main/java/org/pentaho/hadoop/shim/api/format/IPentahoInputFormat.java
@@ -22,6 +22,7 @@
 package org.pentaho.hadoop.shim.api.format;
 
 import java.io.Closeable;
+import java.util.Collections;
 import java.util.List;
 
 import org.pentaho.di.core.RowMetaAndData;
@@ -31,7 +32,9 @@ public interface IPentahoInputFormat {
   /**
    * Get split parts.
    */
-  List<IPentahoInputSplit> getSplits() throws Exception;
+  default List<IPentahoInputSplit> getSplits() {
+    return Collections.emptyList();
+  }
 
   /**
    * Read one split part.

--- a/shim-api/src/main/java/org/pentaho/hadoop/shim/api/format/IPentahoOrcInputFormat.java
+++ b/shim-api/src/main/java/org/pentaho/hadoop/shim/api/format/IPentahoOrcInputFormat.java
@@ -27,20 +27,16 @@ public interface IPentahoOrcInputFormat extends IPentahoInputFormat {
   /**
    * Read schema for display to user.
    */
-  List<? extends IOrcInputField> readSchema() throws Exception;
+  List<IOrcInputField> readSchema();
 
   /**
    * Set schema for file reading.
    */
-  void setSchema( List<? extends IOrcInputField> OrcInputField ) throws Exception;
+  void setSchema( List<IOrcInputField> orcInputField );
 
   /**
    * Set input file.
    */
-  void setInputFile( String file ) throws Exception;
+  void setInputFile( String file );
 
-  /**
-   * Split size, bytes.
-   */
-  void setSplitSize( long blockSize ) throws Exception;
 }


### PR DESCRIPTION
PentahoOrcInputFormat can now work without a named cluster defined.

This commit also includes general cleanup and de-duplication.

https://jira.pentaho.com/browse/BACKLOG-30732
https://jira.pentaho.com/browse/BACKLOG-30639