### PR TITLE
fix[BAD-1967]: include httpcore and httpclient dependencies in the common fragment

### DIFF
--- a/common-fragment-V1/pom.xml
+++ b/common-fragment-V1/pom.xml
@@ -453,6 +453,19 @@
       <version>${jakarta.servlet.version}</version>
       <scope>test</scope>
     </dependency>
+
+    <!-- These may not be needed in the future if this is moved out of karaf (BAD-1967) -->
+    <dependency>
+      <groupId>org.apache.httpcomponents</groupId>
+      <artifactId>httpcore</artifactId>
+      <version>4.4.11</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.httpcomponents</groupId>
+      <artifactId>httpclient</artifactId>
+      <version>4.5.14</version>
+    </dependency>
+
   </dependencies>
   <build>
     <plugins>
@@ -477,6 +490,12 @@
         <version>${shim-bundle-plugin.version}</version>
         <configuration>
           <resolverFilters>
+            <resolverFilter>
+              <include>
+                *:httpcore,*:httpclient
+              </include>
+              <transitive>true</transitive>
+            </resolverFilter>
           </resolverFilters>
         </configuration>
         <executions>

--- a/shims/apache/driver/src/main/java/org/pentaho/hadoop/shim/pvfs/conf/S3Conf.java
+++ b/shims/apache/driver/src/main/java/org/pentaho/hadoop/shim/pvfs/conf/S3Conf.java
@@ -108,6 +108,7 @@ public class S3Conf extends PvfsConf {
     conf.set( "fs.s3a.impl.disable.cache", "true" ); // caching managed by PvfsHadoopBridge
 
     conf.set( "fs.s3a.buffer.dir", System.getProperty( "java.io.tmpdir" ) );
+    conf.set( "fs.s3a.fast.upload.buffer", "array" ); // To avoid Windows native IO issues (BAD-1967)
 
     // Use only when VFS is configured for generic S3 connection
     if ( !isNullOrEmpty( endpoint ) ) {


### PR DESCRIPTION
**Causes:**
The issue is due to [this function](https://github.com/pentaho/pentaho-hadoop-shims/blob/eccfd2edb4ed00beb6e37c99d00a58302b3c8299/common-fragment-V1/src/main/java/org/pentaho/hadoop/shim/common/format/HadoopFormatBase.java#L27) changing from the thread classloader to the class’s classloader. The function then performs an action that, in the case exposed in [BAD-1967](https://hv-eng.atlassian.net/browse/BAD-1967), will eventually call some cache access functions that expect specific dependencies that were only accessible in the thread classloader, and are now are missing. This matches the original design for the big data stuff, which was to be able to have multiple big data drivers active at once, each with its own collection of dependencies.  So, setting the classloader from _whatever the thread was using_ to _its own_ ensured it got the dependencies from its karaf bundle.

**Fix:**
Because at the moment we still depend on changing the classloader, we cannot remove that part, and therefore we need to add these missing dependencies directly in the `shims-common-fragment`. While adding the missing `httpcore` and `httpclient` dependencies (and some extra configuration to the `shim-bundle-plugin)` did fix the issue, it also seems to also have changed the behavior of the Hadoop S3A functionality, defaulting to disk buffering mode, which uses Windows native IO, causing the following error:

`java.lang.UnsatisfiedLinkError: 'boolean org.apache.hadoop.io.nativeio.NativeIO$Windows.access0(java.lang.String, int)'`

This was solved by setting (in the S3 config file) the `fs.s3a.fast.upload.buffer` property to `array`, forcing S3A to use in-memory buffering for multipart uploads, bypassing all native file IO, and avoiding the error above.


**Notes:**
1) There is a small risk this may degrade performance due to increased memory usage, but I'm not sure if it is enough risk to warrant testing specifically for that.

2) Since this will eventually be moved out of karaf, the extra dependencies that were added may not be necessary in the future, and we should remove them from the common-fragment `pom.xml` if/when that happens.

**Tests:**
Tested **only in Windows**, with ORC **and** Parquet input/output transformations, in both `pdi-ee` and `pdi-ce`.

@pentaho/tatooine_dev 

[BAD-1967]: https://hv-eng.atlassian.net/browse/BAD-1967?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ