### PR TITLE
[SP-6694] Remove extra jetty version in cdpdc71 driver

### DIFF
--- a/shims/cdpdc71/driver/pom.xml
+++ b/shims/cdpdc71/driver/pom.xml
@@ -30,7 +30,6 @@
     <pentaho-code.version>11.0.0.0</pentaho-code.version>
     <joda-time.version>2.10</joda-time.version>
     <jython.version>2.5.3</jython.version>
-    <jetty.version>9.3.20.v20170531</jetty.version>
     <org.apache.knox.version>1.3.0.7.2.16.0-287</org.apache.knox.version>
     <gcs-connector.version>hadoop2-1.9.17</gcs-connector.version>
     <google-oauth.version>1.33.3</google-oauth.version>


### PR DESCRIPTION
remove extra jetty version, go back to using the version from the parent poms. It was already this way on master, I think this was because of some backport/branching weirdness around 10.2.0.1 and master