### PR TITLE
[SP-7212] Backport of PDI-20660 - (11.0 Suite) Unable to connect to Hive from v10.2.0.4-v10.2.0.6 using cdpdc71-kar-10.2.0.6-378.kar

### DIFF
--- a/shims/cdpdc71/driver/pom.xml
+++ b/shims/cdpdc71/driver/pom.xml
@@ -43,6 +43,8 @@
     <ranger-raz-hook-s3.version>2.4.0.7.3.1.0-197</ranger-raz-hook-s3.version>
     <hadoop-shaded-guava.version>1.4.0</hadoop-shaded-guava.version>
     <slf4j.version>1.7.36</slf4j.version>
+    <!-- Pin libthrift to the Cloudera/CDP 7.3.1 Hive JDBC-compatible version required for HTTP-based Hive connections -->
+    <org.apache.thrift.version>0.16.0</org.apache.thrift.version>
   </properties>
 
   <dependencyManagement>
@@ -381,6 +383,12 @@
       <groupId>org.apache.hive</groupId>
       <artifactId>hive-service</artifactId>
       <version>${org.apache.hive.version}</version>
+      <exclusions>
+        <exclusion>
+          <artifactId>libthrift</artifactId>
+          <groupId>org.apache.thrift</groupId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>org.apache.hive</groupId>


### PR DESCRIPTION
Customer received hotfix KAR for 10.2.0.6-378. Downgraded libthrift from 0.20.0 to match Cloudera's bundled version (compatible with Hive JDBC 3.1.3000.7.3.1.0-197 ) to resolve HTTP JAR conflicts in Cloudera runtime.
​Ref: https://mvnrepository.com/artifact/org.apache.hive/hive-jdbc/3.1.3000.7.3.1.0-197

Original PR: https://github.com/pentaho/pentaho-hadoop-shims/pull/1734