### PR TITLE
[BACKLOG-34161] Update dataproc UI version to 1.4 from 1.4.21

### DIFF
--- a/shims/dataproc1421/driver/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/shims/dataproc1421/driver/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -7,7 +7,7 @@
     <bean id="dataproc1421ShimIdentifier" class="org.pentaho.hadoop.shim.api.internal.ShimIdentifier" scope="singleton">
         <argument value="dataproc1421"/>
         <argument value="Google Dataproc"/>
-        <argument value="1.4.21"/>
+        <argument value="1.4"/>
         <argument value="COMMUNITY"/>
     </bean>
 


### PR DESCRIPTION
Update the dataproc version to 1.4.
This change only applies to the version shown in the UI dropdown when creating a new hadoop cluster.
The driver version, kar filename etc would still continue to have 1.4.21 in them.