### PR TITLE
[BACKLOG-39454] Bundle plugin is confused by multi-version jar files and

### DIFF
--- a/shims/apache/driver/pom.xml
+++ b/shims/apache/driver/pom.xml
@@ -348,6 +348,9 @@
             <Bundle-Version>3.0.apache</Bundle-Version>
             <Pentaho-Code-Version>${pentaho-code.version}</Pentaho-Code-Version>
             <DynamicImport-Package>*</DynamicImport-Package>
+            <!-- this is needed because the bundle plugin gets fooled by multi-release jars into thinking the required java
+            version is the highest one in the package, which is not the case -->
+            <Require-Capability>osgi.ee;filter:="(&amp;(osgi.ee=JavaSE)(version=1.8))"</Require-Capability>
             <Import-Package>
             </Import-Package>
             <_exportcontents>

--- a/shims/cdh61/driver/pom.xml
+++ b/shims/cdh61/driver/pom.xml
@@ -484,6 +484,9 @@
             </_exportcontents>
             <Embed-Dependency>*</Embed-Dependency>
             <Include-Resource>{maven-resources}</Include-Resource>
+            <!-- this is needed because the bundle plugin gets fooled by multi-release jars into thinking the required java
+            version is the highest one in the package, which is not the case -->
+            <Require-Capability>osgi.ee;filter:="(&amp;(osgi.ee=JavaSE)(version=1.8))"</Require-Capability>
           </instructions>
         </configuration>
       </plugin>

--- a/shims/cdpdc71/driver/pom.xml
+++ b/shims/cdpdc71/driver/pom.xml
@@ -579,6 +579,9 @@
             </_exportcontents>
             <Embed-Dependency>*</Embed-Dependency>
             <Include-Resource>{maven-resources}</Include-Resource>
+            <!-- this is needed because the bundle plugin gets fooled by multi-release jars into thinking the required java
+            version is the highest one in the package, which is not the case -->
+            <Require-Capability>osgi.ee;filter:="(&amp;(osgi.ee=JavaSE)(version=1.8))"</Require-Capability>
           </instructions>
         </configuration>
       </plugin>

--- a/shims/dataproc1421/driver/pom.xml
+++ b/shims/dataproc1421/driver/pom.xml
@@ -478,6 +478,9 @@
             </_exportcontents>
             <Embed-Dependency>*</Embed-Dependency>
             <Include-Resource>{maven-resources}</Include-Resource>
+            <!-- this is needed because the bundle plugin gets fooled by multi-release jars into thinking the required java
+            version is the highest one in the package, which is not the case -->
+            <Require-Capability>osgi.ee;filter:="(&amp;(osgi.ee=JavaSE)(version=1.8))"</Require-Capability>
           </instructions>
         </configuration>
       </plugin>

--- a/shims/emr521/driver/pom.xml
+++ b/shims/emr521/driver/pom.xml
@@ -344,6 +344,9 @@
             </_exportcontents>
             <Embed-Dependency>*</Embed-Dependency>
             <Include-Resource>{maven-resources}</Include-Resource>
+            <!-- this is needed because the bundle plugin gets fooled by multi-release jars into thinking the required java
+            version is the highest one in the package, which is not the case -->
+            <Require-Capability>osgi.ee;filter:="(&amp;(osgi.ee=JavaSE)(version=1.8))"</Require-Capability>
           </instructions>
         </configuration>
       </plugin>

--- a/shims/hdi40/driver/pom.xml
+++ b/shims/hdi40/driver/pom.xml
@@ -516,6 +516,9 @@
             </_exportcontents>
             <Embed-Dependency>*</Embed-Dependency>
             <Include-Resource>{maven-resources}</Include-Resource>
+            <!-- this is needed because the bundle plugin gets fooled by multi-release jars into thinking the required java
+            version is the highest one in the package, which is not the case -->
+            <Require-Capability>osgi.ee;filter:="(&amp;(osgi.ee=JavaSE)(version=1.8))"</Require-Capability>
           </instructions>
         </configuration>
       </plugin>

--- a/shims/hdp30/driver/pom.xml
+++ b/shims/hdp30/driver/pom.xml
@@ -519,6 +519,9 @@
             </_exportcontents>
             <Embed-Dependency>*</Embed-Dependency>
             <Include-Resource>{maven-resources}</Include-Resource>
+            <!-- this is needed because the bundle plugin gets fooled by multi-release jars into thinking the required java
+            version is the highest one in the package, which is not the case -->
+            <Require-Capability>osgi.ee;filter:="(&amp;(osgi.ee=JavaSE)(version=1.8))"</Require-Capability>
           </instructions>
         </configuration>
       </plugin>

--- a/shims/mapr60/driver/pom.xml
+++ b/shims/mapr60/driver/pom.xml
@@ -229,6 +229,9 @@
             </_exportcontents>
             <Embed-Dependency>*</Embed-Dependency>
             <Bundle-Activator>org.pentaho.hadoop.shim.ShimActivator</Bundle-Activator>
+            <!-- this is needed because the bundle plugin gets fooled by multi-release jars into thinking the required java
+            version is the highest one in the package, which is not the case -->
+            <Require-Capability>osgi.ee;filter:="(&amp;(osgi.ee=JavaSE)(version=1.8))"</Require-Capability>
           </instructions>
         </configuration>
       </plugin>

--- a/shims/mapr61/driver/pom.xml
+++ b/shims/mapr61/driver/pom.xml
@@ -229,6 +229,9 @@
             </_exportcontents>
             <Embed-Dependency>*</Embed-Dependency>
             <Bundle-Activator>org.pentaho.hadoop.shim.ShimActivator</Bundle-Activator>
+            <!-- this is needed because the bundle plugin gets fooled by multi-release jars into thinking the required java
+            version is the highest one in the package, which is not the case -->
+            <Require-Capability>osgi.ee;filter:="(&amp;(osgi.ee=JavaSE)(version=1.8))"</Require-Capability>
           </instructions>
         </configuration>
       </plugin>

--- a/shims/pom.xml
+++ b/shims/pom.xml
@@ -362,6 +362,5 @@
     </modules>
   </profile>
 
-
 </profiles>
 </project>


### PR DESCRIPTION
assumes the required JVM is the highest in the package, which is not the case.