### PR TITLE
[BACKLOG-33529] Support for Parquet and ORC GCS read and write operations

### DIFF
--- a/shims/apache/driver/pom.xml
+++ b/shims/apache/driver/pom.xml
@@ -20,6 +20,7 @@
     <hadoop-aws.version>3.1.0.3.0.0.0-1634</hadoop-aws.version>
     <!-- client and default folders -->
     <hadoop.version>3.1.0.3.0.0.0-1634</hadoop.version>
+    <gcs-connector.version>hadoop2-1.9.17</gcs-connector.version>
     <!-- pmr folder -->
     <commons-configuration.version>1.6</commons-configuration.version>
     <commons-configuration2.version>2.1.1</commons-configuration2.version>
@@ -166,6 +167,19 @@
       <artifactId>jackson-dataformat-cbor</artifactId>
     </dependency>
 
+    <!-- Dependencies for GCS connectivity   -->
+    <dependency>
+      <groupId>com.google.cloud.bigdataoss</groupId>
+      <artifactId>gcs-connector</artifactId>
+      <version>${gcs-connector.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>com.google.guava</groupId>
+      <artifactId>guava</artifactId>
+      <version>21.0</version>
+      <scope>provided</scope>
+    </dependency>
+
     <dependency>
       <groupId>org.apache.hadoop</groupId>
       <artifactId>hadoop-aws</artifactId>
@@ -225,7 +239,8 @@
                 *:avro-mapred,
                 org.eclipse.jetty:*,
                 <!--Needed for Hive-->
-                *:commons-configuration,*:commons-configuration2
+                *:commons-configuration,*:commons-configuration2,
+                *:gcs-connector
               </include>
               <exclude>
                 org.slf4j:*,

--- a/shims/apache/driver/src/main/java/org/pentaho/hadoop/shim/pvfs/PvfsHadoopBridge.java
+++ b/shims/apache/driver/src/main/java/org/pentaho/hadoop/shim/pvfs/PvfsHadoopBridge.java
@@ -39,6 +39,7 @@ import org.pentaho.di.connections.ConnectionProvider;
 import org.pentaho.di.connections.vfs.provider.ConnectionFileName;
 import org.pentaho.di.connections.vfs.provider.ConnectionFileNameParser;
 import org.pentaho.hadoop.shim.api.format.org.pentaho.hadoop.shim.pvfs.api.PvfsHadoopBridgeFileSystemExtension;
+import org.pentaho.hadoop.shim.pvfs.conf.GcsConf;
 import org.pentaho.hadoop.shim.pvfs.conf.HCPConf;
 import org.pentaho.hadoop.shim.pvfs.conf.PvfsConf;
 import org.pentaho.hadoop.shim.pvfs.conf.S3Conf;
@@ -72,7 +73,7 @@ public class PvfsHadoopBridge extends FileSystem implements PvfsHadoopBridgeFile
 
   @SuppressWarnings( "unused" )
   public PvfsHadoopBridge() {
-    confFactories = Arrays.asList( S3Conf::new, HCPConf::new, SnwConf::new );
+    confFactories = Arrays.asList( S3Conf::new, HCPConf::new, SnwConf::new, GcsConf::new );
     connMgr = ConnectionManager.getInstance();
   }
 

--- a/shims/apache/driver/src/main/java/org/pentaho/hadoop/shim/pvfs/conf/GcsConf.java
+++ b/shims/apache/driver/src/main/java/org/pentaho/hadoop/shim/pvfs/conf/GcsConf.java
@@ -1,0 +1,106 @@
+/*******************************************************************************
+ *
+ * Pentaho Big Data
+ *
+ * Copyright (C) 2019-2020 by Hitachi Vantara : http://www.pentaho.com
+ *
+ *******************************************************************************
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ******************************************************************************/
+
+package org.pentaho.hadoop.shim.pvfs.conf;
+
+import com.google.cloud.hadoop.gcsio.GoogleCloudStorageFileSystem;
+import com.google.common.base.Preconditions;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.Path;
+import org.pentaho.di.connections.ConnectionDetails;
+
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.Arrays;
+import java.util.Objects;
+import java.util.stream.Collectors;
+
+import static org.apache.hadoop.fs.Path.SEPARATOR;
+import static org.pentaho.hadoop.shim.pvfs.PvfsHadoopBridge.getConnectionName;
+
+public class GcsConf extends PvfsConf {
+
+  private final String credentialsKeyPath;
+
+  public GcsConf( ConnectionDetails details ) {
+    super( details );
+    credentialsKeyPath = details.getProperties().get( "keyPath" );
+  }
+
+  @Override public boolean supportsConnection() {
+    return GoogleCloudStorageFileSystem.SCHEME.equalsIgnoreCase( details.getType() );
+  }
+
+  @Override public Path mapPath( Path pvfsPath ) {
+    validatePath( pvfsPath );
+    String[] splitPath = pvfsPath.toUri().getPath().split( "/" );
+
+    Preconditions.checkArgument( splitPath.length > 0 );
+    String bucket = splitPath[1];
+    String path = SEPARATOR + Arrays.stream( splitPath ).skip( 2 ).collect( Collectors.joining( SEPARATOR ) );
+    try {
+      return new Path( new URI( GoogleCloudStorageFileSystem.SCHEME, bucket, path, null ) );
+    } catch ( URISyntaxException e ) {
+      throw new IllegalStateException( e );
+    }
+  }
+
+  @Override public Path mapPath( Path pvfsPath, Path realFsPath ) {
+    URI uri = realFsPath.toUri();
+    return new Path( pvfsPath.toUri().getScheme(),
+            getConnectionName( pvfsPath ), "/" + uri.getHost() + uri.getPath() );
+  }
+
+  @Override public Configuration conf( Path pvfsPath ) {
+    /**
+     * GCS Connector configurations can be found here :
+     * https://github.com/GoogleCloudDataproc/hadoop-connectors/blob/master/gcs/conf/gcs-core-default.xml
+     */
+    Configuration config = new Configuration();
+    config.set( "fs.gs.impl", "com.google.cloud.hadoop.fs.gcs.GoogleHadoopFileSystem" );
+    config.set( "fs.AbstractFileSystem.gs.impl", "com.google.cloud.hadoop.fs.gcs.GoogleHadoopFS" );
+    config.set( "google.cloud.auth.service.account.enable", "true" );
+    config.set( "google.cloud.auth.service.account.json.keyfile", credentialsKeyPath );
+    config.set( "fs.gs.http.max.retry", "10" );
+    config.set( "fs.gs.http.connect-timeout", "20000" );
+    config.set( "fs.gs.performance.cache.enable", "false" ); // caching managed by PvfsHadoopBridge
+    return config;
+  }
+
+  @Override public boolean equals( Object o ) {
+    if ( this == o ) {
+      return true;
+    }
+    if ( o == null || getClass() != o.getClass() ) {
+      return false;
+    }
+    if ( !super.equals( o ) ) {
+      return false;
+    }
+    GcsConf gcsConf = (GcsConf) o;
+    return Objects.equals( credentialsKeyPath, gcsConf.credentialsKeyPath );
+  }
+
+  @Override public int hashCode() {
+    return Objects.hash( super.hashCode(), credentialsKeyPath );
+  }
+}

--- a/shims/apache/driver/src/test/java/org/pentaho/hadoop/shim/pvfs/conf/GcsConfTest.java
+++ b/shims/apache/driver/src/test/java/org/pentaho/hadoop/shim/pvfs/conf/GcsConfTest.java
@@ -1,0 +1,121 @@
+/*******************************************************************************
+ *
+ * Pentaho Big Data
+ *
+ * Copyright (C) 2019-2020 by Hitachi Vantara : http://www.pentaho.com
+ *
+ *******************************************************************************
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ******************************************************************************/
+package org.pentaho.hadoop.shim.pvfs.conf;
+
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.Path;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+import org.pentaho.di.connections.ConnectionDetails;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.when;
+
+@RunWith( MockitoJUnitRunner.class )
+public class GcsConfTest {
+
+  private GcsConf gcsConf;
+  private GcsConf badGcsConf;
+  private S3Conf s3Conf;
+  private Path path;
+  @Mock private ConnectionDetails gcsConn;
+  @Mock private ConnectionDetails otherGcsConn;
+  @Mock private ConnectionDetails hcpConn;
+  @Mock private ConnectionDetails s3Conn;
+  private Map<String, String> gcsProps = new HashMap<>();
+  private Map<String, String> s3Props = new HashMap<>();
+
+  @Before public void before() {
+    gcsProps.put( "keyPath", "/home/ubuntu/gcs/credentials.json" );
+    when( gcsConn.getProperties() ).thenReturn(gcsProps);
+    when( gcsConn.getType() ).thenReturn( "gs" );
+    gcsConf = new GcsConf(gcsConn);
+    badGcsConf = new GcsConf( gcsConn );
+    path = new Path( "pvfs://namedConn/bucket/somedir/somechild" );
+
+    s3Props.put( "accessKey", "ACCESSKEY" );
+    s3Props.put( "secretKey", "SECRETKEY" );
+    when( s3Conn.getProperties() ).thenReturn(s3Props);
+    when( s3Conn.getType() ).thenReturn( "s3" );
+    s3Conf = new S3Conf( s3Conn );
+
+    when( hcpConn.getType() ).thenReturn( "hcp" );
+    badGcsConf = new GcsConf( hcpConn );
+  }
+
+  @Test public void testSupportedSchemes() {
+    assertTrue( gcsConf.supportsConnection() );
+    assertFalse( badGcsConf.supportsConnection() );
+  }
+
+  @Test public void mapPath() {
+    Path result = gcsConf.mapPath( path );
+    assertThat( result.toString(), equalTo( "gs://bucket/somedir/somechild" ) );
+
+    assertThat( gcsConf.mapPath( path, new Path( "gs://bucket/dir/file" ) ).toString(),
+      equalTo( "pvfs://namedConn/bucket/dir/file" ) );
+  }
+
+  @Test public void mapPathWithSpaces() {
+    Path pathWithSpaces = new Path( "pvfs://nam ed Conn/bucket/somedir/somechild" );
+    Path result = gcsConf.mapPath( pathWithSpaces );
+    assertThat( result.toString(), equalTo( "gs://bucket/somedir/somechild" ) );
+
+    assertThat( gcsConf.mapPath( pathWithSpaces, new Path( "gs://bucket/dir/file" ) ).toString(),
+      equalTo( "pvfs://nam ed Conn/bucket/dir/file" ) );
+  }
+
+  @Test public void testConf() {
+    Configuration conf = gcsConf.conf( path );
+    assertThat( conf.get( "fs.gs.impl" ),
+      equalTo( "com.google.cloud.hadoop.fs.gcs.GoogleHadoopFileSystem" ) );
+    assertThat( conf.get( "google.cloud.auth.service.account.json.keyfile" ),
+      equalTo( "/home/ubuntu/gcs/credentials.json" ) );
+  }
+
+  @Test public void testEquals() {
+    assertNotEquals( null, gcsConf);
+    assertEquals(gcsConf, gcsConf);
+    assertNotEquals(gcsConf, s3Conf );
+    when( otherGcsConn.getProperties() ).thenReturn( new HashMap<>(gcsProps) );
+    when( otherGcsConn.getType() ).thenReturn( "gs" );
+
+    GcsConf otherGcsConf = new GcsConf( otherGcsConn );
+
+    assertEquals( otherGcsConf, gcsConf);
+    // change auth credentials path
+    otherGcsConn.getProperties().put( "keyPath", "/home/ubuntu/gcs/credentials2.json" );
+    assertNotEquals( otherGcsConf, gcsConf);
+
+    assertNotEquals( gcsConf.hashCode(), s3Conf.hashCode() );
+    assertNotEquals( gcsConf.hashCode(), otherGcsConf.hashCode() );
+  }
+
+}


### PR DESCRIPTION
Add support to read and write Parquet and ORC files from Google Cloud Storage Bucket in PDI client.