### PR TITLE
fix[BACKLOG-49904]: bump hive-service back down from 4.2.0 to 4.1.0 to assure correct Java version support

### DIFF
--- a/shims/emr770/driver/pom.xml
+++ b/shims/emr770/driver/pom.xml
@@ -16,7 +16,7 @@
     <shim.id>emr770</shim.id>
     <jsr311-api.version>1.1.1</jsr311-api.version>
     <org.apache.avro.version>1.12.0</org.apache.avro.version>
-    <org.apache.hive.version>4.2.0</org.apache.hive.version>
+    <org.apache.hive.version>4.1.0</org.apache.hive.version>
     <org.apache.oozie.version>5.2.1</org.apache.oozie.version>
     <org.apache.hbase.version>2.6.2</org.apache.hbase.version>
     <sqoop.version>1.4.7</sqoop.version>


### PR DESCRIPTION
Since no version of `hive-service` had an updated, safe version of `grpc-netty-shaded` (>`1.75.0`), we bumped Hive to its latest version `4.2.0`, which includes `grpc-netty-shaded` `1.72.0` and then we bumped `grpc-netty-shaded` independently to `1.76.0`. We believe there are no breaking changes between `grpc-netty-shaded` `1.72.0` and `1.76.0`.

However, `4.2.0` turned out to not be a viable version since it requires Java 21. For that reason, we now bump `hive-service` down to `4.1.0`, since it also has `grpc-netty-shaded` `1.72.0`, but should not break with lower Java versions, as seen in the Apache Hive release notes:
- Apache Hive 4.1.x adds JDK 17 support.
- Apache Hive 4.2.x introduces support for JDK 21 and requires it as the minimum supported Java version.