### PR TITLE
[PPP-5540] Vulnerable Component: jackson-databind within parquet-hado…

### DIFF
--- a/shims/apachevanilla/driver/pom.xml
+++ b/shims/apachevanilla/driver/pom.xml
@@ -18,13 +18,15 @@
     <pentaho-osgi-bundles.version>10.3.0.0-SNAPSHOT</pentaho-osgi-bundles.version>
     <org.apache.avro.version>1.12.0</org.apache.avro.version>
     <org.apache.orc.version>1.5.1.7.2.17.0-334</org.apache.orc.version>
-    <parquet.version>1.11.1</parquet.version>
+    <!-- settting v1.14.4 so shaded jackson-databind inside parquet-hadoop-bundle's  version approximately matches jackson-databind in driver.jar -->
+    <parquet.version>1.14.4</parquet.version>
     <org.apache.hadoop.version>3.4.0</org.apache.hadoop.version>
     <org.apache.hbase.version>2.6.0</org.apache.hbase.version>
     <org.apache.hive.version>3.1.3000.7.1.4.0-203</org.apache.hive.version>
     <org.apache.oozie.version>5.2.1</org.apache.oozie.version>
     <pig.version>0.17.0</pig.version>
-    <parquet-pig.version>1.11.1</parquet-pig.version>
+    <!-- parquet v1.14.4 is build on pig v0.16.0 -->
+    <parquet-pig.version>${parquet.version}</parquet-pig.version>
     <sqoop.version>1.4.7</sqoop.version>
     <vendor-driver.version>3.4.0</vendor-driver.version>
     <pentaho-code.version>11.0.0.0</pentaho-code.version>

--- a/shims/cdpdc71/driver/pom.xml
+++ b/shims/cdpdc71/driver/pom.xml
@@ -18,13 +18,15 @@
     <pentaho-osgi-bundles.version>10.3.0.0-SNAPSHOT</pentaho-osgi-bundles.version>
     <org.apache.avro.version>1.8.2.7.1.4.0-203</org.apache.avro.version>
     <org.apache.orc.version>1.5.1.7.1.4.0-203</org.apache.orc.version>
-    <parquet.version>1.10.99.7.1.4.0-203</parquet.version>
+    <!-- settting v1.14.4 so shaded jackson-databind inside parquet-hadoop-bundle's  version approximately matches jackson-databind in driver.jar -->
+    <parquet.version>1.14.4</parquet.version>
     <org.apache.hadoop.version>3.1.1.7.1.9.0-387</org.apache.hadoop.version>
     <org.apache.hbase.version>2.4.17.7.1.9.0-387</org.apache.hbase.version>
     <org.apache.hive.version>3.1.3000.7.1.9.0-387</org.apache.hive.version>
     <org.apache.oozie.version>5.1.0.7.1.4.0-203</org.apache.oozie.version>
     <pig.version>0.16.0.7.1.4.0-203</pig.version>
-    <parquet-pig.version>1.10.99.7.1.4.0-203</parquet-pig.version>
+    <!-- parquet v1.14.4 is build on pig v0.16.0 -->
+    <parquet-pig.version>${parquet.version}</parquet-pig.version>
     <sqoop.version>1.4.7.7.1.4.0-203</sqoop.version>
     <vendor-driver.version>7.1.4.0-203</vendor-driver.version>
     <pentaho-code.version>11.0.0.0</pentaho-code.version>

--- a/shims/dataproc1421/driver/pom.xml
+++ b/shims/dataproc1421/driver/pom.xml
@@ -13,6 +13,8 @@
 
   <properties>
     <netty.version>4.1.108.Final</netty.version>
+    <!-- settting v1.14.4 so shaded jackson-databind inside parquet-hadoop-bundle's  version approximately matches jackson-databind in driver.jar -->
+    <parquet.version>1.14.4</parquet.version>
   </properties>
 
 

--- a/shims/emr700/driver/pom.xml
+++ b/shims/emr700/driver/pom.xml
@@ -17,6 +17,8 @@
     <org.apache.hive.version>3.1.3</org.apache.hive.version>
     <org.apache.oozie.version>5.2.1</org.apache.oozie.version>
     <org.apache.hbase.version>2.6.1</org.apache.hbase.version>
+    <!-- settting v1.14.4 so shaded jackson-databind inside parquet-hadoop-bundle's  version approximately matches jackson-databind in driver.jar -->
+    <parquet.version>1.14.4</parquet.version>
     <org.apache.hadoop.version>3.3.6</org.apache.hadoop.version>
     <org.apache.orc.version>1.6.1</org.apache.orc.version>
     <sqoop.version>1.4.7</sqoop.version>

--- a/shims/hdi40/driver/pom.xml
+++ b/shims/hdi40/driver/pom.xml
@@ -17,13 +17,15 @@
     <pentaho-osgi-bundles.version>10.3.0.0-SNAPSHOT</pentaho-osgi-bundles.version>
     <org.apache.avro.version>1.12.0</org.apache.avro.version>
     <org.apache.orc.version>1.5.1.7.1.4.0-203</org.apache.orc.version>
-    <parquet.version>1.10.99.7.1.4.0-203</parquet.version>
+    <!-- settting v1.14.4 so shaded jackson-databind inside parquet-hadoop-bundle's  version approximately matches jackson-databind in driver.jar -->
+    <parquet.version>1.14.4</parquet.version>
     <org.apache.hadoop.version>3.1.1.7.1.9.0-387</org.apache.hadoop.version>
     <org.apache.hbase.version>2.4.17.7.1.9.0-387</org.apache.hbase.version>
     <org.apache.hive.version>3.1.3000.7.1.9.0-387</org.apache.hive.version>
     <org.apache.oozie.version>5.1.0.7.1.4.0-203</org.apache.oozie.version>
     <pig.version>0.16.0.7.1.4.0-203</pig.version>
-    <parquet-pig.version>1.10.99.7.1.4.0-203</parquet-pig.version>
+    <!-- parquet v1.14.4 is build on pig v0.16.0 -->
+    <parquet-pig.version>${parquet.version}</parquet-pig.version>
     <sqoop.version>1.4.7.7.1.4.0-203</sqoop.version>
     <vendor-driver.version>7.1.4.0-203</vendor-driver.version>
     <pentaho-code.version>11.0.0.0</pentaho-code.version>


### PR DESCRIPTION
…op-bundle-1.11.1.jar

- update cdpdc71 to v1.14.4
- update apachevanilla to v1.14.4
- update emr700 to v1.14.4
- update hdi40 to v1.14.4
- update dataproc1421 to v1.14.4

parquet-hadoop-bundle has a shaded jackson jar, this newer version still has a shadded jackson jar but the shaded version currently does not have any vulnerablities.

see comment : https://hv-eng.atlassian.net/browse/PPP-5540?focusedCommentId=2135048