### PR TITLE
[BACKLOG-31428] Do not bundle jars that should be pulled from the main

### DIFF
--- a/shims/cdh61/driver/pom.xml
+++ b/shims/cdh61/driver/pom.xml
@@ -281,7 +281,8 @@
                 org.eclipse.jetty:*
               </include>
               <exclude>
-                *:*log4j*,*:xml-apis,*:xercesImpl
+                *:*log4j*,*:xml-apis,*:xercesImpl,*:commons-logging,*:commons-math3,*:commons-pool,*:commons-dbcp,
+                org.apache.httpcomponents:*
               </exclude>
               <transitive>true</transitive>
             </resolverFilter>

--- a/shims/emr521/driver/pom.xml
+++ b/shims/emr521/driver/pom.xml
@@ -197,7 +197,8 @@
                 *:zookeeper
               </include>
               <exclude>
-                *:*log4j*,*:xml-apis,*:xercesImpl
+                *:*log4j*,*:xml-apis,*:xercesImpl,*:commons-logging,*:commons-math3,*:commons-pool,*:commons-dbcp,
+                org.apache.httpcomponents:*
               </exclude>
               <transitive>true</transitive>
             </resolverFilter>

--- a/shims/hdp30/driver/pom.xml
+++ b/shims/hdp30/driver/pom.xml
@@ -341,8 +341,8 @@
                 *:commons-configuration,*:commons-configuration2,*:gateway-shell
               </include>
               <exclude>
-                *:jersey*:jar:2.25.1,
-                *:*log4j*,*:xml-apis,*:xercesImpl,*:tests:*,
+                *:jersey*:jar:2.25.1,*:*log4j*,*:xml-apis,*:xercesImpl,*:tests:*,*:commons-logging,*:commons-math3,
+                *:commons-pool,*:commons-dbcp,org.apache.httpcomponents:*,
                 <!--Needed for hive-->
                 org.apache.hadoop:hadoop-yarn-registry
               </exclude>


### PR DESCRIPTION
karaf classloader.