### PR TITLE
build[PPP-6390][PPP-6391]: exclude jdk18on Bouncy Castle artifacts and align dependencies

### DIFF
--- a/shims/emr770/driver/pom.xml
+++ b/shims/emr770/driver/pom.xml
@@ -694,6 +694,22 @@
           <groupId>org.bouncycastle</groupId>
           <artifactId>bcprov-jdk15on</artifactId>
         </exclusion>
+        <exclusion>
+          <groupId>org.bouncycastle</groupId>
+          <artifactId>bcprov-jdk18on</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.bouncycastle</groupId>
+          <artifactId>bcpkix-jdk18on</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.bouncycastle</groupId>
+          <artifactId>bcutil-jdk18on</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.bouncycastle</groupId>
+          <artifactId>bcmail-jdk18on</artifactId>
+        </exclusion>
       </exclusions>
     </dependency>
     <dependency>
@@ -721,6 +737,22 @@
           <groupId>io.grpc</groupId>
           <artifactId>grpc-netty-shaded</artifactId>
         </exclusion>
+        <exclusion>
+          <groupId>org.bouncycastle</groupId>
+          <artifactId>bcprov-jdk18on</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.bouncycastle</groupId>
+          <artifactId>bcpkix-jdk18on</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.bouncycastle</groupId>
+          <artifactId>bcutil-jdk18on</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.bouncycastle</groupId>
+          <artifactId>bcmail-jdk18on</artifactId>
+        </exclusion>
       </exclusions>
     </dependency>
     <!-- In the future, if hive-service is bumped to a version that includes a safe version of grpc-netty-shaded -->
@@ -729,6 +761,23 @@
       <groupId>io.grpc</groupId>
       <artifactId>grpc-netty-shaded</artifactId>
       <version>1.76.0</version>
+    </dependency>
+    <!-- Keep the Bouncy Castle line aligned with the rest of the product until jdk18on is adopted everywhere. -->
+    <dependency>
+      <groupId>org.bouncycastle</groupId>
+      <artifactId>bcprov-jdk15to18</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.bouncycastle</groupId>
+      <artifactId>bcpkix-jdk15to18</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.bouncycastle</groupId>
+      <artifactId>bcutil-jdk15to18</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.bouncycastle</groupId>
+      <artifactId>bcmail-jdk15to18</artifactId>
     </dependency>
     <dependency>
       <groupId>org.apache.hive.shims</groupId>


### PR DESCRIPTION
This pull request updates the Bouncy Castle dependencies in the `shims/emr770/driver/pom.xml` file to ensure compatibility and avoid conflicts, particularly with different Java versions. The changes focus on excluding newer `jdk18on` variants from transitive dependencies and explicitly adding the `jdk15to18` versions to maintain alignment across the product.

**Dependency exclusions and additions:**

* Excluded the following Bouncy Castle `jdk18on` artifacts from transitive dependencies to prevent conflicts: `bcprov-jdk18on`, `bcpkix-jdk18on`, `bcutil-jdk18on`, and `bcmail-jdk18on`. [[1]](diffhunk://#diff-cec8a2ee6b8be8e9f02f6b142e99e256654559727034f9bdea7326887deda820R697-R712) [[2]](diffhunk://#diff-cec8a2ee6b8be8e9f02f6b142e99e256654559727034f9bdea7326887deda820R740-R755)

* Added direct dependencies on the `jdk15to18` variants of Bouncy Castle libraries (`bcprov-jdk15to18`, `bcpkix-jdk15to18`, `bcutil-jdk15to18`, and `bcmail-jdk15to18`) to ensure consistent cryptography support until the `jdk18on` versions are adopted everywhere.