### PR TITLE
fix[SP-7322]: bump grpc-netty-shaded to 1.76.0 and hive to 4.1.0

### DIFF
--- a/shims/emr770/driver/pom.xml
+++ b/shims/emr770/driver/pom.xml
@@ -16,7 +16,7 @@
     <shim.id>emr770</shim.id>
     <jsr311-api.version>1.1.1</jsr311-api.version>
     <org.apache.avro.version>1.12.0</org.apache.avro.version>
-    <org.apache.hive.version>4.0.1</org.apache.hive.version>
+    <org.apache.hive.version>4.2.0</org.apache.hive.version>
     <org.apache.oozie.version>5.2.1</org.apache.oozie.version>
     <org.apache.hbase.version>2.6.2</org.apache.hbase.version>
     <sqoop.version>1.4.7</sqoop.version>
@@ -748,6 +748,13 @@
     <dependency>
       <groupId>org.bouncycastle</groupId>
       <artifactId>bcmail-jdk15to18</artifactId>
+    </dependency>
+    <!-- In the future, if hive-service is bumped to a version that includes a safe version of grpc-netty-shaded -->
+    <!-- we should remove the explicit grpc-netty-shaded dependency below, as well as the exclusion above-->
+    <dependency>
+      <groupId>io.grpc</groupId>
+      <artifactId>grpc-netty-shaded</artifactId>
+      <version>1.76.0</version>
     </dependency>
     <dependency>
       <groupId>org.apache.hive.shims</groupId>

--- a/shims/emr770/driver/pom.xml
+++ b/shims/emr770/driver/pom.xml
@@ -16,7 +16,7 @@
     <shim.id>emr770</shim.id>
     <jsr311-api.version>1.1.1</jsr311-api.version>
     <org.apache.avro.version>1.12.0</org.apache.avro.version>
-    <org.apache.hive.version>4.2.0</org.apache.hive.version>
+    <org.apache.hive.version>4.1.0</org.apache.hive.version>
     <org.apache.oozie.version>5.2.1</org.apache.oozie.version>
     <org.apache.hbase.version>2.6.2</org.apache.hbase.version>
     <sqoop.version>1.4.7</sqoop.version>

--- a/shims/emr770/driver/pom.xml
+++ b/shims/emr770/driver/pom.xml
@@ -473,11 +473,6 @@
         </exclusion>
       </exclusions>
     </dependency>
-    <dependency>
-      <groupId>io.grpc</groupId>
-      <artifactId>grpc-netty-shaded</artifactId>
-      <version>${grpc-netty.version}</version>
-    </dependency>
 
     <dependency>
       <groupId>org.apache.hadoop</groupId>


### PR DESCRIPTION
Original PRs: https://github.com/pentaho/pentaho-hadoop-shims/pull/1803, https://github.com/pentaho/pentaho-hadoop-shims/pull/1808, https://github.com/pentaho/pentaho-hadoop-shims/pull/1849