### PR TITLE
[BACKLOG-32217] Avro jar files are needed on export if the files to be

### DIFF
--- a/common-fragment-V1/src/main/java/org/pentaho/big/data/impl/shim/HadoopClientServicesImpl.java
+++ b/common-fragment-V1/src/main/java/org/pentaho/big/data/impl/shim/HadoopClientServicesImpl.java
@@ -182,7 +182,9 @@ public class HadoopClientServicesImpl implements HadoopClientServices {
         loadBundleFilesLocations();
         System.setProperty( ALT_CLASSPATH, createHadoopAltClasspath() );
         c.set( TMPJARS, getSqoopJarLocation( c ) );
-        if ( args.length > 0 && Arrays.asList( args ).contains( "--as-avrodatafile" ) ) {
+        if ( args.length > 0
+          && ( Arrays.asList( args ).contains( "--as-avrodatafile" )
+            || Arrays.asList( args ).contains( "--export-dir" ) ) ) { // BACKLOG-32217: Avro libs needed for export
           addDependencyJars( c, Conversion.class, AvroWrapper.class );
         }
         if ( args.length > 0 && Arrays.asList( args ).contains( "--hbase-table" ) ) {


### PR DESCRIPTION
exported are Avro format.  No way to specify this via the gui/command
line, so always include the avro jars on export.