### PR TITLE
fix[SP-7120]: bump grpc-netty-shaded to 1.76.0 and hive to 4.1.0

### DIFF
--- a/shims/emr770/driver/pom.xml
+++ b/shims/emr770/driver/pom.xml
@@ -14,7 +14,7 @@
 
   <properties>
     <org.apache.avro.version>1.12.0</org.apache.avro.version>
-    <org.apache.hive.version>4.0.1</org.apache.hive.version>
+    <org.apache.hive.version>4.2.0</org.apache.hive.version>
     <org.apache.oozie.version>5.2.1</org.apache.oozie.version>
     <org.apache.hbase.version>2.6.1</org.apache.hbase.version>
     <sqoop.version>1.4.7</sqoop.version>
@@ -703,6 +703,10 @@
           <groupId>org.bouncycastle</groupId>
           <artifactId>bcmail-jdk18on</artifactId>
         </exclusion>
+        <exclusion>
+          <groupId>io.grpc</groupId>
+          <artifactId>grpc-netty-shaded</artifactId>
+        </exclusion>
       </exclusions>
     </dependency>
     <!-- Keep the Bouncy Castle line aligned with the rest of the product until jdk18on is adopted everywhere. -->
@@ -721,6 +725,13 @@
     <dependency>
       <groupId>org.bouncycastle</groupId>
       <artifactId>bcmail-jdk15to18</artifactId>
+    </dependency>
+    <!-- In the future, if hive-service is bumped to a version that includes a safe version of grpc-netty-shaded -->
+    <!-- we should remove the explicit grpc-netty-shaded dependency below, as well as the exclusion above-->
+    <dependency>
+      <groupId>io.grpc</groupId>
+      <artifactId>grpc-netty-shaded</artifactId>
+      <version>1.76.0</version>
     </dependency>
     <dependency>
       <groupId>org.apache.hive.shims</groupId>

--- a/shims/emr770/driver/pom.xml
+++ b/shims/emr770/driver/pom.xml
@@ -14,7 +14,7 @@
 
   <properties>
     <org.apache.avro.version>1.12.0</org.apache.avro.version>
-    <org.apache.hive.version>4.2.0</org.apache.hive.version>
+    <org.apache.hive.version>4.1.0</org.apache.hive.version>
     <org.apache.oozie.version>5.2.1</org.apache.oozie.version>
     <org.apache.hbase.version>2.6.1</org.apache.hbase.version>
     <sqoop.version>1.4.7</sqoop.version>


### PR DESCRIPTION
Original PRs: https://github.com/pentaho/pentaho-hadoop-shims/pull/1808, https://github.com/pentaho/pentaho-hadoop-shims/pull/1849