### PR TITLE
fix[SP-6904]: include httpcore and httpclient dependencies in the common fragment

### DIFF
--- a/common-fragment-V1/pom.xml
+++ b/common-fragment-V1/pom.xml
@@ -448,6 +448,19 @@
       <classifier>tests</classifier>
       <scope>test</scope>
     </dependency>
+
+    <!-- These may not be needed in the future if this is moved out of karaf (BAD-1967) -->
+    <dependency>
+      <groupId>org.apache.httpcomponents</groupId>
+      <artifactId>httpcore</artifactId>
+      <version>4.4.11</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.httpcomponents</groupId>
+      <artifactId>httpclient</artifactId>
+      <version>4.5.14</version>
+    </dependency>
+
   </dependencies>
   <build>
     <plugins>
@@ -472,6 +485,12 @@
         <version>${shim-bundle-plugin.version}</version>
         <configuration>
           <resolverFilters>
+            <resolverFilter>
+              <include>
+                *:httpcore,*:httpclient
+              </include>
+              <transitive>true</transitive>
+            </resolverFilter>
           </resolverFilters>
         </configuration>
         <executions>

--- a/shims/apache/driver/src/main/java/org/pentaho/hadoop/shim/pvfs/conf/S3Conf.java
+++ b/shims/apache/driver/src/main/java/org/pentaho/hadoop/shim/pvfs/conf/S3Conf.java
@@ -108,7 +108,7 @@ public class S3Conf extends PvfsConf {
     conf.set( "fs.s3a.impl.disable.cache", "true" ); // caching managed by PvfsHadoopBridge
 
     conf.set( "fs.s3a.buffer.dir", System.getProperty( "java.io.tmpdir" ) );
-    conf.set( "fs.s3a.fast.upload.buffer", "array" ); // To avoid Windows native IO issues (BAD-1967)
+    conf.set( "fs.s3a.fast.upload.buffer", "array" ); // To avoid native IO issues (BAD-1967)
 
     // Use only when VFS is configured for generic S3 connection
     if ( !isNullOrEmpty( endpoint ) ) {

--- a/shims/apache/driver/src/main/java/org/pentaho/hadoop/shim/pvfs/conf/S3Conf.java
+++ b/shims/apache/driver/src/main/java/org/pentaho/hadoop/shim/pvfs/conf/S3Conf.java
@@ -17,6 +17,7 @@ import com.amazonaws.auth.AWSCredentials;
 import com.amazonaws.auth.BasicSessionCredentials;
 import com.amazonaws.auth.profile.ProfileCredentialsProvider;
 import com.google.common.base.Preconditions;
+import org.apache.commons.lang3.SystemUtils;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.Path;
 import org.pentaho.di.connections.ConnectionDetails;
@@ -108,7 +109,12 @@ public class S3Conf extends PvfsConf {
     conf.set( "fs.s3a.impl.disable.cache", "true" ); // caching managed by PvfsHadoopBridge
 
     conf.set( "fs.s3a.buffer.dir", System.getProperty( "java.io.tmpdir" ) );
-    conf.set( "fs.s3a.fast.upload.buffer", "array" ); // To avoid native IO issues (BAD-1967)
+
+    // If we are in Windows, add this config to avoid Windows native IO issues (BAD-1967)
+    String os = System.getProperty( "os.name" ).toLowerCase();
+    if ( SystemUtils.IS_OS_WINDOWS || os.contains( "win" )  ) {
+      conf.set( "fs.s3a.fast.upload.buffer", "array" );
+    }
 
     // Use only when VFS is configured for generic S3 connection
     if ( !isNullOrEmpty( endpoint ) ) {

--- a/shims/apache/driver/src/main/java/org/pentaho/hadoop/shim/pvfs/conf/S3Conf.java
+++ b/shims/apache/driver/src/main/java/org/pentaho/hadoop/shim/pvfs/conf/S3Conf.java
@@ -108,6 +108,7 @@ public class S3Conf extends PvfsConf {
     conf.set( "fs.s3a.impl.disable.cache", "true" ); // caching managed by PvfsHadoopBridge
 
     conf.set( "fs.s3a.buffer.dir", System.getProperty( "java.io.tmpdir" ) );
+    conf.set( "fs.s3a.fast.upload.buffer", "array" ); // To avoid Windows native IO issues (BAD-1967)
 
     // Use only when VFS is configured for generic S3 connection
     if ( !isNullOrEmpty( endpoint ) ) {


### PR DESCRIPTION
Original PRs: https://github.com/pentaho/pentaho-hadoop-shims/pull/1643, https://github.com/pentaho/pentaho-hadoop-shims/pull/1644, https://github.com/pentaho/pentaho-hadoop-shims/pull/1645