### PR TITLE
build[PPP-6390][PPP-6391]: use maven-parent-pom `bouncycastle.version`

### DIFF
--- a/shims/hdi40/driver/pom.xml
+++ b/shims/hdi40/driver/pom.xml
@@ -31,7 +31,6 @@
     <automaton.version>1.11-8</automaton.version>
     <joda-time.version>2.9.3</joda-time.version>
     <commons-configuration2.version>2.10.1</commons-configuration2.version>
-    <bouncycastle.version>1.78</bouncycastle.version>
     <websocket.version>9.4.53.v20231009</websocket.version>
   </properties>
 

--- a/shims/hdi40/driver/pom.xml
+++ b/shims/hdi40/driver/pom.xml
@@ -217,12 +217,6 @@
     <dependency>
       <groupId>org.bouncycastle</groupId>
       <artifactId>bcpkix-jdk18on</artifactId>
-      <version>${bouncycastle.version}</version>
-    </dependency>
-    <dependency>
-      <groupId>org.bouncycastle</groupId>
-      <artifactId>bcpkix-jdk18on</artifactId>
-      <version>${bouncycastle.version}</version>
     </dependency>
     <dependency>
       <groupId>org.apache.hive</groupId>


### PR DESCRIPTION
This pull request makes a minor update to the `pom.xml` file by removing the `bouncycastle.version` property, to use the one declared in maven-parent-poms: https://github.com/pentaho/maven-parent-poms/pull/843