### PR TITLE
[PPP-4461] Bumping 'maven-bundle-plugin' to 3.5.1 to fix a build issu…

### DIFF
--- a/common-dependencies-V1/pom.xml
+++ b/common-dependencies-V1/pom.xml
@@ -180,7 +180,6 @@
       <plugin>
         <groupId>org.apache.felix</groupId>
         <artifactId>maven-bundle-plugin</artifactId>
-        <version>${dependency.maven-bundle-plugin.version}</version>
         <extensions>true</extensions>
         <configuration>
           <instructions>

--- a/common-fragment-V1/pom.xml
+++ b/common-fragment-V1/pom.xml
@@ -649,7 +649,6 @@
       <plugin>
         <groupId>org.apache.felix</groupId>
         <artifactId>maven-bundle-plugin</artifactId>
-        <version>${dependency.maven-bundle-plugin.version}</version>
         <extensions>true</extensions>
         <configuration>
           <instructions>

--- a/pom.xml
+++ b/pom.xml
@@ -49,7 +49,7 @@
     <shim-bundle-plugin.version>1.0</shim-bundle-plugin.version>
     <htrace-core.version>3.1.0-incubating</htrace-core.version>
     <zookeeper.version>3.4.6.2.6.0.3-8</zookeeper.version>
-    <dependency.maven-bundle-plugin.version>3.2.0</dependency.maven-bundle-plugin.version>
+    <maven-bundle-plugin.version>3.5.1</maven-bundle-plugin.version>
   </properties>
 
   <dependencyManagement>
@@ -260,6 +260,16 @@
   </dependencyManagement>
 
   <build>
+    <pluginManagement>
+      <plugins>
+        <plugin>
+          <groupId>org.apache.felix</groupId>
+          <artifactId>maven-bundle-plugin</artifactId>
+          <version>${maven-bundle-plugin.version}</version>
+        </plugin>
+      </plugins>
+    </pluginManagement>
+
     <plugins>
       <plugin>
         <artifactId>maven-surefire-plugin</artifactId>

--- a/shim-api/pom.xml
+++ b/shim-api/pom.xml
@@ -40,7 +40,6 @@
       <plugin>
         <groupId>org.apache.felix</groupId>
         <artifactId>maven-bundle-plugin</artifactId>
-        <version>3.2.0</version>
         <extensions>true</extensions>
         <configuration>
           <instructions>

--- a/shims/apache/driver/pom.xml
+++ b/shims/apache/driver/pom.xml
@@ -261,7 +261,6 @@
       <plugin>
         <groupId>org.apache.felix</groupId>
         <artifactId>maven-bundle-plugin</artifactId>
-        <version>${dependency.maven-bundle-plugin.version}</version>
         <extensions>true</extensions>
         <configuration>
           <instructions>

--- a/shims/cdh514/driver/pom.xml
+++ b/shims/cdh514/driver/pom.xml
@@ -209,7 +209,6 @@
       <plugin>
         <groupId>org.apache.felix</groupId>
         <artifactId>maven-bundle-plugin</artifactId>
-        <version>${dependency.maven-bundle-plugin.version}</version>
         <extensions>true</extensions>
         <configuration>
           <instructions>

--- a/shims/cdh61/driver/pom.xml
+++ b/shims/cdh61/driver/pom.xml
@@ -307,7 +307,6 @@
       <plugin>
         <groupId>org.apache.felix</groupId>
         <artifactId>maven-bundle-plugin</artifactId>
-        <version>${dependency.maven-bundle-plugin.version}</version>
         <extensions>true</extensions>
         <configuration>
           <instructions>

--- a/shims/hdp26/driver/pom.xml
+++ b/shims/hdp26/driver/pom.xml
@@ -231,7 +231,6 @@
       <plugin>
         <groupId>org.apache.felix</groupId>
         <artifactId>maven-bundle-plugin</artifactId>
-        <version>${dependency.maven-bundle-plugin.version}</version>
         <extensions>true</extensions>
         <configuration>
           <instructions>

--- a/shims/hdp30/driver/pom.xml
+++ b/shims/hdp30/driver/pom.xml
@@ -375,7 +375,6 @@
       <plugin>
         <groupId>org.apache.felix</groupId>
         <artifactId>maven-bundle-plugin</artifactId>
-        <version>${dependency.maven-bundle-plugin.version}</version>
         <extensions>true</extensions>
         <configuration>
           <instructions>

--- a/shims/mapr60/driver/pom.xml
+++ b/shims/mapr60/driver/pom.xml
@@ -208,7 +208,6 @@
       <plugin>
         <groupId>org.apache.felix</groupId>
         <artifactId>maven-bundle-plugin</artifactId>
-        <version>${dependency.maven-bundle-plugin.version}</version>
         <extensions>true</extensions>
         <configuration>
           <instructions>


### PR DESCRIPTION
…e caused by Java modules in the new version of fasterxml-jackson

This is a consequence of the work done in https://github.com/pentaho/maven-parent-poms/pull/201.

@graimundo 