### PR TITLE
[SP-6610] Backport of PPP-5166 - Use of Vulnerable Component: Components/jackson-databind 2.14.2 (Non OSGi upgrade)

### DIFF
--- a/common-dependencies-V1/pom.xml
+++ b/common-dependencies-V1/pom.xml
@@ -150,7 +150,7 @@
                 *:hbase-server,*:protobuf-java
               </include>
               <exclude>
-                *:*log4j*,*:xml-apis,*:xercesImpl,*:hadoop*,*:hbase*,*:zookeeper*
+                *:*log4j*,*:xml-apis,*:xercesImpl,*:hadoop*,*:hbase*,*:zookeeper*,com.fasterxml.jackson.core:jackson-databind
               </exclude>
               <transitive>true</transitive>
             </resolverFilter>

--- a/common-fragment-V1/pom.xml
+++ b/common-fragment-V1/pom.xml
@@ -246,6 +246,9 @@
         <version>${shim-bundle-plugin.version}</version>
         <configuration>
           <resolverFilters>
+            <resolverFilter>
+              <exclude>com.fasterxml.jackson.core:jackson-databind</exclude>
+            </resolverFilter>
           </resolverFilters>
         </configuration>
         <executions>

--- a/shims/apache/driver/pom.xml
+++ b/shims/apache/driver/pom.xml
@@ -193,8 +193,6 @@
           <groupId>com.fasterxml.jackson.core</groupId>
           <artifactId>jackson-databind</artifactId>
         </exclusion>
-      </exclusions>
-      <exclusions>
         <exclusion>
           <groupId>io.netty</groupId>
           <artifactId>netty-all</artifactId>
@@ -418,7 +416,6 @@
                 *:jersey*:jar:2.25.1,
                 *:*log4j*,*:xml-apis,*:xercesImpl,*:tests:*,
                 <!--Needed for hive-->
-                org.apache.hadoop:hadoop-yarn-registry
                 org.apache.hadoop:hadoop-yarn-registry,org.apache.velocity:velocity,
                 com.fasterxml.jackson.core:jackson-databind
               </exclude>

--- a/shims/apache/driver/pom.xml
+++ b/shims/apache/driver/pom.xml
@@ -132,6 +132,10 @@
           <groupId>io.netty</groupId>
           <artifactId>netty-all</artifactId>
         </exclusion>
+        <exclusion>
+          <groupId>com.fasterxml.jackson.core</groupId>
+          <artifactId>jackson-databind</artifactId>
+        </exclusion>
       </exclusions>
     </dependency>
     <dependency>
@@ -186,6 +190,12 @@
       <version>${org.apache.hadoop.version}</version>
       <exclusions>
         <exclusion>
+          <groupId>com.fasterxml.jackson.core</groupId>
+          <artifactId>jackson-databind</artifactId>
+        </exclusion>
+      </exclusions>
+      <exclusions>
+        <exclusion>
           <groupId>io.netty</groupId>
           <artifactId>netty-all</artifactId>
         </exclusion>
@@ -229,6 +239,10 @@
         <exclusion>
           <groupId>io.netty</groupId>
           <artifactId>netty-transport-native-epoll</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>com.fasterxml.jackson.core</groupId>
+          <artifactId>jackson-databind</artifactId>
         </exclusion>
       </exclusions>
     </dependency>
@@ -405,6 +419,8 @@
                 *:*log4j*,*:xml-apis,*:xercesImpl,*:tests:*,
                 <!--Needed for hive-->
                 org.apache.hadoop:hadoop-yarn-registry
+                org.apache.hadoop:hadoop-yarn-registry,org.apache.velocity:velocity,
+                com.fasterxml.jackson.core:jackson-databind
               </exclude>
               <transitive>true</transitive>
             </resolverFilter>

--- a/shims/apache/kar/pom.xml
+++ b/shims/apache/kar/pom.xml
@@ -18,16 +18,34 @@
       <groupId>org.pentaho.hadoop.shims</groupId>
       <artifactId>pentaho-hadoop-shims-common-dependencies-V1</artifactId>
       <version>${project.version}</version>
+      <exclusions>
+        <exclusion>
+          <groupId>com.fasterxml.jackson.core</groupId>
+          <artifactId>jackson-databind</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>org.pentaho.hadoop.shims</groupId>
       <artifactId>pentaho-hadoop-shims-common-fragment-V1</artifactId>
       <version>${project.version}</version>
+      <exclusions>
+        <exclusion>
+          <groupId>com.fasterxml.jackson.core</groupId>
+          <artifactId>jackson-databind</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>org.pentaho.hadoop.shims</groupId>
       <artifactId>pentaho-hadoop-shims-apache-driver</artifactId>
       <version>${project.version}</version>
+      <exclusions>
+        <exclusion>
+          <groupId>com.fasterxml.jackson.core</groupId>
+          <artifactId>jackson-databind</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
   </dependencies>
 


### PR DESCRIPTION
This PR replaces [pentaho-hadoop-shims#1483](https://github.com/pentaho/pentaho-hadoop-shims/pull/1483) as I couldn't update it directly.
The extra commit solves:
- the existence of two 'exclusions' groups on a dependency tab group
- the repetition of an 'exclusion' on a resolverFilter tab group

@rmansoor @pentaho/tatooine_dev 