### PR TITLE
[SP-6768] Backport of PPP-5540 - Vulnerable Component: jackson-databi…

### DIFF
--- a/shims/apache/driver/pom.xml
+++ b/shims/apache/driver/pom.xml
@@ -30,7 +30,7 @@
     <org.apache.hadoop.version>3.4.0</org.apache.hadoop.version>
     <hadoop-azure.version>3.4.0</hadoop-azure.version>
     <org.apache.orc.version>1.6.1</org.apache.orc.version>
-    <parquet.version>1.11.1</parquet.version>
+    <parquet.version>1.14.4</parquet.version>
     <joda-time.version>2.9.9</joda-time.version>
     <jetty-runner.version>9.3.20.v20170531</jetty-runner.version>
     <zookeeper.version>3.9.2</zookeeper.version>


### PR DESCRIPTION
…nd within parquet-hadoop-bundle-1.11.1.jar (10.2 Suite)

PPP-5540 PPP-5622 [Bigdata] Vulnerable component parquet-hadoop-bundle-1.11.1.jar still present in latest build.
- updating apache driver to v1.14.4