### PR TITLE
[PPP-5035] fix incorrect jetty artifact version

### DIFF
--- a/shims/apache/driver/pom.xml
+++ b/shims/apache/driver/pom.xml
@@ -76,13 +76,13 @@
     <dependency>
       <groupId>org.eclipse.jetty</groupId>
       <artifactId>jetty-rewrite</artifactId>
-      <version>${jetty-runner.version}</version>
+      <version>${jetty.version}</version>
       <scope>runtime</scope>
     </dependency>
     <dependency>
       <groupId>org.eclipse.jetty</groupId>
       <artifactId>jetty-runner</artifactId>
-      <version>${jetty.version}</version>
+      <version>${jetty-runner.version}</version>
       <scope>runtime</scope>
     </dependency>
     <dependency>


### PR DESCRIPTION
Accidentally changed the version on `jetty-rewrite` instead of `jetty-runner` for the apache driver. Fix for that.