### PR TITLE
build[SP-7278]: Remove bouncycastle.version property to force inherit from maven-parent-pom

### DIFF
--- a/shims/apache/driver/pom.xml
+++ b/shims/apache/driver/pom.xml
@@ -30,7 +30,6 @@
     <zookeeper.version>3.9.3</zookeeper.version>
     <bouncycastle.version>1.78</bouncycastle.version>
     <curator.version>5.6.0</curator.version>
-    <bouncycastle.version>1.78</bouncycastle.version>
   </properties>
 
   <dependencies>


### PR DESCRIPTION
⚠️ this also needs https://github.com/pentaho/pentaho-hadoop-shims/pull/1864, that had removed a duplicate of `bouncycastle.version` in same pom.xml file.