### PR TITLE
[PPP-4582] [BACKLOG-42260] Use of Vulnerable Component: Components/oauth_client_library_for_java

### DIFF
--- a/shims/apachevanilla/driver/pom.xml
+++ b/shims/apachevanilla/driver/pom.xml
@@ -32,7 +32,7 @@
     <jython.version>2.5.3</jython.version>
     <jetty.version>9.4.52.v20230823</jetty.version>
     <org.apache.knox.version>1.3.0.7.2.16.0-287</org.apache.knox.version>
-    <gcs-connector.version>hadoop2-1.9.17</gcs-connector.version>
+    <gcs-connector.version>hadoop3-2.2.25</gcs-connector.version>
     <commons-configuration2.version>2.10.1</commons-configuration2.version>
   </properties>
 
@@ -240,6 +240,10 @@
         <exclusion>
           <groupId>org.slf4j</groupId>
           <artifactId>slf4j-api</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>com.google.guava</groupId>
+          <artifactId>guava</artifactId>
         </exclusion>
       </exclusions>
     </dependency>


### PR DESCRIPTION
**Addressing this issue:** https://hv-eng.atlassian.net/browse/BACKLOG-42260. 

- By Upgrading Hadoop to 3.4.0 we can utilise the 3.0.2 version of gcs-connector which is the latest.
- This hadoop upgrade is a comprehensive upgrade which is tagged to https://hv-eng.atlassian.net/browse/BACKLOG-41761.
- For now, we are just upgrading to safest possible version of gcs-connector that gives us the capability to run hadoop services smoothly.