### PR TITLE
[BACKLOG-40823] - Upgrade the Tomcat version from current to 10.x.x with Java 17 

### DIFF
--- a/common-fragment-V1/pom.xml
+++ b/common-fragment-V1/pom.xml
@@ -448,6 +448,12 @@
       <classifier>tests</classifier>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>jakarta.servlet</groupId>
+      <artifactId>jakarta.servlet-api</artifactId>
+      <version>${jakarta.servlet.version}</version>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
   <build>
     <plugins>

--- a/pom.xml
+++ b/pom.xml
@@ -47,7 +47,6 @@
     <shim-bundle-plugin.version>1.1</shim-bundle-plugin.version>
     <zookeeper.version>3.9.3</zookeeper.version>
     <org.apache.hbase.thirdparty.version>2.1.0</org.apache.hbase.thirdparty.version>
-    <jetty-hadoop.version>9.4.54.v20240208</jetty-hadoop.version>
     <snakeyaml.version>2.2</snakeyaml.version>
     <dnsjava.version>3.6.0</dnsjava.version>
   </properties>

--- a/pom.xml
+++ b/pom.xml
@@ -47,6 +47,7 @@
     <shim-bundle-plugin.version>1.1</shim-bundle-plugin.version>
     <zookeeper.version>3.9.3</zookeeper.version>
     <org.apache.hbase.thirdparty.version>2.1.0</org.apache.hbase.thirdparty.version>
+    <jetty-hadoop.version>9.4.54.v20240208</jetty-hadoop.version>
     <snakeyaml.version>2.2</snakeyaml.version>
     <dnsjava.version>3.6.0</dnsjava.version>
   </properties>

--- a/shims/apache/driver/pom.xml
+++ b/shims/apache/driver/pom.xml
@@ -39,25 +39,25 @@
     <dependency>
       <groupId>org.eclipse.jetty</groupId>
       <artifactId>jetty-annotations</artifactId>
-      <version>${jetty.version}</version>
+      <version>${jetty-hadoop.version}</version>
       <scope>runtime</scope>
     </dependency>
     <dependency>
       <groupId>org.eclipse.jetty</groupId>
       <artifactId>jetty-server</artifactId>
-      <version>${jetty.version}</version>
+      <version>${jetty-hadoop.version}</version>
       <scope>runtime</scope>
     </dependency>
     <dependency>
       <groupId>org.eclipse.jetty</groupId>
       <artifactId>jetty-client</artifactId>
-      <version>${jetty.version}</version>
+      <version>${jetty-hadoop.version}</version>
       <scope>runtime</scope>
     </dependency>
     <dependency>
       <groupId>org.eclipse.jetty</groupId>
       <artifactId>jetty-jaas</artifactId>
-      <version>${jetty.version}</version>
+      <version>${jetty-hadoop.version}</version>
       <scope>runtime</scope>
       <exclusions>
         <exclusion>
@@ -69,19 +69,19 @@
     <dependency>
       <groupId>org.eclipse.jetty</groupId>
       <artifactId>jetty-jndi</artifactId>
-      <version>${jetty.version}</version>
+      <version>${jetty-hadoop.version}</version>
       <scope>runtime</scope>
     </dependency>
     <dependency>
       <groupId>org.eclipse.jetty</groupId>
       <artifactId>jetty-plus</artifactId>
-      <version>${jetty.version}</version>
+      <version>${jetty-hadoop.version}</version>
       <scope>runtime</scope>
     </dependency>
     <dependency>
       <groupId>org.eclipse.jetty</groupId>
       <artifactId>jetty-rewrite</artifactId>
-      <version>${jetty.version}</version>
+      <version>${jetty-hadoop.version}</version>
       <scope>runtime</scope>
     </dependency>
     <dependency>
@@ -93,22 +93,22 @@
     <dependency>
       <groupId>org.eclipse.jetty</groupId>
       <artifactId>jetty-security</artifactId>
-      <version>${jetty.version}</version>
+      <version>${jetty-hadoop.version}</version>
     </dependency>
     <dependency>
       <groupId>org.eclipse.jetty</groupId>
       <artifactId>jetty-servlet</artifactId>
-      <version>${jetty.version}</version>
+      <version>${jetty-hadoop.version}</version>
     </dependency>
     <dependency>
       <groupId>org.eclipse.jetty</groupId>
       <artifactId>jetty-webapp</artifactId>
-      <version>${jetty.version}</version>
+      <version>${jetty-hadoop.version}</version>
     </dependency>
     <dependency>
       <groupId>org.eclipse.jetty</groupId>
       <artifactId>jetty-xml</artifactId>
-      <version>${jetty.version}</version>
+      <version>${jetty-hadoop.version}</version>
     </dependency>
     <dependency>
       <groupId>org.eclipse.jetty.websocket</groupId>

--- a/shims/apache/driver/pom.xml
+++ b/shims/apache/driver/pom.xml
@@ -87,7 +87,7 @@
     <dependency>
       <groupId>org.eclipse.jetty</groupId>
       <artifactId>jetty-runner</artifactId>
-      <version>${jetty.version}</version>
+      <version>${jetty-hadoop.version}</version>
       <scope>runtime</scope>
     </dependency>
     <dependency>
@@ -113,7 +113,7 @@
     <dependency>
       <groupId>org.eclipse.jetty.websocket</groupId>
       <artifactId>javax-websocket-server-impl</artifactId>
-      <version>${jetty.version}</version>
+      <version>${jetty-hadoop.version}</version>
     </dependency>
 
     <dependency>
@@ -595,7 +595,7 @@
                 <artifactItem>
                   <groupId>org.eclipse.jetty</groupId>
                   <artifactId>jetty-runner</artifactId>
-                  <version>${jetty.version}</version>
+                  <version>${jetty-hadoop.version}</version>
                   <type>jar</type>
                   <overWrite>true</overWrite>
                   <outputDirectory>${project.build.directory}/jetty-runner-jar</outputDirectory>
@@ -619,7 +619,7 @@
             </goals>
             <configuration>
               <target>
-                <zip destfile="${project.build.directory}/extra-resources/jetty-runner-${jetty.version}.jar"
+                <zip destfile="${project.build.directory}/extra-resources/jetty-runner-${jetty-hadoop.version}.jar"
                       basedir="${project.build.directory}/jetty-runner-jar">
                   <exclude name="org/slf4j/**"/>
                 </zip>
@@ -704,7 +704,7 @@
             <_exportcontents>
             </_exportcontents>
             <Embed-Dependency>*</Embed-Dependency>
-            <Include-Resource>{maven-resources};${project.build.directory}/extra-resources/jetty-runner-${jetty.version}.jar</Include-Resource>
+            <Include-Resource>{maven-resources};${project.build.directory}/extra-resources/jetty-runner-${jetty-hadoop.version}.jar</Include-Resource>
             <Bundle-ClassPath>.,{maven-dependencies}</Bundle-ClassPath>
             <!-- this is needed because the bundle plugin gets fooled by multi-release jars into thinking the required java
             version is the highest one in the package, which is not the case -->

--- a/shims/apachevanilla/driver/pom.xml
+++ b/shims/apachevanilla/driver/pom.xml
@@ -49,31 +49,31 @@
       <dependency>
         <groupId>org.eclipse.jetty</groupId>
         <artifactId>jetty-annotations</artifactId>
-        <version>${jetty.version}</version>
+        <version>${jetty-hadoop.version}</version>
         <scope>runtime</scope>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty</groupId>
         <artifactId>jetty-client</artifactId>
-        <version>${jetty.version}</version>
+        <version>${jetty-hadoop.version}</version>
         <scope>runtime</scope>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty</groupId>
         <artifactId>jetty-http</artifactId>
-        <version>${jetty.version}</version>
+        <version>${jetty-hadoop.version}</version>
         <scope>runtime</scope>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty</groupId>
         <artifactId>jetty-io</artifactId>
-        <version>${jetty.version}</version>
+        <version>${jetty-hadoop.version}</version>
         <scope>runtime</scope>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty</groupId>
         <artifactId>jetty-jaas</artifactId>
-        <version>${jetty.version}</version>
+        <version>${jetty-hadoop.version}</version>
         <scope>runtime</scope>
         <exclusions>
           <exclusion>
@@ -85,19 +85,19 @@
       <dependency>
         <groupId>org.eclipse.jetty</groupId>
         <artifactId>jetty-jndi</artifactId>
-        <version>${jetty.version}</version>
+        <version>${jetty-hadoop.version}</version>
         <scope>runtime</scope>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty</groupId>
         <artifactId>jetty-plus</artifactId>
-        <version>${jetty.version}</version>
+        <version>${jetty-hadoop.version}</version>
         <scope>runtime</scope>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty</groupId>
         <artifactId>jetty-rewrite</artifactId>
-        <version>${jetty.version}</version>
+        <version>${jetty-hadoop.version}</version>
         <scope>runtime</scope>
       </dependency>
       <dependency>
@@ -109,43 +109,43 @@
       <dependency>
         <groupId>org.eclipse.jetty</groupId>
         <artifactId>jetty-security</artifactId>
-        <version>${jetty.version}</version>
+        <version>${jetty-hadoop.version}</version>
         <scope>runtime</scope>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty</groupId>
         <artifactId>jetty-server</artifactId>
-        <version>${jetty.version}</version>
+        <version>${jetty-hadoop.version}</version>
         <scope>runtime</scope>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty</groupId>
         <artifactId>jetty-servlet</artifactId>
-        <version>${jetty.version}</version>
+        <version>${jetty-hadoop.version}</version>
         <scope>runtime</scope>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty</groupId>
         <artifactId>jetty-util</artifactId>
-        <version>${jetty.version}</version>
+        <version>${jetty-hadoop.version}</version>
         <scope>runtime</scope>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty</groupId>
         <artifactId>jetty-util-ajax</artifactId>
-        <version>${jetty.version}</version>
+        <version>${jetty-hadoop.version}</version>
         <scope>runtime</scope>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty</groupId>
         <artifactId>jetty-webapp</artifactId>
-        <version>${jetty.version}</version>
+        <version>${jetty-hadoop.version}</version>
         <scope>runtime</scope>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty</groupId>
         <artifactId>jetty-xml</artifactId>
-        <version>${jetty.version}</version>
+        <version>${jetty-hadoop.version}</version>
         <scope>runtime</scope>
       </dependency>
       <dependency>

--- a/shims/apachevanilla/driver/pom.xml
+++ b/shims/apachevanilla/driver/pom.xml
@@ -103,7 +103,7 @@
       <dependency>
         <groupId>org.eclipse.jetty</groupId>
         <artifactId>jetty-runner</artifactId>
-        <version>${jetty.version}</version>
+        <version>${jetty-hadoop.version}</version>
         <scope>runtime</scope>
       </dependency>
       <dependency>
@@ -151,12 +151,12 @@
       <dependency>
         <groupId>org.eclipse.jetty.websocket</groupId>
         <artifactId>websocket-client</artifactId>
-        <version>${jetty.version}</version>
+        <version>${jetty-hadoop.version}</version>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty.websocket</groupId>
         <artifactId>javax-websocket-server-impl</artifactId>
-        <version>${jetty.version}</version>
+        <version>${jetty-hadoop.version}</version>
       </dependency>
     </dependencies>
   </dependencyManagement>
@@ -1088,7 +1088,7 @@
                 <artifactItem>
                   <groupId>org.eclipse.jetty</groupId>
                   <artifactId>jetty-runner</artifactId>
-                  <version>${jetty.version}</version>
+                  <version>${jetty-hadoop.version}</version>
                   <type>jar</type>
                   <overWrite>true</overWrite>
                   <outputDirectory>${project.build.directory}/jetty-runner-jar</outputDirectory>
@@ -1112,7 +1112,7 @@
             </goals>
             <configuration>
               <target>
-                <zip destfile="${project.build.directory}/extra-resources/jetty-runner-${jetty.version}.jar"
+                <zip destfile="${project.build.directory}/extra-resources/jetty-runner-${jetty-hadoop.version}.jar"
                       basedir="${project.build.directory}/jetty-runner-jar">
                   <exclude name="org/slf4j/**"/>
                 </zip>
@@ -1185,7 +1185,7 @@
             <_exportcontents>
             </_exportcontents>
             <Embed-Dependency>*</Embed-Dependency>
-            <Include-Resource>{maven-resources};${project.build.directory}/extra-resources/jetty-runner-${jetty.version}.jar</Include-Resource>
+            <Include-Resource>{maven-resources};${project.build.directory}/extra-resources/jetty-runner-${jetty-hadoop.version}.jar</Include-Resource>
             <Bundle-ClassPath>.,{maven-dependencies}</Bundle-ClassPath>
             <!-- this is needed because the bundle plugin gets fooled by multi-release jars into thinking the required java
             version is the highest one in the package, which is not the case -->

--- a/shims/cdh61/driver/pom.xml
+++ b/shims/cdh61/driver/pom.xml
@@ -36,61 +36,61 @@
       <dependency>
         <groupId>org.eclipse.jetty</groupId>
         <artifactId>jetty-annotations</artifactId>
-        <version>${jetty.version}</version>
+        <version>${jetty-hadoop.version}</version>
         <scope>runtime</scope>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty</groupId>
         <artifactId>jetty-client</artifactId>
-        <version>${jetty.version}</version>
+        <version>${jetty-hadoop.version}</version>
         <scope>runtime</scope>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty</groupId>
         <artifactId>jetty-http</artifactId>
-        <version>${jetty.version}</version>
+        <version>${jetty-hadoop.version}</version>
         <scope>runtime</scope>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty</groupId>
         <artifactId>jetty-io</artifactId>
-        <version>${jetty.version}</version>
+        <version>${jetty-hadoop.version}</version>
         <scope>runtime</scope>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty</groupId>
         <artifactId>jetty-jaas</artifactId>
-        <version>${jetty.version}</version>
+        <version>${jetty-hadoop.version}</version>
         <scope>runtime</scope>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty</groupId>
         <artifactId>jetty-jndi</artifactId>
-        <version>${jetty.version}</version>
+        <version>${jetty-hadoop.version}</version>
         <scope>runtime</scope>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty</groupId>
         <artifactId>jetty-plus</artifactId>
-        <version>${jetty.version}</version>
+        <version>${jetty-hadoop.version}</version>
         <scope>runtime</scope>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty</groupId>
         <artifactId>jetty-rewrite</artifactId>
-        <version>${jetty.version}</version>
+        <version>${jetty-hadoop.version}</version>
         <scope>runtime</scope>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty</groupId>
         <artifactId>jetty-runner</artifactId>
-        <version>${jetty.version}</version>
+        <version>${jetty-hadoop.version}</version>
         <scope>runtime</scope>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty</groupId>
         <artifactId>jetty-security</artifactId>
-        <version>${jetty.version}</version>
+        <version>${jetty-hadoop.version}</version>
         <scope>runtime</scope>
       </dependency>
       <dependency>
@@ -102,31 +102,31 @@
       <dependency>
         <groupId>org.eclipse.jetty</groupId>
         <artifactId>jetty-servlet</artifactId>
-        <version>${jetty.version}</version>
+        <version>${jetty-hadoop.version}</version>
         <scope>runtime</scope>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty</groupId>
         <artifactId>jetty-util</artifactId>
-        <version>${jetty.version}</version>
+        <version>${jetty-hadoop.version}</version>
         <scope>runtime</scope>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty</groupId>
         <artifactId>jetty-util-ajax</artifactId>
-        <version>${jetty.version}</version>
+        <version>${jetty-hadoop.version}</version>
         <scope>runtime</scope>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty</groupId>
         <artifactId>jetty-webapp</artifactId>
-        <version>${jetty.version}</version>
+        <version>${jetty-hadoop.version}</version>
         <scope>runtime</scope>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty</groupId>
         <artifactId>jetty-xml</artifactId>
-        <version>${jetty.version}</version>
+        <version>${jetty-hadoop.version}</version>
         <scope>runtime</scope>
       </dependency>
     </dependencies>

--- a/shims/cdh61/driver/pom.xml
+++ b/shims/cdh61/driver/pom.xml
@@ -96,7 +96,7 @@
       <dependency>
         <groupId>org.eclipse.jetty</groupId>
         <artifactId>jetty-server</artifactId>
-        <version>${jetty-server.version}</version>
+        <version>${jetty-hadoop.version}</version>
         <scope>runtime</scope>
       </dependency>
       <dependency>

--- a/shims/cdpdc71/driver/pom.xml
+++ b/shims/cdpdc71/driver/pom.xml
@@ -46,31 +46,31 @@
       <dependency>
         <groupId>org.eclipse.jetty</groupId>
         <artifactId>jetty-annotations</artifactId>
-        <version>${jetty.version}</version>
+        <version>${jetty-hadoop.version}</version>
         <scope>runtime</scope>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty</groupId>
         <artifactId>jetty-client</artifactId>
-        <version>${jetty.version}</version>
+        <version>${jetty-hadoop.version}</version>
         <scope>runtime</scope>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty</groupId>
         <artifactId>jetty-http</artifactId>
-        <version>${jetty.version}</version>
+        <version>${jetty-hadoop.version}</version>
         <scope>runtime</scope>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty</groupId>
         <artifactId>jetty-io</artifactId>
-        <version>${jetty.version}</version>
+        <version>${jetty-hadoop.version}</version>
         <scope>runtime</scope>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty</groupId>
         <artifactId>jetty-jaas</artifactId>
-        <version>${jetty.version}</version>
+        <version>${jetty-hadoop.version}</version>
         <scope>runtime</scope>
         <exclusions>
           <exclusion>
@@ -82,19 +82,19 @@
       <dependency>
         <groupId>org.eclipse.jetty</groupId>
         <artifactId>jetty-jndi</artifactId>
-        <version>${jetty.version}</version>
+        <version>${jetty-hadoop.version}</version>
         <scope>runtime</scope>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty</groupId>
         <artifactId>jetty-plus</artifactId>
-        <version>${jetty.version}</version>
+        <version>${jetty-hadoop.version}</version>
         <scope>runtime</scope>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty</groupId>
         <artifactId>jetty-rewrite</artifactId>
-        <version>${jetty.version}</version>
+        <version>${jetty-hadoop.version}</version>
         <scope>runtime</scope>
       </dependency>
       <dependency>
@@ -106,43 +106,43 @@
       <dependency>
         <groupId>org.eclipse.jetty</groupId>
         <artifactId>jetty-security</artifactId>
-        <version>${jetty.version}</version>
+        <version>${jetty-hadoop.version}</version>
         <scope>runtime</scope>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty</groupId>
         <artifactId>jetty-server</artifactId>
-        <version>${jetty.version}</version>
+        <version>${jetty-hadoop.version}</version>
         <scope>runtime</scope>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty</groupId>
         <artifactId>jetty-servlet</artifactId>
-        <version>${jetty.version}</version>
+        <version>${jetty-hadoop.version}</version>
         <scope>runtime</scope>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty</groupId>
         <artifactId>jetty-util</artifactId>
-        <version>${jetty.version}</version>
+        <version>${jetty-hadoop.version}</version>
         <scope>runtime</scope>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty</groupId>
         <artifactId>jetty-util-ajax</artifactId>
-        <version>${jetty.version}</version>
+        <version>${jetty-hadoop.version}</version>
         <scope>runtime</scope>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty</groupId>
         <artifactId>jetty-webapp</artifactId>
-        <version>${jetty.version}</version>
+        <version>${jetty-hadoop.version}</version>
         <scope>runtime</scope>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty</groupId>
         <artifactId>jetty-xml</artifactId>
-        <version>${jetty.version}</version>
+        <version>${jetty-hadoop.version}</version>
         <scope>runtime</scope>
       </dependency>
     </dependencies>

--- a/shims/cdpdc71/driver/pom.xml
+++ b/shims/cdpdc71/driver/pom.xml
@@ -100,7 +100,7 @@
       <dependency>
         <groupId>org.eclipse.jetty</groupId>
         <artifactId>jetty-runner</artifactId>
-        <version>${jetty.version}</version>
+        <version>${jetty-hadoop.version}</version>
         <scope>runtime</scope>
       </dependency>
       <dependency>
@@ -863,7 +863,7 @@
                 <artifactItem>
                   <groupId>org.eclipse.jetty</groupId>
                   <artifactId>jetty-runner</artifactId>
-                  <version>${jetty.version}</version>
+                  <version>${jetty-hadoop.version}</version>
                   <type>jar</type>
                   <overWrite>true</overWrite>
                   <outputDirectory>${project.build.directory}/jetty-runner-jar</outputDirectory>
@@ -887,7 +887,7 @@
             </goals>
             <configuration>
               <target>
-                <zip destfile="${project.build.directory}/extra-resources/jetty-runner-${jetty.version}.jar"
+                <zip destfile="${project.build.directory}/extra-resources/jetty-runner-${jetty-hadoop.version}.jar"
                       basedir="${project.build.directory}/jetty-runner-jar">
                   <exclude name="org/slf4j/**"/>
                 </zip>
@@ -959,7 +959,7 @@
             <_exportcontents>
             </_exportcontents>
             <Embed-Dependency>*</Embed-Dependency>
-            <Include-Resource>{maven-resources};${project.build.directory}/extra-resources/jetty-runner-${jetty.version}.jar</Include-Resource>
+            <Include-Resource>{maven-resources};${project.build.directory}/extra-resources/jetty-runner-${jetty-hadoop.version}.jar</Include-Resource>
             <Bundle-ClassPath>.,{maven-dependencies}</Bundle-ClassPath>
             <!-- this is needed because the bundle plugin gets fooled by multi-release jars into thinking the required java
             version is the highest one in the package, which is not the case -->

--- a/shims/dataproc1421/driver/pom.xml
+++ b/shims/dataproc1421/driver/pom.xml
@@ -621,7 +621,7 @@
     <dependency>
       <groupId>org.eclipse.jetty</groupId>
       <artifactId>jetty-server</artifactId>
-      <version>${jetty.version}</version>
+      <version>${jetty-hadoop.version}</version>
     </dependency>
     <dependency>
       <groupId>org.eclipse.jetty</groupId>

--- a/shims/dataproc1421/driver/pom.xml
+++ b/shims/dataproc1421/driver/pom.xml
@@ -626,13 +626,13 @@
     <dependency>
       <groupId>org.eclipse.jetty</groupId>
       <artifactId>jetty-runner</artifactId>
-      <version>${jetty.version}</version>
+      <version>${jetty-hadoop.version}</version>
       <scope>runtime</scope>
     </dependency>
     <dependency>
       <groupId>org.eclipse.jetty.websocket</groupId>
       <artifactId>websocket-client</artifactId>
-      <version>${jetty.version}</version>
+      <version>${jetty-hadoop.version}</version>
     </dependency>
 
     <!-- The following added for Pig -->
@@ -741,7 +741,7 @@
                 <artifactItem>
                   <groupId>org.eclipse.jetty</groupId>
                   <artifactId>jetty-runner</artifactId>
-                  <version>${jetty.version}</version>
+                  <version>${jetty-hadoop.version}</version>
                   <type>jar</type>
                   <overWrite>true</overWrite>
                   <outputDirectory>${project.build.directory}/jetty-runner-jar</outputDirectory>
@@ -765,7 +765,7 @@
             </goals>
             <configuration>
               <target>
-                <zip destfile="${project.build.directory}/extra-resources/jetty-runner-${jetty.version}.jar"
+                <zip destfile="${project.build.directory}/extra-resources/jetty-runner-${jetty-hadoop.version}.jar"
                       basedir="${project.build.directory}/jetty-runner-jar">
                   <exclude name="org/slf4j/**"/>
                 </zip>
@@ -836,7 +836,7 @@
             <_exportcontents>
             </_exportcontents>
             <Embed-Dependency>*</Embed-Dependency>
-            <Include-Resource>{maven-resources};${project.build.directory}/extra-resources/jetty-runner-${jetty.version}.jar</Include-Resource>
+            <Include-Resource>{maven-resources};${project.build.directory}/extra-resources/jetty-runner-${jetty-hadoop.version}.jar</Include-Resource>
             <Bundle-ClassPath>.,{maven-dependencies}</Bundle-ClassPath>
             <!-- this is needed because the bundle plugin gets fooled by multi-release jars into thinking the required java
             version is the highest one in the package, which is not the case -->

--- a/shims/emr700/driver/pom.xml
+++ b/shims/emr700/driver/pom.xml
@@ -827,7 +827,7 @@
     <dependency>
       <groupId>org.eclipse.jetty</groupId>
       <artifactId>jetty-runner</artifactId>
-      <version>${jetty.version}</version>
+      <version>${jetty-hadoop.version}</version>
       <exclusions>
         <exclusion>
           <groupId>org.apache.mina</groupId>
@@ -894,7 +894,7 @@
                 <artifactItem>
                   <groupId>org.eclipse.jetty</groupId>
                   <artifactId>jetty-runner</artifactId>
-                  <version>${jetty.version}</version>
+                  <version>${jetty-hadoop.version}</version>
                   <type>jar</type>
                   <overWrite>true</overWrite>
                   <outputDirectory>${project.build.directory}/jetty-runner-jar</outputDirectory>
@@ -918,7 +918,7 @@
             </goals>
             <configuration>
               <target>
-                <zip destfile="${project.build.directory}/extra-resources/jetty-runner-${jetty.version}.jar"
+                <zip destfile="${project.build.directory}/extra-resources/jetty-runner-${jetty-hadoop.version}.jar"
                       basedir="${project.build.directory}/jetty-runner-jar">
                   <exclude name="org/slf4j/**"/>
                 </zip>
@@ -988,7 +988,7 @@
             <_exportcontents>
             </_exportcontents>
             <Embed-Dependency>*</Embed-Dependency>
-            <Include-Resource>{maven-resources};${project.build.directory}/extra-resources/jetty-runner-${jetty.version}.jar</Include-Resource>
+            <Include-Resource>{maven-resources};${project.build.directory}/extra-resources/jetty-runner-${jetty-hadoop.version}.jar</Include-Resource>
             <Bundle-ClassPath>.,{maven-dependencies}</Bundle-ClassPath>
             <!-- this is needed because the bundle plugin gets fooled by multi-release jars into thinking the required java
             version is the highest one in the package, which is not the case -->

--- a/shims/emr700/driver/pom.xml
+++ b/shims/emr700/driver/pom.xml
@@ -817,12 +817,12 @@
     <dependency>
       <groupId>org.eclipse.jetty</groupId>
       <artifactId>jetty-server</artifactId>
-      <version>${jetty.version}</version>
+      <version>${jetty-hadoop.version}</version>
     </dependency>
     <dependency>
       <groupId>org.eclipse.jetty</groupId>
       <artifactId>jetty-util-ajax</artifactId>
-      <version>${jetty.version}</version>
+      <version>${jetty-hadoop.version}</version>
     </dependency>
     <dependency>
       <groupId>org.eclipse.jetty</groupId>
@@ -838,12 +838,12 @@
     <dependency>
       <groupId>org.eclipse.jetty</groupId>
       <artifactId>jetty-util</artifactId>
-      <version>${jetty.version}</version>
+      <version>${jetty-hadoop.version}</version>
     </dependency>
     <dependency>
       <groupId>org.eclipse.jetty.websocket</groupId>
       <artifactId>websocket-client</artifactId>
-      <version>${jetty.version}</version>
+      <version>${jetty-hadoop.version}</version>
     </dependency>
     <dependency>
       <groupId>org.apache.curator</groupId>

--- a/shims/emr770/driver/pom.xml
+++ b/shims/emr770/driver/pom.xml
@@ -852,17 +852,17 @@
     <dependency>
       <groupId>org.eclipse.jetty</groupId>
       <artifactId>jetty-server</artifactId>
-      <version>${jetty.version}</version>
+      <version>${jetty-hadoop.version}</version>
     </dependency>
     <dependency>
       <groupId>org.eclipse.jetty</groupId>
       <artifactId>jetty-util-ajax</artifactId>
-      <version>${jetty.version}</version>
+      <version>${jetty-hadoop.version}</version>
     </dependency>
     <dependency>
       <groupId>org.eclipse.jetty</groupId>
       <artifactId>jetty-runner</artifactId>
-      <version>${jetty.version}</version>
+      <version>${jetty-hadoop.version}</version>
       <exclusions>
         <exclusion>
           <groupId>org.apache.mina</groupId>
@@ -873,12 +873,12 @@
     <dependency>
       <groupId>org.eclipse.jetty</groupId>
       <artifactId>jetty-util</artifactId>
-      <version>${jetty.version}</version>
+      <version>${jetty-hadoop.version}</version>
     </dependency>
     <dependency>
       <groupId>org.eclipse.jetty.websocket</groupId>
       <artifactId>websocket-client</artifactId>
-      <version>${jetty.version}</version>
+      <version>${jetty-hadoop.version}</version>
     </dependency>
     <dependency>
       <groupId>org.apache.curator</groupId>
@@ -929,7 +929,7 @@
                 <artifactItem>
                   <groupId>org.eclipse.jetty</groupId>
                   <artifactId>jetty-runner</artifactId>
-                  <version>${jetty.version}</version>
+                  <version>${jetty-hadoop.version}</version>
                   <type>jar</type>
                   <overWrite>true</overWrite>
                   <outputDirectory>${project.build.directory}/jetty-runner-jar</outputDirectory>
@@ -953,7 +953,7 @@
             </goals>
             <configuration>
               <target>
-                <zip destfile="${project.build.directory}/extra-resources/jetty-runner-${jetty.version}.jar"
+                <zip destfile="${project.build.directory}/extra-resources/jetty-runner-${jetty-hadoop.version}.jar"
                       basedir="${project.build.directory}/jetty-runner-jar">
                   <exclude name="org/slf4j/**"/>
                 </zip>
@@ -1023,7 +1023,7 @@
             <_exportcontents>
             </_exportcontents>
             <Embed-Dependency>*</Embed-Dependency>
-            <Include-Resource>{maven-resources};${project.build.directory}/extra-resources/jetty-runner-${jetty.version}.jar</Include-Resource>
+            <Include-Resource>{maven-resources};${project.build.directory}/extra-resources/jetty-runner-${jetty-hadoop.version}.jar</Include-Resource>
             <Bundle-ClassPath>.,{maven-dependencies}</Bundle-ClassPath>
             <!-- this is needed because the bundle plugin gets fooled by multi-release jars into thinking the required java
             version is the highest one in the package, which is not the case -->

--- a/shims/hdi40/driver/pom.xml
+++ b/shims/hdi40/driver/pom.xml
@@ -40,31 +40,31 @@
       <dependency>
         <groupId>org.eclipse.jetty</groupId>
         <artifactId>jetty-annotations</artifactId>
-        <version>${jetty.version}</version>
+        <version>${jetty-hadoop.version}</version>
         <scope>runtime</scope>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty</groupId>
         <artifactId>jetty-client</artifactId>
-        <version>${jetty.version}</version>
+        <version>${jetty-hadoop.version}</version>
         <scope>runtime</scope>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty</groupId>
         <artifactId>jetty-http</artifactId>
-        <version>${jetty.version}</version>
+        <version>${jetty-hadoop.version}</version>
         <scope>runtime</scope>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty</groupId>
         <artifactId>jetty-io</artifactId>
-        <version>${jetty.version}</version>
+        <version>${jetty-hadoop.version}</version>
         <scope>runtime</scope>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty</groupId>
         <artifactId>jetty-jaas</artifactId>
-        <version>${jetty.version}</version>
+        <version>${jetty-hadoop.version}</version>
         <scope>runtime</scope>
         <exclusions>
           <exclusion>
@@ -76,25 +76,25 @@
       <dependency>
         <groupId>org.eclipse.jetty</groupId>
         <artifactId>jetty-jndi</artifactId>
-        <version>${jetty.version}</version>
+        <version>${jetty-hadoop.version}</version>
         <scope>runtime</scope>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty</groupId>
         <artifactId>jetty-plus</artifactId>
-        <version>${jetty.version}</version>
+        <version>${jetty-hadoop.version}</version>
         <scope>runtime</scope>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty</groupId>
         <artifactId>jetty-rewrite</artifactId>
-        <version>${jetty.version}</version>
+        <version>${jetty-hadoop.version}</version>
         <scope>runtime</scope>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty</groupId>
         <artifactId>jetty-runner</artifactId>
-        <version>${jetty.version}</version>
+        <version>${jetty-hadoop.version}</version>
         <scope>runtime</scope>
         <exclusions>
           <exclusion>
@@ -114,43 +114,43 @@
       <dependency>
         <groupId>org.eclipse.jetty</groupId>
         <artifactId>jetty-security</artifactId>
-        <version>${jetty.version}</version>
+        <version>${jetty-hadoop.version}</version>
         <scope>runtime</scope>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty</groupId>
         <artifactId>jetty-server</artifactId>
-        <version>${jetty.version}</version>
+        <version>${jetty-hadoop.version}</version>
         <scope>runtime</scope>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty</groupId>
         <artifactId>jetty-servlet</artifactId>
-        <version>${jetty.version}</version>
+        <version>${jetty-hadoop.version}</version>
         <scope>runtime</scope>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty</groupId>
         <artifactId>jetty-util</artifactId>
-        <version>${jetty.version}</version>
+        <version>${jetty-hadoop.version}</version>
         <scope>runtime</scope>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty</groupId>
         <artifactId>jetty-util-ajax</artifactId>
-        <version>${jetty.version}</version>
+        <version>${jetty-hadoop.version}</version>
         <scope>runtime</scope>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty</groupId>
         <artifactId>jetty-webapp</artifactId>
-        <version>${jetty.version}</version>
+        <version>${jetty-hadoop.version}</version>
         <scope>runtime</scope>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty</groupId>
         <artifactId>jetty-xml</artifactId>
-        <version>${jetty.version}</version>
+        <version>${jetty-hadoop.version}</version>
         <scope>runtime</scope>
       </dependency>
     </dependencies>


### PR DESCRIPTION
This pull request introduces changes to multiple `pom.xml` files across various modules to update dependencies and align versioning. The key updates include adding a new test dependency in one module and replacing the `jetty.version` property with `jetty-hadoop.version` for Jetty dependencies in several modules.

### Dependency Updates:

* Added `jakarta.servlet-api` as a test dependency in the `common-fragment-V1/pom.xml` file. This ensures compatibility with Jakarta Servlet APIs during testing.

* Updated Jetty dependencies in the following modules to use the `jetty-hadoop.version` property instead of `jetty.version`:
  - `shims/apache/driver/pom.xml` [[1]](diffhunk://#diff-40c0b80627f3a69386cedc49c7cd0bed5ae3e456ad48416d7df52ffbb51e1c49L42-R60) [[2]](diffhunk://#diff-40c0b80627f3a69386cedc49c7cd0bed5ae3e456ad48416d7df52ffbb51e1c49L72-R116) [[3]](diffhunk://#diff-40c0b80627f3a69386cedc49c7cd0bed5ae3e456ad48416d7df52ffbb51e1c49L578-R578) [[4]](diffhunk://#diff-40c0b80627f3a69386cedc49c7cd0bed5ae3e456ad48416d7df52ffbb51e1c49L602-R602) [[5]](diffhunk://#diff-40c0b80627f3a69386cedc49c7cd0bed5ae3e456ad48416d7df52ffbb51e1c49L686-R686)
  - `shims/apachevanilla/driver/pom.xml` [[1]](diffhunk://#diff-6830cbf5240cec70574f3fb906574adbcac571e6cbb8e01c01a407767e3b4a82L52-R76) [[2]](diffhunk://#diff-6830cbf5240cec70574f3fb906574adbcac571e6cbb8e01c01a407767e3b4a82L88-R159) [[3]](diffhunk://#diff-6830cbf5240cec70574f3fb906574adbcac571e6cbb8e01c01a407767e3b4a82L1091-R1091) [[4]](diffhunk://#diff-6830cbf5240cec70574f3fb906574adbcac571e6cbb8e01c01a407767e3b4a82L1115-R1115) [[5]](diffhunk://#diff-6830cbf5240cec70574f3fb906574adbcac571e6cbb8e01c01a407767e3b4a82L1188-R1188)
  - `shims/cdh61/driver/pom.xml`
  - `shims/cdpdc71/driver/pom.xml` [[1]](diffhunk://#diff-658a85923c2cb7cb9a4f409c10f8ae5788a8ba294a82a146dc5a7efdd5210299L49-R73) [[2]](diffhunk://#diff-658a85923c2cb7cb9a4f409c10f8ae5788a8ba294a82a146dc5a7efdd5210299L85-R145) [[3]](diffhunk://#diff-658a85923c2cb7cb9a4f409c10f8ae5788a8ba294a82a146dc5a7efdd5210299L866-R866) [[4]](diffhunk://#diff-658a85923c2cb7cb9a4f409c10f8ae5788a8ba294a82a146dc5a7efdd5210299L890-R890)

These changes standardize the Jetty dependency versioning across modules, likely to ensure consistency and compatibility with the Hadoop ecosystem.