### PR TITLE
[BACKLOG-45306]-Fix test failures in test1 pipeline when running on JDK 21

### DIFF
--- a/common-fragment-V1/src/main/java/org/pentaho/big/data/impl/shim/pig/KettleLoggingPrintWriter.java
+++ b/common-fragment-V1/src/main/java/org/pentaho/big/data/impl/shim/pig/KettleLoggingPrintWriter.java
@@ -15,8 +15,10 @@ package org.pentaho.big.data.impl.shim.pig;
 
 import org.pentaho.di.core.logging.LogChannelInterface;
 
+import java.io.OutputStreamWriter;
 import java.io.PrintStream;
 import java.io.PrintWriter;
+import java.nio.charset.Charset;
 
 /**
  * An extended PrintWriter that sends output to Kettle's logging
@@ -31,7 +33,7 @@ public class KettleLoggingPrintWriter extends PrintWriter {
   }
 
   public KettleLoggingPrintWriter( LogChannelInterface logChannelInterface, PrintStream printStream ) {
-    super( printStream );
+    super( new OutputStreamWriter( printStream, Charset.defaultCharset() ), true );
     this.logChannelInterface = logChannelInterface;
   }
 


### PR DESCRIPTION
[BACKLOG-45306]-Fix test failures in test1 pipeline when running on JDK 21

[BACKLOG-45306]: https://hv-eng.atlassian.net/browse/BACKLOG-45306?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ