### PR TITLE
chore[SP-7120]: centralize grpc-netty-shaded version and update it to 1.78.0

### DIFF
--- a/shims/emr770/driver/pom.xml
+++ b/shims/emr770/driver/pom.xml
@@ -251,6 +251,11 @@
       <artifactId>netty-transport-udt</artifactId>
       <version>${netty.version}</version>
     </dependency>
+    <dependency>
+      <groupId>io.grpc</groupId>
+      <artifactId>grpc-netty-shaded</artifactId>
+      <version>${grpc-netty.version}</version>
+    </dependency>
 
     <dependency>
       <groupId>org.apache.hadoop</groupId>


### PR DESCRIPTION
NOTE: This PR was created by Copilot automation.

## Backport Information
- **SP Issue:** [SP-7120 - Backport of PPP-6180 - (10.2 Suite) CVE-2025-55163 | pdia-master has a security violation in gav://io.grpc:grpc-netty-shaded:1.67.1](https://hv-eng.atlassian.net/browse/SP-7120)
- **Base Case:** [PPP-6180 - Backport of PPP-6180 - (10.2 Suite) CVE-2025-55163 | pdia-master has a security violation in gav://io.grpc:grpc-netty-shaded:1.67.1](https://hv-eng.atlassian.net/browse/PPP-6180)
- **Original Master PR:** https://github.com/pentaho/pentaho-hadoop-shims/pull/1742

## Changes
- Cherry-picked from https://github.com/pentaho/pentaho-hadoop-shims/pull/1742
- Commit: not provided

## Conflict Resolution
- No manual conflict resolution required

## Target
- **Target Branch:** 10.2 (10.2 Suite maintenance branch)
