### PR TITLE
[SP-6610] [PPP-5281][PPP-5166][BACKLOG-42289] Backport of PPP-5166 - Use of Vulnerable Component: Components/jackson-databind 2.14.2 (Non OSGi upgrade)

### DIFF
--- a/common-fragment-V1/pom.xml
+++ b/common-fragment-V1/pom.xml
@@ -246,9 +246,6 @@
         <version>${shim-bundle-plugin.version}</version>
         <configuration>
           <resolverFilters>
-            <resolverFilter>
-              <exclude>com.fasterxml.jackson.core:jackson-databind</exclude>
-            </resolverFilter>
           </resolverFilters>
         </configuration>
         <executions>


### PR DESCRIPTION
Another ticket raised to fix bug https://hv-eng.atlassian.net/browse/PPP-5281 which was cause due to https://hv-eng.atlassian.net/browse/PPP-5166