### PR TITLE
fix[SP-7215]: update to parent pom version of woodstox-core (6.6.2)

### DIFF
--- a/shims/apache/driver/pom.xml
+++ b/shims/apache/driver/pom.xml
@@ -570,6 +570,11 @@
         </exclusion>
       </exclusions>
     </dependency>
+    <dependency>
+      <groupId>com.fasterxml.woodstox</groupId>
+      <artifactId>woodstox-core</artifactId>
+      <version>${woodstox-core.version}</version>
+    </dependency>
   </dependencies>
 
   <dependencyManagement>


### PR DESCRIPTION
NOTE: This PR was created by Copilot automation.

## Backport Information
- **SP Issue:** [SP-7215 - Backport of PPP-4969 - (10.2 Suite) Vulnerable Component: woodstox](https://hv-eng.atlassian.net/browse/SP-7215)
- **Base Case:** [PPP-4969 - Vulnerable Component: woodstox](https://hv-eng.atlassian.net/browse/PPP-4969)
- **Original Master PR:** https://github.com/pentaho/pentaho-hadoop-shims/pull/1795

## Changes
- Updated woodstox-core to version 6.6.2 via parent pom version bump to address CVE woodstox vulnerability.
- Cherry-picked merge commit d77aecd7732b2f30e47e43501dcf4fa9ef3c44e4 from PR #1795.
- Commit: d77aecd7732b2f30e47e43501dcf4fa9ef3c44e4

## Conflict Resolution
- No manual conflict resolution required

## Target
- **Target Branch:** 10.2 (10.2 Suite maintenance branch)
