### PR TITLE
[BACKLOG-44864] Removing obsolete shim emr700 references and their profiles from code

### DIFF
--- a/shims/emr770/driver/pom.xml
+++ b/shims/emr770/driver/pom.xml
@@ -653,6 +653,10 @@
           <artifactId>orc-core</artifactId>
           <groupId>org.apache.orc</groupId>
         </exclusion>
+        <exclusion>
+          <artifactId>nimbus-jose-jwt</artifactId>
+          <groupId>com.nimbusds</groupId>
+        </exclusion>
       </exclusions>
     </dependency>
     <dependency>

--- a/shims/pom.xml
+++ b/shims/pom.xml
@@ -264,7 +264,6 @@
       <module>apache</module>
       <module>hdi40</module>
       <module>apachevanilla</module>
-      <module>emr700</module>
       <module>emr770</module>
     </modules>
   </profile>
@@ -310,17 +309,6 @@
     </activation>
     <modules>
       <module>apachevanilla</module>
-    </modules>
-  </profile>
-  <profile>
-    <id>emr700</id>
-    <activation>
-      <property>
-        <name>!skipDefault</name>
-      </property>
-    </activation>
-    <modules>
-      <module>emr700</module>
     </modules>
   </profile>
   <profile>


### PR DESCRIPTION
Also addressed vulnerable nimbus-jose-jwt popping up