### PR TITLE
build[SP-7277]: use maven-parent-pom `bouncycastle.version`

### DIFF
--- a/shims/apachevanilla/driver/pom.xml
+++ b/shims/apachevanilla/driver/pom.xml
@@ -458,6 +458,22 @@
           <artifactId>netty-all</artifactId>
         </exclusion>
         <exclusion>
+          <groupId>org.bouncycastle</groupId>
+          <artifactId>bcprov-jdk18on</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.bouncycastle</groupId>
+          <artifactId>bcpkix-jdk18on</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.bouncycastle</groupId>
+          <artifactId>bcutil-jdk18on</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.bouncycastle</groupId>
+          <artifactId>bcmail-jdk18on</artifactId>
+        </exclusion>
+        <exclusion>
           <groupId>io.netty</groupId>
           <artifactId>netty</artifactId>
         </exclusion>
@@ -558,6 +574,23 @@
           <groupId>dnsjava</groupId>
         </exclusion>
       </exclusions>
+    </dependency>
+    <!-- Keep the Bouncy Castle line aligned with the rest of the product until jdk18on is adopted everywhere. -->
+    <dependency>
+      <groupId>org.bouncycastle</groupId>
+      <artifactId>bcprov-jdk15to18</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.bouncycastle</groupId>
+      <artifactId>bcpkix-jdk15to18</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.bouncycastle</groupId>
+      <artifactId>bcutil-jdk15to18</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.bouncycastle</groupId>
+      <artifactId>bcmail-jdk15to18</artifactId>
     </dependency>
     <dependency>
       <groupId>org.apache.parquet</groupId>

--- a/shims/cdpdc71/driver/pom.xml
+++ b/shims/cdpdc71/driver/pom.xml
@@ -405,6 +405,22 @@
           <artifactId>netty-all</artifactId>
         </exclusion>
         <exclusion>
+          <groupId>org.bouncycastle</groupId>
+          <artifactId>bcprov-jdk18on</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.bouncycastle</groupId>
+          <artifactId>bcpkix-jdk18on</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.bouncycastle</groupId>
+          <artifactId>bcutil-jdk18on</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.bouncycastle</groupId>
+          <artifactId>bcmail-jdk18on</artifactId>
+        </exclusion>
+        <exclusion>
           <groupId>io.netty</groupId>
           <artifactId>netty</artifactId>
         </exclusion>
@@ -444,6 +460,23 @@
           <groupId>dnsjava</groupId>
         </exclusion>
       </exclusions>
+    </dependency>
+    <!-- Keep the Bouncy Castle line aligned with the rest of the product until jdk18on is adopted everywhere. -->
+    <dependency>
+      <groupId>org.bouncycastle</groupId>
+      <artifactId>bcprov-jdk15to18</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.bouncycastle</groupId>
+      <artifactId>bcpkix-jdk15to18</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.bouncycastle</groupId>
+      <artifactId>bcutil-jdk15to18</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.bouncycastle</groupId>
+      <artifactId>bcmail-jdk15to18</artifactId>
     </dependency>
     <dependency>
       <groupId>org.apache.parquet</groupId>

--- a/shims/dataproc1421/driver/pom.xml
+++ b/shims/dataproc1421/driver/pom.xml
@@ -402,9 +402,41 @@
           <groupId>io.netty</groupId>
           <artifactId>netty-all</artifactId>
         </exclusion>
+        <exclusion>
+          <groupId>org.bouncycastle</groupId>
+          <artifactId>bcprov-jdk18on</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.bouncycastle</groupId>
+          <artifactId>bcpkix-jdk18on</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.bouncycastle</groupId>
+          <artifactId>bcutil-jdk18on</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.bouncycastle</groupId>
+          <artifactId>bcmail-jdk18on</artifactId>
+        </exclusion>
       </exclusions>
     </dependency>
-
+    <!-- Keep the Bouncy Castle line aligned with the rest of the product until jdk18on is adopted everywhere. -->
+    <dependency>
+      <groupId>org.bouncycastle</groupId>
+      <artifactId>bcprov-jdk15to18</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.bouncycastle</groupId>
+      <artifactId>bcpkix-jdk15to18</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.bouncycastle</groupId>
+      <artifactId>bcutil-jdk15to18</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.bouncycastle</groupId>
+      <artifactId>bcmail-jdk15to18</artifactId>
+    </dependency>
     <dependency>
       <groupId>org.apache.hive</groupId>
       <artifactId>hive-shims</artifactId>

--- a/shims/emr770/driver/pom.xml
+++ b/shims/emr770/driver/pom.xml
@@ -628,6 +628,22 @@
           <artifactId>zookeeper</artifactId>
           <groupId>org.apache.zookeeper</groupId>
         </exclusion>
+        <exclusion>
+          <groupId>org.bouncycastle</groupId>
+          <artifactId>bcprov-jdk18on</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.bouncycastle</groupId>
+          <artifactId>bcpkix-jdk18on</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.bouncycastle</groupId>
+          <artifactId>bcutil-jdk18on</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.bouncycastle</groupId>
+          <artifactId>bcmail-jdk18on</artifactId>
+        </exclusion>
       </exclusions>
     </dependency>
     <dependency>
@@ -671,7 +687,40 @@
           <groupId>io.netty</groupId>
           <artifactId>netty-all</artifactId>
         </exclusion>
+        <exclusion>
+          <groupId>org.bouncycastle</groupId>
+          <artifactId>bcprov-jdk18on</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.bouncycastle</groupId>
+          <artifactId>bcpkix-jdk18on</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.bouncycastle</groupId>
+          <artifactId>bcutil-jdk18on</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.bouncycastle</groupId>
+          <artifactId>bcmail-jdk18on</artifactId>
+        </exclusion>
       </exclusions>
+    </dependency>
+    <!-- Keep the Bouncy Castle line aligned with the rest of the product until jdk18on is adopted everywhere. -->
+    <dependency>
+      <groupId>org.bouncycastle</groupId>
+      <artifactId>bcprov-jdk15to18</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.bouncycastle</groupId>
+      <artifactId>bcpkix-jdk15to18</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.bouncycastle</groupId>
+      <artifactId>bcutil-jdk15to18</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.bouncycastle</groupId>
+      <artifactId>bcmail-jdk15to18</artifactId>
     </dependency>
     <dependency>
       <groupId>org.apache.hive.shims</groupId>

--- a/shims/hdi40/driver/pom.xml
+++ b/shims/hdi40/driver/pom.xml
@@ -26,7 +26,7 @@
     <joda-time.version>2.10</joda-time.version>
     <jython.version>2.5.3</jython.version>
     <commons-configuration2.version>2.10.1</commons-configuration2.version>
-    <bouncycastle.version>1.78</bouncycastle.version>
+    <websocket.version>9.4.53.v20231009</websocket.version>
   </properties>
 
   <dependencyManagement>
@@ -258,7 +258,6 @@
     <dependency>
       <groupId>org.bouncycastle</groupId>
       <artifactId>bcpkix-jdk18on</artifactId>
-      <version>${bouncycastle.version}</version>
     </dependency>
     <dependency>
       <groupId>org.apache.hive</groupId>

--- a/shims/hdi40/driver/pom.xml
+++ b/shims/hdi40/driver/pom.xml
@@ -26,7 +26,6 @@
     <joda-time.version>2.10</joda-time.version>
     <jython.version>2.5.3</jython.version>
     <commons-configuration2.version>2.10.1</commons-configuration2.version>
-    <websocket.version>9.4.53.v20231009</websocket.version>
   </properties>
 
   <dependencyManagement>


### PR DESCRIPTION
NOTE: This PR was created by Copilot automation.

## Backport Information
- **SP Issue:** [SP-7277 - Backport of PPP-6391 - (10.2 Suite) CVE-2025-14813 | pdia-master has a security violation in bouncycastle](https://hv-eng.atlassian.net/browse/SP-7277)
- **Base Case:** [PPP-6391 - Backport of PPP-6391 - (10.2 Suite) CVE-2025-14813 | pdia-master has a security violation in bouncycastle](https://hv-eng.atlassian.net/browse/PPP-6391)
- **Original Master PRs:**
  - https://github.com/pentaho/pentaho-hadoop-shims/pull/1829
  - https://github.com/pentaho/pentaho-hadoop-shims/pull/1835
  - https://github.com/pentaho/pentaho-hadoop-shims/pull/1836

## Changes
- Cherry-picked from https://github.com/pentaho/pentaho-hadoop-shims/pull/1829
- Cherry-picked from https://github.com/pentaho/pentaho-hadoop-shims/pull/1835
- Cherry-picked from https://github.com/pentaho/pentaho-hadoop-shims/pull/1836
- Commit: 7448565543f75e2c3790608f6ccaed5668c1b92c
- Commit: 2b5ab99483ea3a94e4692034edb90041139c9a22
- Commit: af6c04ef17270811649e68023fa2a3d4dcfefe9e

## Conflict Resolution
- Conflict at `7448565543f7` (build[PPP-6390][PPP-6391]: use maven-parent-pom `bouncycastle.version` (#1829)): resolved in `shims/hdi40/driver/pom.xml`
- Conflict at `2b5ab99483ea` (build[PPP-6390][PPP-6391]: exclude jdk18on Bouncy Castle artifacts and align dependencies (#1835)): resolved in `shims/emr770/driver/pom.xml`
- Conflict at `af6c04ef1727` (build[PPP-6390][PPP-6391]: exclude jdk18on Bouncy Castle artifacts and align dependencies (#1836)): resolved in `shims/apachevanilla/driver/pom.xml`, `shims/cdpdc71/driver/pom.xml`, `shims/dataproc1421/driver/pom.xml`

## Target
- **Target Branch:** 10.2 (10.2 Suite maintenance branch)


[PPP-6391]: https://hv-eng.atlassian.net/browse/PPP-6391?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ