### PR TITLE
[PPP-5035][BACKLOG-42242] Revert jetty-runner version

### DIFF
--- a/shims/apache/driver/pom.xml
+++ b/shims/apache/driver/pom.xml
@@ -31,6 +31,7 @@
     <joda-time.version>2.9.9</joda-time.version>
     <zookeeper.version>3.9.2</zookeeper.version>
     <netty.version>4.1.108.Final</netty.version>
+    <jetty-runner.version>9.3.20.v20170531</jetty-runner.version>
   </properties>
 
   <dependencies>
@@ -75,7 +76,7 @@
     <dependency>
       <groupId>org.eclipse.jetty</groupId>
       <artifactId>jetty-rewrite</artifactId>
-      <version>${jetty.version}</version>
+      <version>${jetty-runner.version}</version>
       <scope>runtime</scope>
     </dependency>
     <dependency>

--- a/shims/apachevanilla/driver/pom.xml
+++ b/shims/apachevanilla/driver/pom.xml
@@ -34,6 +34,7 @@
     <gcs-connector.version>hadoop3-2.2.25</gcs-connector.version>
     <commons-configuration2.version>2.10.1</commons-configuration2.version>
     <netty.version>4.1.108.Final</netty.version>
+    <jetty-runner.version>9.3.20.v20170531</jetty-runner.version>
   </properties>
 
   <dependencyManagement>
@@ -90,7 +91,7 @@
       <dependency>
         <groupId>org.eclipse.jetty</groupId>
         <artifactId>jetty-runner</artifactId>
-        <version>${jetty.version}</version>
+        <version>${jetty-runner.version}</version>
         <scope>runtime</scope>
       </dependency>
       <dependency>

--- a/shims/cdpdc71/driver/pom.xml
+++ b/shims/cdpdc71/driver/pom.xml
@@ -34,6 +34,7 @@
     <gcs-connector.version>hadoop3-2.2.25</gcs-connector.version>
     <commons-configuration2.version>2.10.1</commons-configuration2.version>
     <netty.version>4.1.108.Final</netty.version>
+    <jetty-runner.version>9.3.20.v20170531</jetty-runner.version>
   </properties>
 
   <dependencyManagement>
@@ -90,7 +91,7 @@
       <dependency>
         <groupId>org.eclipse.jetty</groupId>
         <artifactId>jetty-runner</artifactId>
-        <version>${jetty.version}</version>
+        <version>${jetty-runner.version}</version>
         <scope>runtime</scope>
       </dependency>
       <dependency>

--- a/shims/emr700/driver/pom.xml
+++ b/shims/emr700/driver/pom.xml
@@ -27,6 +27,7 @@
     <jython.version>2.5.3</jython.version>
     <automaton.version>1.11-8</automaton.version>
     <netty.version>4.1.108.Final</netty.version>
+    <jetty-runner.version>9.3.20.v20170531</jetty-runner.version>
   </properties>
   <dependencies>
     <dependency>
@@ -562,7 +563,7 @@
     <dependency>
       <groupId>org.eclipse.jetty</groupId>
       <artifactId>jetty-runner</artifactId>
-      <version>${jetty.version}</version>
+      <version>${jetty-runner.version}</version>
     </dependency>
     <dependency>
       <groupId>org.eclipse.jetty</groupId>


### PR DESCRIPTION
The newer jetty-runner version includes some slf4j stuff that causes excessive debug logs when using parquet files. This reverts to an older version that shouldn't be vulnerable (at least according to maven central)