### PR TITLE
[PPP-4582] Use of Vulnerable Component: Components/oauth_client_library_for_java:

### DIFF
--- a/shims/apache/driver/pom.xml
+++ b/shims/apache/driver/pom.xml
@@ -19,14 +19,14 @@
     <!-- default folder -->
     <failureaccess.version>1.0.1</failureaccess.version>
     <org.apache.avro.version>1.8.0</org.apache.avro.version>
-    <hadoop-aws.version>3.3.0</hadoop-aws.version>
+    <hadoop-aws.version>3.3.3</hadoop-aws.version>
     <!-- client and default folders -->
-    <hadoop.version>3.3.0</hadoop.version>
-    <gcs-connector.version>hadoop2-1.9.17</gcs-connector.version>
+    <hadoop.version>3.3.3</hadoop.version>
+    <gcs-connector.version>3.0.1</gcs-connector.version>
     <!-- pmr folder -->
     <commons-configuration.version>1.6</commons-configuration.version>
     <commons-configuration2.version>2.10.1</commons-configuration2.version>
-    <org.apache.hadoop.version>3.3.0</org.apache.hadoop.version>
+    <org.apache.hadoop.version>3.3.6</org.apache.hadoop.version>
     <org.apache.orc.version>1.6.1</org.apache.orc.version>
     <parquet.version>1.11.1</parquet.version>
     <joda-time.version>2.9.9</joda-time.version>
@@ -218,12 +218,12 @@
     <dependency>
       <groupId>org.apache.hadoop</groupId>
       <artifactId>hadoop-azure</artifactId>
-      <version>3.3.0</version>
+      <version>${org.apache.hadoop.version}</version>
     </dependency>
     <dependency>
       <groupId>org.apache.hadoop</groupId>
       <artifactId>hadoop-azure-datalake</artifactId>
-      <version>3.3.0</version>
+      <version>${org.apache.hadoop.version}</version>
     </dependency>
     <dependency>
       <groupId>com.google.guava</groupId>

--- a/shims/apachevanilla/driver/pom.xml
+++ b/shims/apachevanilla/driver/pom.xml
@@ -33,7 +33,7 @@
     <jython.version>2.5.3</jython.version>
     <jetty.version>9.3.20.v20170531</jetty.version>
     <org.apache.knox.version>1.3.0.7.2.16.0-287</org.apache.knox.version>
-    <gcs-connector.version>hadoop2-1.9.17</gcs-connector.version>
+    <gcs-connector.version>3.0.1</gcs-connector.version>
     <commons-configuration2.version>2.10.1</commons-configuration2.version>
   </properties>
 

--- a/shims/cdpdc71/driver/pom.xml
+++ b/shims/cdpdc71/driver/pom.xml
@@ -33,7 +33,7 @@
     <jython.version>2.5.3</jython.version>
     <jetty.version>9.3.20.v20170531</jetty.version>
     <org.apache.knox.version>1.3.0.7.2.16.0-287</org.apache.knox.version>
-    <gcs-connector.version>hadoop2-1.9.17</gcs-connector.version>
+    <gcs-connector.version>3.0.1</gcs-connector.version>
     <commons-configuration2.version>2.10.1</commons-configuration2.version>
   </properties>
 

--- a/shims/dataproc1421/driver/pom.xml
+++ b/shims/dataproc1421/driver/pom.xml
@@ -16,6 +16,12 @@
       <groupId>com.google.cloud.bigdataoss</groupId>
       <artifactId>gcs-connector</artifactId>
       <version>${gcs-connector.version}</version>
+      <exclusions>
+        <exclusion>
+          <groupId>*</groupId>
+          <artifactId>*</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>com.google.guava</groupId>

--- a/shims/dataproc1421/pom.xml
+++ b/shims/dataproc1421/pom.xml
@@ -15,7 +15,7 @@
     <pentaho-code.version>11.0.0.0</pentaho-code.version>
 
     <!-- GCP properties -->
-    <gcs-connector.version>hadoop2-1.9.17</gcs-connector.version>
+    <gcs-connector.version>hadoop2-2.2.24</gcs-connector.version>
 
     <!-- default folder -->
     <org.apache.hbase.version>2.2.0</org.apache.hbase.version>


### PR DESCRIPTION
- Update gcs-connector to 3.0.1 where possible (Hadoop 3.x)
- Update gcs-connector to latest 2.x where needed (Hadoop 2.x), and exclude transitive dependencies

PR Set for https://hv-eng.atlassian.net/browse/PPP-4582:
- https://github.com/pentaho/pdi-plugins-ee/pull/1290
- https://github.com/pentaho/pentaho-platform/pull/5676
- https://github.com/pentaho/pentaho-hadoop-shims/pull/1452