### PR TITLE
[PPP-4582] [BACKLOG-42260] Use of Vulnerable Component: Components/oauth_client_library_for_java

### DIFF
--- a/shims/cdpdc71/driver/pom.xml
+++ b/shims/cdpdc71/driver/pom.xml
@@ -31,7 +31,7 @@
     <joda-time.version>2.10</joda-time.version>
     <jython.version>2.5.3</jython.version>
     <org.apache.knox.version>1.3.0.7.2.16.0-287</org.apache.knox.version>
-    <gcs-connector.version>3.0.2</gcs-connector.version>
+    <gcs-connector.version>hadoop3-2.2.25</gcs-connector.version>
     <commons-configuration2.version>2.10.1</commons-configuration2.version>
     <netty.version>4.1.108.Final</netty.version>
   </properties>


### PR DESCRIPTION
- Fix gcs-connector version mismatch for cdpdc71 case