### PR TITLE
[BACKLOG-33827] Upgrade Avro version from 1.7.7 to 1.8.1 

### DIFF
--- a/shims/dataproc1421/pom.xml
+++ b/shims/dataproc1421/pom.xml
@@ -26,7 +26,7 @@
     <org.apache.oozie.version>4.3.1</org.apache.oozie.version>
     <sqoop.version>1.4.7</sqoop.version>
     <hive-jdbc.version>2.3.6</hive-jdbc.version>
-    <org.apache.avro.version>1.7.7</org.apache.avro.version>
+    <org.apache.avro.version>1.8.1</org.apache.avro.version>
     <hadoop-aws.version>2.9.2</hadoop-aws.version>
 
     <!-- client and default folders -->


### PR DESCRIPTION
Upgrade Avro version from 1.7.7 to 1.8.1 for Executing Sqoop on GDP