### PR TITLE
Revert "[SP-5678] Backport of PDI-18840.  Provide a way to exclude in…

### DIFF
--- a/api/src/main/java/org/pentaho/hadoop/shim/api/DistributedCacheUtil.java
+++ b/api/src/main/java/org/pentaho/hadoop/shim/api/DistributedCacheUtil.java
@@ -2,7 +2,7 @@
  *
  * Pentaho Big Data
  *
- * Copyright (C) 2002-2020 by Hitachi Vantara : http://www.pentaho.com
+ * Copyright (C) 2002-2017 by Hitachi Vantara : http://www.pentaho.com
  *
  *******************************************************************************
  *
@@ -69,8 +69,7 @@ public interface DistributedCacheUtil {
    * @throws Exception Error staging the Kettle environment
    */
   void installKettleEnvironment( FileObject pmrLibArchive, FileSystem fs, Path destination,
-                                 FileObject bigDataPluginFolder, String additionalPlugins,
-                                 String excludePluginFileNames ) throws Exception;
+                                 FileObject bigDataPluginFolder, String additionalPlugins ) throws Exception;
 
   /**
    * Stages the source file or folder to a Hadoop file system and sets their permission and replication value
@@ -88,8 +87,7 @@ public interface DistributedCacheUtil {
    * @throws IOException Destination exists is not a directory, Source does not exist or destination exists and
    *                     overwrite is false.
    */
-  void stageForCache( FileObject source, FileSystem fs, Path dest, String excludeFiles, boolean overwrite, boolean isPublic )
-    throws IOException;
+  void stageForCache( FileObject source, FileSystem fs, Path dest, boolean overwrite, boolean isPublic ) throws IOException;
 
   /**
    * Register a list of files from a Hadoop file system to be available and placed on the classpath when the

--- a/common/common-shim/src/test/java/org/pentaho/hadoop/shim/common/DistributedCacheTestUtil.java
+++ b/common/common-shim/src/test/java/org/pentaho/hadoop/shim/common/DistributedCacheTestUtil.java
@@ -2,7 +2,7 @@
  *
  * Pentaho Big Data
  *
- * Copyright (C) 2002-2020 by Hitachi Vantara : http://www.pentaho.com
+ * Copyright (C) 2002-2017 by Hitachi Vantara : http://www.pentaho.com
  *
  *******************************************************************************
  *
@@ -42,16 +42,10 @@ public class DistributedCacheTestUtil {
   }
 
   static FileObject createTestFolderWithContent( String rootFolderName ) throws Exception {
-    return createTestFolderWithContent( rootFolderName, 2 );
-  }
-
-  static FileObject createTestFolderWithContent( String rootFolderName, int numJars ) throws Exception {
     String rootName = "bin/test/" + rootFolderName;
     FileObject root = KettleVFS.getFileObject( rootName );
-    for ( int i = 1; i < numJars + 1; i++ ) {
-      String jarName = "jar" + i + ".jar";
-      root.resolveFile( jarName ).createFile();
-    }
+    root.resolveFile( "jar1.jar" ).createFile();
+    root.resolveFile( "jar2.jar" ).createFile();
     root.resolveFile( "folder" ).resolveFile( "file.txt" ).createFile();
     root.resolveFile( "pentaho-mapreduce-libraries.zip" ).createFile();
 

--- a/common/common-shim/src/test/java/org/pentaho/hadoop/shim/common/DistributedCacheUtilImplOSDependentTest.java
+++ b/common/common-shim/src/test/java/org/pentaho/hadoop/shim/common/DistributedCacheUtilImplOSDependentTest.java
@@ -2,7 +2,7 @@
  *
  * Pentaho Big Data
  *
- * Copyright (C) 2002-2020 by Hitachi Vantara : http://www.pentaho.com
+ * Copyright (C) 2002-2017 by Hitachi Vantara : http://www.pentaho.com
  *
  *******************************************************************************
  *
@@ -140,7 +140,7 @@ public class DistributedCacheUtilImplOSDependentTest {
     FileObject pluginDir = DistributedCacheTestUtil.createTestFolderWithContent();
 
     try {
-      ch.stagePluginsForCache( fs, pluginsDir, "bin/test/sample-folder", "" );
+      ch.stagePluginsForCache( fs, pluginsDir, "bin/test/sample-folder" );
       Path pluginInstallPath = new Path( pluginsDir, "bin/test/sample-folder" );
       assertTrue( fs.exists( pluginInstallPath ) );
       ContentSummary summary = fs.getContentSummary( pluginInstallPath );
@@ -196,7 +196,7 @@ public class DistributedCacheUtilImplOSDependentTest {
 
     Path root = new Path( "bin/test/installKettleEnvironment" );
     try {
-      ch.installKettleEnvironment( pmrArchive, fs, root, bigDataPluginDir, null, "" );
+      ch.installKettleEnvironment( pmrArchive, fs, root, bigDataPluginDir, null );
       assertTrue( ch.isKettleEnvironmentInstalledAt( fs, root ) );
     } finally {
       bigDataPluginDir.delete( new AllFileSelector() );
@@ -219,7 +219,7 @@ public class DistributedCacheUtilImplOSDependentTest {
     FileObject additionalPluginDir = DistributedCacheTestUtil.createTestFolderWithContent( pluginName );
     Path root = new Path( "bin/test/installKettleEnvironment" );
     try {
-      ch.installKettleEnvironment( pmrArchive, fs, root, bigDataPluginDir, "bin/test/" + pluginName, "" );
+      ch.installKettleEnvironment( pmrArchive, fs, root, bigDataPluginDir, "bin/test/" + pluginName );
       assertTrue( ch.isKettleEnvironmentInstalledAt( fs, root ) );
       assertTrue( fs.exists( new Path( root, "plugins/bin/test/" + pluginName ) ) );
     } finally {
@@ -280,7 +280,7 @@ public class DistributedCacheUtilImplOSDependentTest {
 
     Path root = new Path( "bin/test/installKettleEnvironment" );
     try {
-      ch.installKettleEnvironment( pmrArchive, fs, root, bigDataPluginDir, null, "" );
+      ch.installKettleEnvironment( pmrArchive, fs, root, bigDataPluginDir, null );
       assertTrue( ch.isKettleEnvironmentInstalledAt( fs, root ) );
 
       ch.configureWithKettleEnvironment( conf, fs, root );

--- a/common/common-shim/src/test/java/org/pentaho/hadoop/shim/common/DistributedCacheUtilImplTest.java
+++ b/common/common-shim/src/test/java/org/pentaho/hadoop/shim/common/DistributedCacheUtilImplTest.java
@@ -2,7 +2,7 @@
  *
  * Pentaho Big Data
  *
- * Copyright (C) 2002-2020 by Hitachi Vantara : http://www.pentaho.com
+ * Copyright (C) 2002-2017 by Hitachi Vantara : http://www.pentaho.com
  *
  *******************************************************************************
  *
@@ -313,33 +313,6 @@ public class DistributedCacheUtilImplTest {
   }
 
   @Test
-  public void stageForCache_exclude_file() throws Exception {
-    DistributedCacheUtilImpl ch = new DistributedCacheUtilImpl( TEST_CONFIG );
-
-    Configuration conf = new Configuration();
-    FileSystem fs = DistributedCacheTestUtil.getLocalFileSystem( conf );
-
-    FileObject source = DistributedCacheTestUtil.createTestFolderWithContent( "sample-folder", 3 );
-    try {
-      Path root = new Path( "bin/test/stageForCache_exclude_file" );
-      Path dest = new Path( root, "dest" );
-
-      try {
-        ch.stageForCache( source, fs, dest, "foo,jar2,bar,jar3", false, true );
-        assertTrue( fs.exists( new Path( dest, "jar1.jar" ) ) );
-        assertTrue( fs.exists( new Path( dest, "folder/file.txt" ) ) );
-        assertTrue( fs.exists( new Path( dest, "pentaho-mapreduce-libraries.zip" ) ) );
-        assertFalse( fs.exists( new Path( dest, "jar2.jar" ) ) );
-        assertFalse( fs.exists( new Path( dest, "jar3.jar" ) ) );
-      } finally {
-        fs.delete( root, true );
-      }
-    } finally {
-      source.delete( new AllFileSelector() );
-    }
-  }
-
-  @Test
   public void addCachedFilesToClasspath() throws IOException {
     DistributedCacheUtilImpl ch = new DistributedCacheUtilImpl( TEST_CONFIG );
     Configuration conf = new Configuration();
@@ -364,23 +337,21 @@ public class DistributedCacheUtilImplTest {
     DistributedCacheUtilImpl ch = new DistributedCacheUtilImpl( TEST_CONFIG );
 
     try {
-      ch.installKettleEnvironment( null, (org.pentaho.hadoop.shim.api.fs.FileSystem) null, null, null, null,
-        "" );
+      ch.installKettleEnvironment( null, (org.pentaho.hadoop.shim.api.fs.FileSystem) null, null, null, null );
       fail( "Expected exception on missing archive" );
     } catch ( NullPointerException ex ) {
       assertEquals( "pmrArchive is required", ex.getMessage() );
     }
 
     try {
-      ch.installKettleEnvironment( KettleVFS.getFileObject( "." ), (org.pentaho.hadoop.shim.api.fs.FileSystem) null, null, null, null, "" );
+      ch.installKettleEnvironment( KettleVFS.getFileObject( "." ), (org.pentaho.hadoop.shim.api.fs.FileSystem) null, null, null, null );
       fail( "Expected exception on missing archive" );
     } catch ( NullPointerException ex ) {
       assertEquals( "destination is required", ex.getMessage() );
     }
 
     try {
-      ch.installKettleEnvironment( KettleVFS.getFileObject( "." ),
-        (org.pentaho.hadoop.shim.api.fs.FileSystem) null, new PathProxy( "." ), null, null, "" );
+      ch.installKettleEnvironment( KettleVFS.getFileObject( "." ), (org.pentaho.hadoop.shim.api.fs.FileSystem) null, new PathProxy( "." ), null, null );
       fail( "Expected exception on missing archive" );
     } catch ( NullPointerException ex ) {
       assertEquals( "big data plugin required", ex.getMessage() );
@@ -390,15 +361,13 @@ public class DistributedCacheUtilImplTest {
   @Test( expected = IllegalArgumentException.class )
   public void stagePluginsForCache_no_folders() throws Exception {
     DistributedCacheUtilImpl ch = new DistributedCacheUtilImpl( TEST_CONFIG );
-    ch.stagePluginsForCache( DistributedCacheTestUtil.getLocalFileSystem( new Configuration() ),
-      new Path( "bin/test/plugins-installation-dir" ), null, "" );
+    ch.stagePluginsForCache( DistributedCacheTestUtil.getLocalFileSystem( new Configuration() ), new Path( "bin/test/plugins-installation-dir" ), null );
   }
 
   @Test( expected = KettleFileException.class )
   public void stagePluginsForCache_invalid_folder() throws Exception {
     DistributedCacheUtilImpl ch = new DistributedCacheUtilImpl( TEST_CONFIG );
-    ch.stagePluginsForCache( DistributedCacheTestUtil.getLocalFileSystem( new Configuration() ),
-      new Path( "bin/test/plugins-installation-dir" ), "bin/bogus-plugin-name", "" );
+    ch.stagePluginsForCache( DistributedCacheTestUtil.getLocalFileSystem( new Configuration() ), new Path( "bin/test/plugins-installation-dir" ), "bin/bogus-plugin-name" );
   }
 
   @Test


### PR DESCRIPTION
Reverts pentaho/pentaho-hadoop-shims#1152

Reverting this from `8.3.0.14` for two reasons:
1. This fix is not scheduled for the August SP
2. This fix is breaking the 8.3 service pack build.

This is probably because the shims aren't rebuilt in the service pack build.

Leaving in the `8.3` branch to be addressed in the September SP.