### PR TITLE
[BACKLOG-42957] - [Bigdata] PMR Job is failing with ApacheVanilla Shim

### DIFF
--- a/shims/apachevanilla/driver/pom.xml
+++ b/shims/apachevanilla/driver/pom.xml
@@ -916,7 +916,7 @@
                 *:hadoop-yarn-api,*:hbase-client,*:hbase-common,*:hbase-hadoop-compat,*:hbase-protocol,
                 *:hbase-server,*:oozie-client,*:parquet-hadoop-bundle,*:zookeeper,*:hbase-shaded-miscellaneous,
                 org.eclipse.jetty:*,com.google.guava:*,*:hadoop-lzo,*:hadoop-client,*:hadoop-aws,*:hadoop-azure,*:gcs-connector,*:hadoop-hdfs-client,*:commons-configuration2,
-                *:google-oauth-client,*:hbase-mapreduce
+                *:google-oauth-client,*:hbase-mapreduce,*:commons-codec
               </include>
               <exclude>
                 *:*log4j*,*:xml-apis,*:xercesImpl,*:commons-logging,*:commons-math3,*:commons-pool2,*:commons-dbcp2,


### PR DESCRIPTION
Added the missing library which failing to read input data in hdfs input step

**Error details:**
DestHost:destPort hadoopavs.orl.eng.hitachivantara.com:9000 , LocalHost:localPort hadoopavs/10.177.176.195:0. Failed on local exception: java.io.IOException: Couldn't set up IO streams: java.lang.NoClassDefFoundError: org/apache/commons/codec/binary/Base64