### PR TITLE
[PPP-4582] [BACKLOG-42260] REVERT cdpdc71 and apachevanilla changes

### DIFF
--- a/shims/cdpdc71/driver/pom.xml
+++ b/shims/cdpdc71/driver/pom.xml
@@ -31,7 +31,7 @@
     <joda-time.version>2.10</joda-time.version>
     <jython.version>2.5.3</jython.version>
     <org.apache.knox.version>1.3.0.7.2.16.0-287</org.apache.knox.version>
-    <gcs-connector.version>3.0.2</gcs-connector.version>
+    <gcs-connector.version>hadoop2-1.9.17</gcs-connector.version>
     <commons-configuration2.version>2.10.1</commons-configuration2.version>
     <netty.version>4.1.108.Final</netty.version>
   </properties>
@@ -257,10 +257,6 @@
         <exclusion>
           <groupId>org.slf4j</groupId>
           <artifactId>slf4j-api</artifactId>
-        </exclusion>
-        <exclusion>
-          <groupId>com.google.guava</groupId>
-          <artifactId>guava</artifactId>
         </exclusion>
       </exclusions>
     </dependency>


### PR DESCRIPTION
gcs-connector and hadoop mismatch causes error

partial revert of a3903f9a2916e7c7348bea5be67100ab4a5aab30