### PR TITLE
chore[SP-7186]: centralize netty version in parent pom (#1777)

### DIFF
--- a/shims/dataproc1421/driver/pom.xml
+++ b/shims/dataproc1421/driver/pom.xml
@@ -13,7 +13,6 @@
 
   <properties>
     <shim.id>dataproc1421</shim.id>
-    <netty.version>4.1.108.Final</netty.version>
     <!-- setting v1.14.4 so shaded jackson-databind inside parquet-hadoop-bundle's  version approximately matches jackson-databind in driver.jar -->
     <parquet.version>1.14.4</parquet.version>
     <curator.version>5.6.0</curator.version>


### PR DESCRIPTION
NOTE: This PR was created by Copilot automation.

## Backport Information
**SP Issue:** [SP-7186 - Backport of PPP-6270 - (11.0 Suite) CVE-2025-67735 | Vulnerable component io.netty:netty-codec-http detected in Pentaho](https://hv-eng.atlassian.net/browse/SP-7186)
**Base Case:** [PPP-6270 - CVE-2025-67735 | Vulnerable component io.netty:netty-codec-http detected in Pentaho](https://hv-eng.atlassian.net/browse/PPP-6270)
**Original Master PR:** [pentaho/pentaho-hadoop-shims#1777](https://github.com/pentaho/pentaho-hadoop-shims/pull/1777)

## Changes
- Removed the remaining child-level `netty.version` override in `shims/dataproc1421/driver/pom.xml` so it inherits the parent value.
- Reviewer note on PR size discrepancy vs original master PR: the maintenance branch `11.0` had already removed shim-level `netty.version` overrides for `apachevanilla`, `cdpdc71`, `emr770`, and `hdi40` in commit `ac6743d8dab4e1d181f6be756655f5bcea94e453` (`fix[PPP-5746]: centralize netty version and bump to 4.1.118.Final`). Therefore only `dataproc1421` remained for this SP backport.
- Commit: adf538db2f1f267796d7fde69c76066073a964d0

## Conflict Resolution
- Resolved overlap in dataproc1421/emr770 driver poms while preserving the master change intent and 11.0-specific local content where unrelated.

## Target
- **Target Branch:** 11.0 (11.0 Suite maintenance branch)
- **Code Freeze Status:** Detected (SP2026 - 11.0 (11.0.0.2)), but backport only to maintenance branch per policy
