### PR TITLE
[BACKLOG-41761] Upgrade Apache Vanilla Shim to latest Hadoop 3.4.0 and start supporting Apache Vanilla Hadoop3.3.0+ cluster connectivity ( Direct dependency )

### DIFF
--- a/shims/apachevanilla/driver/pom.xml
+++ b/shims/apachevanilla/driver/pom.xml
@@ -16,24 +16,23 @@
     <commons-lang.version>2.6</commons-lang.version>
     <failureaccess.version>1.0.1</failureaccess.version>
     <pentaho-osgi-bundles.version>10.3.0.0-SNAPSHOT</pentaho-osgi-bundles.version>
-    <org.apache.avro.version>1.8.2.7.1.4.0-203</org.apache.avro.version>
-    <org.apache.orc.version>1.5.1.7.1.4.0-203</org.apache.orc.version>
-    <parquet.version>1.10.99.7.1.4.0-203</parquet.version>
-    <org.apache.hadoop.version>3.1.1.7.1.4.0-203</org.apache.hadoop.version>
-    <org.apache.hbase.version>2.2.3.7.1.4.0-203</org.apache.hbase.version>
+    <org.apache.avro.version>1.12.0</org.apache.avro.version>
+    <org.apache.orc.version>2.0.2</org.apache.orc.version>
+    <parquet.version>1.14.1</parquet.version>
+    <org.apache.hadoop.version>3.4.0</org.apache.hadoop.version>
+    <org.apache.hbase.version>2.6.0</org.apache.hbase.version>
     <org.apache.hive.version>3.1.3000.7.1.4.0-203</org.apache.hive.version>
-    <org.apache.oozie.version>5.1.0.7.1.4.0-203</org.apache.oozie.version>
-    <pig.version>0.16.0.7.1.4.0-203</pig.version>
-    <parquet-pig.version>1.10.99.7.1.4.0-203</parquet-pig.version>
-    <sqoop.version>1.4.7.7.1.4.0-203</sqoop.version>
-    <vendor-driver.version>7.1.4.0-203</vendor-driver.version>
+    <org.apache.oozie.version>5.2.1</org.apache.oozie.version>
+    <pig.version>0.17.0</pig.version>
+    <parquet-pig.version>1.14.1</parquet-pig.version>
+    <sqoop.version>1.4.7</sqoop.version>
+    <vendor-driver.version>3.4.0</vendor-driver.version>
     <pentaho-code.version>11.0.0.0</pentaho-code.version>
-    <joda-time.version>2.10</joda-time.version>
-    <jython.version>2.5.3</jython.version>
+    <joda-time.version>2.12.7</joda-time.version>
+    <jython.version>2.7.4</jython.version>
     <jetty.version>9.3.20.v20170531</jetty.version>
-    <org.apache.knox.version>1.3.0.7.2.16.0-287</org.apache.knox.version>
-    <gcs-connector.version>hadoop2-1.9.17</gcs-connector.version>
-    <commons-configuration2.version>2.10.1</commons-configuration2.version>
+    <gcs-connector.version>3.0.2</gcs-connector.version>
+    <commons-configuration2.version>2.11.0</commons-configuration2.version>
   </properties>
 
   <dependencyManagement>
@@ -206,6 +205,12 @@
       <groupId>org.apache.hadoop</groupId>
       <artifactId>hadoop-aws</artifactId>
       <version>${org.apache.hadoop.version}</version>
+      <exclusions>
+        <exclusion>
+          <groupId>software.amazon.awssdk</groupId>
+          <artifactId>bundle</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>org.apache.hadoop</groupId>
@@ -229,60 +234,9 @@
       <version>0.4.20</version>
     </dependency>
     <dependency>
-      <groupId>org.apache.knox</groupId>
-      <artifactId>gateway-cloud-bindings</artifactId>
-      <version>${org.apache.knox.version}</version>
-      <exclusions>
-        <exclusion>
-          <groupId>org.slf4j</groupId>
-          <artifactId>slf4j-simple</artifactId>
-        </exclusion>
-        <exclusion>
-          <groupId>org.slf4j</groupId>
-          <artifactId>slf4j-api</artifactId>
-        </exclusion>
-      </exclusions>
-    </dependency>
-    <dependency>
-      <groupId>org.apache.knox</groupId>
-      <artifactId>gateway-util-common</artifactId>
-      <version>${org.apache.knox.version}</version>
-      <exclusions>
-        <exclusion>
-          <groupId>org.slf4j</groupId>
-          <artifactId>slf4j-simple</artifactId>
-        </exclusion>
-        <exclusion>
-          <groupId>org.slf4j</groupId>
-          <artifactId>slf4j-api</artifactId>
-        </exclusion>
-      </exclusions>
-    </dependency>
-    <dependency>
       <groupId>stax</groupId>
       <artifactId>stax</artifactId>
       <version>1.2.0</version>
-    </dependency>
-
-    <dependency>
-      <groupId>org.apache.knox</groupId>
-      <artifactId>gateway-shell</artifactId>
-      <version>${org.apache.knox.version}</version>
-      <exclusions>
-        <exclusion>
-          <groupId>org.slf4j</groupId>
-          <artifactId>slf4j-simple</artifactId>
-        </exclusion>
-        <exclusion>
-          <groupId>org.slf4j</groupId>
-          <artifactId>slf4j-api</artifactId>
-        </exclusion>
-      </exclusions>
-    </dependency>
-    <dependency>
-      <groupId>org.apache.knox</groupId>
-      <artifactId>gateway-i18n</artifactId>
-      <version>${org.apache.knox.version}</version>
     </dependency>
     <dependency>
       <groupId>org.apache.hive</groupId>
@@ -462,6 +416,11 @@
     </dependency>
     <dependency>
       <groupId>org.apache.hbase</groupId>
+      <artifactId>hbase-mapreduce</artifactId>
+      <version>${org.apache.hbase.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.hbase</groupId>
       <artifactId>hbase-server</artifactId>
       <version>${org.apache.hbase.version}</version>
       <exclusions>
@@ -556,11 +515,12 @@
                 *:hive-service,*:orc-core,*:hadoop-common,*:hadoop-hdfs,*:hadoop-mapreduce-*,
                 *:hadoop-yarn-api,*:hbase-client,*:hbase-common,*:hbase-hadoop-compat,*:hbase-protocol,
                 *:hbase-server,*:oozie-client,*:parquet-hadoop-bundle,*:zookeeper,*:hbase-shaded-miscellaneous,
-                org.eclipse.jetty:*,com.google.guava:*,*:hadoop-lzo,*:hadoop-client,*:hadoop-aws,*:hadoop-azure,*:gcs-connector,*:hadoop-hdfs-client,*:commons-configuration2
+                org.eclipse.jetty:*,com.google.guava:*,*:hadoop-lzo,*:hadoop-client,*:hadoop-aws,*:hadoop-azure,*:gcs-connector,*:hadoop-hdfs-client,*:commons-configuration2,
+                *:hbase-mapreduce
               </include>
               <exclude>
                 *:*log4j*,*:xml-apis,*:xercesImpl,*:commons-logging,*:commons-math3,*:commons-pool2,*:commons-dbcp2,
-                *:janino,org.apache.velocity:velocity
+                *:janino,org.apache.velocity:velocity,*:dnsjava
               </exclude>
               <transitive>true</transitive>
             </resolverFilter>
@@ -591,7 +551,7 @@
         <configuration>
           <instructions>
             <Bundle-SymbolicName>pentaho-hadoop-driver-V1</Bundle-SymbolicName>
-            <Bundle-Version>3.3.0.apachevanilla</Bundle-Version>
+            <Bundle-Version>3.4.0.apachevanilla</Bundle-Version>
             <Pentaho-Code-Version>${pentaho-code.version}</Pentaho-Code-Version>
             <DynamicImport-Package>*</DynamicImport-Package>
             <excludes>

--- a/shims/apachevanilla/driver/src/main/java/org/pentaho/hadoop/shim/HadoopShim.java
+++ b/shims/apachevanilla/driver/src/main/java/org/pentaho/hadoop/shim/HadoopShim.java
@@ -41,7 +41,6 @@ import org.apache.hadoop.hbase.zookeeper.ZKWatcher;
 import org.apache.hbase.thirdparty.com.google.common.collect.Lists;
 import org.apache.hbase.thirdparty.com.google.protobuf.UnsafeByteOperations;
 import org.apache.hbase.thirdparty.io.netty.channel.Channel;
-import org.apache.htrace.core.Tracer;
 import org.apache.zookeeper.ZooKeeper;
 import org.apache.hbase.thirdparty.com.google.common.cache.CacheLoader;
 import org.pentaho.di.core.exception.KettlePluginException;
@@ -68,8 +67,7 @@ public class HadoopShim extends HadoopShimImpl {
       HConstants.class, org.apache.hadoop.hbase.protobuf.generated.ClientProtos.class,
       org.apache.hadoop.hbase.shaded.protobuf.generated.ClientProtos.class, Put.class,
       RpcServer.class, CompatibilityFactory.class, JobUtil.class, TableMapper.class, FastLongHistogram.class,
-      Snapshot.class, ZooKeeper.class, Channel.class, Message.class, UnsafeByteOperations.class, Lists.class,
-      Tracer.class, MetricRegistry.class, ArrayUtils.class, ObjectMapper.class, Versioned.class,
+      Snapshot.class, ZooKeeper.class, Channel.class, Message.class, UnsafeByteOperations.class, Lists.class, MetricRegistry.class, ArrayUtils.class, ObjectMapper.class, Versioned.class,
       JsonView.class, ZKWatcher.class, CacheLoader.class
     };
   }

--- a/shims/apachevanilla/driver/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/shims/apachevanilla/driver/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -7,7 +7,7 @@
   <bean id="apachevanillaShimIdentifier" class="org.pentaho.hadoop.shim.api.internal.ShimIdentifier" scope="singleton">
     <argument value="apachevanilla"/>
     <argument value="ApacheVanilla"/>
-    <argument value="3.3.0"/>
+    <argument value="3.4.0"/>
     <argument value="COMMUNITY"/>
   </bean>
 


### PR DESCRIPTION
- **Upgraded Hadoop Services**
Hadoop Version: Upgraded Hadoop components to version 3.4.0, adhering to the Apache Vanilla standard.
Removed Knox Dependencies

- **Knox Support:** Eliminated Knox-related dependencies to align with the current Apache Vanilla configuration (no knox support yet) and prevent unnecessary imports.

- **Added HBase Libraries**
HBase Integration: Incorporated HBase libraries, supporting version 2.6.0, to enhance data storage and retrieval capabilities.