### PR TITLE
[PPP-4582] Use of Vulnerable Component: Components/oauth_client_library_for_java

### DIFF
--- a/shims/apache/driver/pom.xml
+++ b/shims/apache/driver/pom.xml
@@ -21,7 +21,7 @@
     <org.apache.avro.version>1.12.0</org.apache.avro.version>
     <hadoop-aws.version>3.3.0</hadoop-aws.version>
     <!-- client and default folders -->
-    <gcs-connector.version>hadoop2-1.9.17</gcs-connector.version>
+    <gcs.version>3.0.2</gcs.version>
     <!-- pmr folder -->
     <commons-configuration.version>1.6</commons-configuration.version>
     <commons-configuration2.version>2.10.1</commons-configuration2.version>
@@ -251,7 +251,12 @@
     <dependency>
       <groupId>com.google.cloud.bigdataoss</groupId>
       <artifactId>gcs-connector</artifactId>
-      <version>${gcs-connector.version}</version>
+      <version>${gcs.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>com.google.cloud.bigdataoss</groupId>
+      <artifactId>gcsio</artifactId>
+      <version>${gcs.version}</version>
     </dependency>
     <dependency>
       <groupId>org.apache.hadoop</groupId>

--- a/shims/apachevanilla/driver/pom.xml
+++ b/shims/apachevanilla/driver/pom.xml
@@ -32,7 +32,7 @@
     <jython.version>2.5.3</jython.version>
     <jetty.version>9.4.52.v20230823</jetty.version>
     <org.apache.knox.version>1.3.0.7.2.16.0-287</org.apache.knox.version>
-    <gcs-connector.version>hadoop2-1.9.17</gcs-connector.version>
+    <gcs-connector.version>3.0.2</gcs-connector.version>
     <commons-configuration2.version>2.10.1</commons-configuration2.version>
   </properties>
 
@@ -240,6 +240,10 @@
         <exclusion>
           <groupId>org.slf4j</groupId>
           <artifactId>slf4j-api</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>com.google.guava</groupId>
+          <artifactId>guava</artifactId>
         </exclusion>
       </exclusions>
     </dependency>

--- a/shims/cdpdc71/driver/pom.xml
+++ b/shims/cdpdc71/driver/pom.xml
@@ -32,7 +32,7 @@
     <jython.version>2.5.3</jython.version>
     <jetty.version>9.4.52.v20230823</jetty.version>
     <org.apache.knox.version>1.3.0.7.2.16.0-287</org.apache.knox.version>
-    <gcs-connector.version>hadoop2-1.9.17</gcs-connector.version>
+    <gcs-connector.version>3.0.2</gcs-connector.version>
     <commons-configuration2.version>2.10.1</commons-configuration2.version>
   </properties>
 
@@ -253,6 +253,10 @@
         <exclusion>
           <groupId>org.slf4j</groupId>
           <artifactId>slf4j-api</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>com.google.guava</groupId>
+          <artifactId>guava</artifactId>
         </exclusion>
       </exclusions>
     </dependency>

--- a/shims/dataproc1421/driver/pom.xml
+++ b/shims/dataproc1421/driver/pom.xml
@@ -16,6 +16,12 @@
       <groupId>com.google.cloud.bigdataoss</groupId>
       <artifactId>gcs-connector</artifactId>
       <version>${gcs-connector.version}</version>
+      <exclusions>
+        <exclusion>
+          <groupId>com.google.guava</groupId>
+          <artifactId>guava</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>com.google.guava</groupId>

--- a/shims/dataproc1421/pom.xml
+++ b/shims/dataproc1421/pom.xml
@@ -15,7 +15,7 @@
     <pentaho-code.version>11.0.0.0</pentaho-code.version>
 
     <!-- GCP properties -->
-    <gcs-connector.version>hadoop2-1.9.17</gcs-connector.version>
+    <gcs-connector.version>hadoop2-2.2.24</gcs-connector.version>
 
     <!-- default folder -->
     <org.apache.hbase.version>2.2.0</org.apache.hbase.version>


### PR DESCRIPTION
PR Set for https://hv-eng.atlassian.net/browse/PPP-4582:
- https://github.com/pentaho/pdi-plugins-ee/pull/1290
- https://github.com/pentaho/pentaho-platform/pull/5676
- https://github.com/pentaho/pentaho-hadoop-shims/pull/1452

Updated the gcs-connector versions to 3.0.2 where possible; it doesn't include gooogle-oauth-client at all.
- I had to add gcsio for apache driver so that it can be used in GcsConf for import com.google.cloud.hadoop.gcsio.GoogleCloudStorageFileSystem;

Dataproc1421 is stuck on Hadoop 2, so, we have to go with hadoop2-2.2.24 version, which has vulnerabilities pertaining to Hadoop 2.

All remaining instances of google oauth (including that from gcs-connector:jar:hadoop2-2.2.24 → google-oauth-client:jar:1.34.1) are now on 1.33.3+, whose indirect vulnerabilities pertain to guava, which is managed in its own dependency block.
- https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2023-2976
- https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2020-8908

I didn't see guava being pulled in on oauth anywhere, but I have excluded it in related, gateway-cloud-bindings dependencies to be sure that oauth doesn't pull it in and it is only ever intentionally added by us elsewhere.