### PR TITLE
fix[PPP-5750]: explicitly declare aws-java-sdk-bundle dependency on cdpdc71 driver to force the parent-poms version and avoid an unsafe version from being pulled transitively

### DIFF
--- a/shims/cdpdc71/driver/pom.xml
+++ b/shims/cdpdc71/driver/pom.xml
@@ -839,6 +839,11 @@
       <artifactId>protobuf-java</artifactId>
       <version>${protobuf-java.version}</version>
     </dependency>
+    <dependency>
+      <groupId>com.amazonaws</groupId>
+      <artifactId>aws-java-sdk-bundle</artifactId>
+      <version>${aws-java-sdk.version}</version>
+    </dependency>
   </dependencies>
 
   <build>


### PR DESCRIPTION
Dependency updates:

* [`shims/cdpdc71/driver/pom.xml`](diffhunk://#diff-658a85923c2cb7cb9a4f409c10f8ae5788a8ba294a82a146dc5a7efdd5210299R842-R846): Added the `aws-java-sdk-bundle` dependency with the version specified by `${aws-java-sdk.version}` to enable AWS SDK features. (This forces the version in parent-poms instead of the unsafe version that was being pulled transitively)

@pentaho/tatooine_dev 