### PR TITLE
[PDI-18615] Could not find named connection null

### DIFF
--- a/shims/apache/driver/src/main/java/org/pentaho/hadoop/shim/pvfs/PvfsHadoopBridge.java
+++ b/shims/apache/driver/src/main/java/org/pentaho/hadoop/shim/pvfs/PvfsHadoopBridge.java
@@ -226,15 +226,23 @@ public class PvfsHadoopBridge extends FileSystem {
   }
 
   @VisibleForTesting ConnectionDetails getConnectionDetails( Path path ) {
+    return connMgr.getConnectionDetails( getConnectionName( path ) );
+  }
+
+  /**
+   * Retrieves the Pentaho VFS connection name associated with path, if one is present.
+   *
+   * @param path input path, expected to have pvfs scheme.
+   * @return PVFS connection name
+   */
+  public static String getConnectionName( Path path ) {
     try {
-      String connectionName = ( (ConnectionFileName) new ConnectionFileNameParser()
+      return ( (ConnectionFileName) new ConnectionFileNameParser()
         .parseUri( null, null, path.toString() ) ).getConnection();
-      return connMgr.getConnectionDetails( connectionName );
     } catch ( FileSystemException e ) {
       LOGGER.warn( "Failed to retrieve connection details with unexpected exception", e );
       return null;
     }
-
   }
 
   private String getProviderName( ConnectionDetails details ) {

--- a/shims/apache/driver/src/main/java/org/pentaho/hadoop/shim/pvfs/conf/HCPConf.java
+++ b/shims/apache/driver/src/main/java/org/pentaho/hadoop/shim/pvfs/conf/HCPConf.java
@@ -2,7 +2,7 @@
  *
  * Pentaho Big Data
  *
- * Copyright (C) 2019 by Hitachi Vantara : http://www.pentaho.com
+ * Copyright (C) 2019-2020 by Hitachi Vantara : http://www.pentaho.com
  *
  *******************************************************************************
  *
@@ -34,6 +34,7 @@ import java.util.Base64;
 import java.util.Map;
 
 import static org.pentaho.di.core.util.Utils.isEmpty;
+import static org.pentaho.hadoop.shim.pvfs.PvfsHadoopBridge.getConnectionName;
 
 
 public class HCPConf extends PvfsConf {
@@ -61,7 +62,7 @@ public class HCPConf extends PvfsConf {
   @Override public Path mapPath( Path pvfsPath, Path realFsPath ) {
     URI uri = realFsPath.toUri();
     return new Path( pvfsPath.toUri().getScheme(),
-      pvfsPath.toUri().getHost(), "/" + uri.getPath() );
+      getConnectionName( pvfsPath ), "/" + uri.getPath() );
   }
 
   @Override public Configuration conf( Path pvfsPath ) {

--- a/shims/apache/driver/src/main/java/org/pentaho/hadoop/shim/pvfs/conf/S3Conf.java
+++ b/shims/apache/driver/src/main/java/org/pentaho/hadoop/shim/pvfs/conf/S3Conf.java
@@ -2,7 +2,7 @@
  *
  * Pentaho Big Data
  *
- * Copyright (C) 2019 by Hitachi Vantara : http://www.pentaho.com
+ * Copyright (C) 2019-2020 by Hitachi Vantara : http://www.pentaho.com
  *
  *******************************************************************************
  *
@@ -39,6 +39,7 @@ import java.util.stream.Collectors;
 
 import static com.google.common.base.Strings.isNullOrEmpty;
 import static org.apache.hadoop.fs.Path.SEPARATOR;
+import static org.pentaho.hadoop.shim.pvfs.PvfsHadoopBridge.getConnectionName;
 
 
 public class S3Conf extends PvfsConf {
@@ -90,7 +91,7 @@ public class S3Conf extends PvfsConf {
   @Override public Path mapPath( Path pvfsPath, Path realFsPath ) {
     URI uri = realFsPath.toUri();
     return new Path( pvfsPath.toUri().getScheme(),
-      pvfsPath.toUri().getHost(), "/" + uri.getHost() + uri.getPath() );
+      getConnectionName( pvfsPath ), "/" + uri.getHost() + uri.getPath() );
   }
 
   @Override public Configuration conf( Path pvfsPath ) {

--- a/shims/apache/driver/src/test/java/org/pentaho/hadoop/shim/pvfs/conf/HCPConfTest.java
+++ b/shims/apache/driver/src/test/java/org/pentaho/hadoop/shim/pvfs/conf/HCPConfTest.java
@@ -2,7 +2,7 @@
  *
  * Pentaho Big Data
  *
- * Copyright (C) 2019 by Hitachi Vantara : http://www.pentaho.com
+ * Copyright (C) 2019-2020 by Hitachi Vantara : http://www.pentaho.com
  *
  *******************************************************************************
  *
@@ -79,7 +79,14 @@ public class HCPConfTest {
     assertThat( result.toString(), equalTo( "s3a://nstest/somedir/somechild" ) );
     assertThat( hcpConf.mapPath( path, new Path( "s3a://nstest/dir/file" ) ).toString(),
       equalTo( "pvfs://namedConn/dir/file" ) );
+  }
 
+  @Test public void mapPathWithSpaces() {
+    Path pathWithSpaces = new Path( "pvfs://nam ed Conn/somedir/somechild" );
+    Path result = hcpConf.mapPath( pathWithSpaces );
+    assertThat( result.toString(), equalTo( "s3a://nstest/somedir/somechild" ) );
+    assertThat( hcpConf.mapPath( pathWithSpaces, new Path( "s3a://nstest/dir/file" ) ).toString(),
+      equalTo( "pvfs://nam ed Conn/dir/file" ) );
   }
 
   @Test public void testConf() {

--- a/shims/apache/driver/src/test/java/org/pentaho/hadoop/shim/pvfs/conf/S3ConfTest.java
+++ b/shims/apache/driver/src/test/java/org/pentaho/hadoop/shim/pvfs/conf/S3ConfTest.java
@@ -2,7 +2,7 @@
  *
  * Pentaho Big Data
  *
- * Copyright (C) 2019 by Hitachi Vantara : http://www.pentaho.com
+ * Copyright (C) 2019-2020 by Hitachi Vantara : http://www.pentaho.com
  *
  *******************************************************************************
  *
@@ -81,6 +81,15 @@ public class S3ConfTest {
 
     assertThat( s3Conf.mapPath( path, new Path( "s3a://bucket/dir/file" ) ).toString(),
       equalTo( "pvfs://namedConn/bucket/dir/file" ) );
+  }
+
+  @Test public void mapPathWithSpaces() {
+    Path pathWithSpaces = new Path( "pvfs://nam ed Conn/bucket/somedir/somechild" );
+    Path result = s3Conf.mapPath( pathWithSpaces );
+    assertThat( result.toString(), equalTo( "s3a://bucket/somedir/somechild" ) );
+
+    assertThat( s3Conf.mapPath( pathWithSpaces, new Path( "s3a://bucket/dir/file" ) ).toString(),
+      equalTo( "pvfs://nam ed Conn/bucket/dir/file" ) );
   }
 
   @Test public void testConf() {


### PR DESCRIPTION
when writing Parquet and Orc files to S3 bucket

Previous commit missed 2 places where URI.getHost()
was being used to retrieve the connection name.

https://jira.pentaho.com/browse/PDI-18615