### PR TITLE
chore[SP-7178]: bump org.apache.hadoop to 3.1.1.7.3.1.700-158

### DIFF
--- a/shims/cdpdc71/driver/pom.xml
+++ b/shims/cdpdc71/driver/pom.xml
@@ -20,7 +20,7 @@
     <org.apache.avro.version>1.11.1.7.3.1.0-197</org.apache.avro.version>
 <!--    <org.apache.orc.version>1.5.1.7.1.4.0-203</org.apache.orc.version>-->
     <org.apache.orc.version>1.5.1.7.1.4.0-203</org.apache.orc.version>
-    <org.apache.hadoop.version>3.1.1.7.3.1.0-197</org.apache.hadoop.version>
+    <org.apache.hadoop.version>3.1.1.7.3.1.700-158</org.apache.hadoop.version>
     <org.apache.hbase.version>2.4.17.7.3.1.0-197</org.apache.hbase.version>
     <org.apache.hbase.thirdparty.version>4.1.10</org.apache.hbase.thirdparty.version>
     <org.apache.hive.version>3.1.3000.7.3.1.0-197</org.apache.hive.version>


### PR DESCRIPTION
NOTE: This PR was created by Copilot automation.

## Backport Information
- **SP Issue:** [SP-7178 - Backport of PPP-6280 - (11.0 Suite) CVE-2021-37404 | pdia-master has a security violation in gav://org.apache.hadoop:hadoop-common:3.1.1.7.3.1.600-337](https://hv-eng.atlassian.net/browse/SP-7178)
- **Base Case:** [PPP-6280 - Backport of PPP-6280 - (11.0 Suite) CVE-2021-37404 | pdia-master has a security violation in gav://org.apache.hadoop:hadoop-common:3.1.1.7.3.1.600-337](https://hv-eng.atlassian.net/browse/PPP-6280)
- **Original Master PR:** https://github.com/pentaho/pentaho-hadoop-shims/pull/1789

## Changes
- Cherry-picked from https://github.com/pentaho/pentaho-hadoop-shims/pull/1789
- Commit: not provided

## Conflict Resolution
- No manual conflict resolution required

## Target
- **Target Branch:** 11.0 (11.0 Suite maintenance branch)
