### PR TITLE
[SP-6875] Removing obsolete shim emr700 references and their profiles from code

### DIFF
--- a/shims/pom.xml
+++ b/shims/pom.xml
@@ -263,7 +263,6 @@
       <module>apachevanilla</module>
       <module>cdpdc71</module>
       <module>dataproc1421</module>
-      <module>emr700</module>
       <module>emr770</module>
       <module>hdi40</module>
     </modules>
@@ -288,17 +287,6 @@
     </activation>
     <modules>
       <module>apachevanilla</module>
-    </modules>
-  </profile>
-  <profile>
-    <id>emr700</id>
-    <activation>
-      <property>
-        <name>!skipDefault</name>
-      </property>
-    </activation>
-    <modules>
-      <module>emr700</module>
     </modules>
   </profile>
   <profile>


### PR DESCRIPTION
- As we had upgraded to Hadoop 3.4.0, we initially decided to create a new emr770 shim specifically to support EMR 7.7.0 clusters, given their Hadoop 3.4.0 runtime. This emr770 shim was subsequently backported into our 10.2.0.4 release.

- Initially, our plan was to remove the emr700 shim in the 10.2.0.4 release to avoid confusion. However, a recent request from the SP triage meeting prompted us to reconsider, aiming to maintain emr700 shim support for customers on EMR 7.0.0 clusters. This led to the rejection of PRs that addressed its removal.

- We began investigating how to make the emr700 shim work effectively in 10.2.0.4.

- Unfortunately, making the emr700 shim fully functional and secure in 10.2.0.4 proved to be problematic:

- Initial Library Compatibility Issues: Post-Protobuf and other vulnerability fixes, we had upgraded various Hadoop-related libraries to 3.4.0 to ensure the emr700 shim was non-vulnerable and up-to-date. However, EMR 7.0.0 clusters are still on Hadoop runtime 3.3.6, which caused library clashes and led to PMR test failures, specifically with S3 file locations.

- Further Complications (Downgrade Attempt): In an attempt to resolve these clashes, we tried downgrading the internal hadoop libraries of the emr700 shim back to 3.3.6. This introduced new problems, as not only PMR tests but also Kerberos-related tests began failing. This was due to another library mismatch, this time between the downgraded emr700 shim and the libraries (still on 3.4.0) within our pentaho-big-data-ee repository and big-data-plugin.

- Significant Refactoring and Reintroduction of Vulnerabilities: The only way to truly fix these issues would be to downgrade all Hadoop-related library references across modules like pentaho-hadoop-shims, pentaho-big-data-ee, and big-data-plugin. This would mean reverting most of the changes made for the Protobuf vulnerability, making our libraries outdated and vulnerable again

After discussing these findings,, we've decided on the following:

- It's best to retain only the emr770 shim in 10.2.0.4.

- The emr770 shim is fully functional and non-vulnerable.

- While customers on EMR 7.0.0 clusters might experience PMR failures only with S3 combinations using their existing setup (as this is the only specific test case that fails), all other tests pass.

- Customers can resolve the PMR S3 issue by upgrading their EMR clusters to 7.4.0 or newer, which would then allow them to use the emr770 shim without any issues.

- Consequently, we recommend removing the emr700 shim from the 10.2.0.4 build altogether, as it not only fails several test cases even after attempted downgrades but also makes it vulnerable. Also this avoids confusion