### PR TITLE
[SP-7213] Backport of PDI-20660 - (10.2 Suite) Unable to connect to Hive from v10.2.0.4-v10.2.0.6 using cdpdc71-kar-10.2.0.6-378.kar

### DIFF
--- a/shims/cdpdc71/driver/pom.xml
+++ b/shims/cdpdc71/driver/pom.xml
@@ -33,6 +33,8 @@
     <google-oauth.version>1.33.3</google-oauth.version>
     <commons-configuration2.version>2.10.1</commons-configuration2.version>
     <wildfly-openssl.version>1.1.3.Final</wildfly-openssl.version>
+    <!-- Pin libthrift to the Cloudera/CDP 7.1.9.0-387 Hive JDBC-compatible version required for HTTP-based Hive connections -->
+    <org.apache.thrift.version>0.16.0</org.apache.thrift.version>
   </properties>
 
   <dependencyManagement>


### PR DESCRIPTION
Customer received hotfix KAR for 10.2.0.6-378. Downgraded libthrift from 0.20.0 to match Cloudera's bundled version (compatible with Hive JDBC 3.1.3000.7.1.9.0-387) to resolve HTTP JAR conflicts in Cloudera runtime.
Ref: [Maven Repository: org.apache.hive » hive-jdbc » 3.1.3000.7.1.9.0-387 - Dependencies](https://mvnrepository.com/artifact/org.apache.hive/hive-jdbc/3.1.3000.7.1.9.0-387/dependencies)
 
Original PR: https://github.com/pentaho/pentaho-hadoop-shims/pull/1734