### PR TITLE
[BACKLOG-34197] Process system variables in config.properties when

### DIFF
--- a/common-fragment-V1/src/main/java/org/pentaho/hadoop/shim/ShimConfigsLoader.java
+++ b/common-fragment-V1/src/main/java/org/pentaho/hadoop/shim/ShimConfigsLoader.java
@@ -184,6 +184,13 @@ public class ShimConfigsLoader {
 
   public static void addConfigsAsResources( String additionalPath, Consumer<? super URL> configurationConsumer,
                                             ClusterConfigNames... fileNames ) {
+    setSystemProperties( additionalPath );
+
+    addConfigsAsResources( additionalPath, configurationConsumer,
+      Arrays.stream( fileNames ).map( ClusterConfigNames::toString ).collect( Collectors.toList() ) );
+  }
+
+  public static void setSystemProperties( String additionalPath ) {
     Properties properties = loadConfigProperties( additionalPath );
     for ( String propertyName : properties.stringPropertyNames() ) {
       if ( propertyName.startsWith( "java.system." ) ) {
@@ -191,9 +198,6 @@ public class ShimConfigsLoader {
           properties.get( propertyName ).toString() );
       }
     }
-
-    addConfigsAsResources( additionalPath, configurationConsumer,
-      Arrays.stream( fileNames ).map( ClusterConfigNames::toString ).collect( Collectors.toList() ) );
   }
 
   public static void addConfigsAsResources( String additionalPath, Consumer<? super URL> configurationConsumer,

--- a/common-fragment-V1/src/main/java/org/pentaho/hadoop/shim/common/ConfigurationProxyV2.java
+++ b/common-fragment-V1/src/main/java/org/pentaho/hadoop/shim/common/ConfigurationProxyV2.java
@@ -82,6 +82,7 @@ public class ConfigurationProxyV2 implements Configuration {
               namedClusterSiteFile.getSiteFileName() );
         }
       }
+      ShimConfigsLoader.setSystemProperties( nc.getName() );
     }
   }
 


### PR DESCRIPTION
creating a Configuration object.