### PR TITLE
fix[SP-7345]: Exclude bcprov-jdk15on from emr770

### DIFF
--- a/shims/emr770/driver/pom.xml
+++ b/shims/emr770/driver/pom.xml
@@ -441,6 +441,10 @@
           <groupId>ch.qos.logback</groupId>
         </exclusion>
         <exclusion>
+          <groupId>org.bouncycastle</groupId>
+          <artifactId>bcprov-jdk15on</artifactId>
+        </exclusion>
+        <exclusion>
           <artifactId>zookeeper</artifactId>
           <groupId>org.apache.zookeeper</groupId>
         </exclusion>


### PR DESCRIPTION
This pull request makes a minor update to the dependency exclusions in the `shims/emr770/driver/pom.xml` file. The main change is the addition of an exclusion for the `org.bouncycastle:bcprov-jdk15on` dependency.

Dependency management:

* [`shims/emr770/driver/pom.xml`](diffhunk://#diff-cec8a2ee6b8be8e9f02f6b142e99e256654559727034f9bdea7326887deda820R443-R446): Added an exclusion for the `org.bouncycastle:bcprov-jdk15on` library to prevent it from being included as a transitive dependency.