### PR TITLE
[PPP-4582] [BACKLOG-42260] Use of Vulnerable Component: Components/oauth_client_library_for_java

### DIFF
--- a/shims/apachevanilla/driver/pom.xml
+++ b/shims/apachevanilla/driver/pom.xml
@@ -31,7 +31,7 @@
     <joda-time.version>2.10</joda-time.version>
     <jython.version>2.5.3</jython.version>
     <org.apache.knox.version>1.3.0.7.2.16.0-287</org.apache.knox.version>
-    <gcs-connector.version>3.0.2</gcs-connector.version>
+    <gcs-connector.version>hadoop3-2.2.25</gcs-connector.version>
     <commons-configuration2.version>2.10.1</commons-configuration2.version>
   </properties>
 


### PR DESCRIPTION
**Addressing this issue**: https://hv-eng.atlassian.net/browse/BACKLOG-42260

- By Upgrading Hadoop to 3.4.0 we can utilise the 3.0.2 version of gcs-connector which is the latest.

- This hadoop upgrade is a comprehensive upgrade which is tagged to https://hv-eng.atlassian.net/browse/BACKLOG-41761.

- For now, we are just upgrading to safest possible version of gcs-connector that gives us the capability to run hadoop services smoothly.