### PR TITLE
[BACKLOG-42279] Remove obsolete shim drivers for 10.2.0.1 build pipel…

### DIFF
--- a/shims/pom.xml
+++ b/shims/pom.xml
@@ -259,39 +259,12 @@
       </property>
     </activation>
     <modules>
-      <module>emr521</module>
-      <module>dataproc1421</module>
       <module>cdpdc71</module>
       <module>apache</module>
-      <module>hdi40</module>
       <module>apachevanilla</module>
       <module>emr700</module>
     </modules>
   </profile>
-
-  <profile>
-    <id>emr521</id>
-    <activation>
-      <property>
-        <name>!skipDefault</name>
-      </property>
-    </activation>
-    <modules>
-      <module>emr521</module>
-    </modules>
-  </profile>
-
-  <profile>
-    <id>dataproc1421</id>
-    <activation>
-      <property>
-        <name>!skipDefault</name>
-      </property>
-    </activation>
-    <modules>
-      <module>dataproc1421</module>
-    </modules>
-    </profile>
   <profile>
     <id>cdpdc71</id>
     <activation>
@@ -301,17 +274,6 @@
     </activation>
     <modules>
       <module>cdpdc71</module>
-    </modules>
-  </profile>
-  <profile>
-    <id>hdi40</id>
-    <activation>
-      <property>
-        <name>!skipDefault</name>
-      </property>
-    </activation>
-    <modules>
-      <module>hdi40</module>
     </modules>
   </profile>
   <profile>


### PR DESCRIPTION
…ine - emr521, dataproc1421, hdi40