### PR TITLE
fix[PPP-6452]: add apache-mina exclusion to jetty-runner dependency

### DIFF
--- a/shims/dataproc1421/driver/pom.xml
+++ b/shims/dataproc1421/driver/pom.xml
@@ -559,6 +559,12 @@
       <artifactId>jetty-runner</artifactId>
       <version>${jetty-hadoop.version}</version>
       <scope>runtime</scope>
+      <exclusions>
+        <exclusion>
+          <groupId>org.apache.mina</groupId>
+          <artifactId>mina-core</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>org.eclipse.jetty.websocket</groupId>


### PR DESCRIPTION
This pull request makes a minor change to the `pom.xml` for the Dataproc 1.4.21 driver shim by excluding the `mina-core` dependency from the `jetty-runner` dependency. This helps prevent potential dependency conflicts or unnecessary transitive dependencies, which was the case, as it pulled mina-core 2.2.7, when the version in maven-parent-poms was 2.2.3.

@pentaho/tatooine_dev 