### PR TITLE
fix[SP-7345]: Add explicit dependency to bcprov-jdk15to18

### DIFF
--- a/shims/emr770/driver/pom.xml
+++ b/shims/emr770/driver/pom.xml
@@ -454,6 +454,11 @@
         </exclusion>
       </exclusions>
     </dependency>
+    <!-- Explicit modern Bouncy Castle to override old transitive from hadoop-common -->
+    <dependency>
+      <groupId>org.bouncycastle</groupId>
+      <artifactId>bcprov-jdk15to18</artifactId>
+    </dependency>
     <dependency>
       <groupId>dnsjava</groupId>
       <artifactId>dnsjava</artifactId>

--- a/shims/emr770/driver/pom.xml
+++ b/shims/emr770/driver/pom.xml
@@ -454,11 +454,6 @@
         </exclusion>
       </exclusions>
     </dependency>
-    <!-- Explicit modern Bouncy Castle to override old transitive from hadoop-common -->
-    <dependency>
-      <groupId>org.bouncycastle</groupId>
-      <artifactId>bcprov-jdk15to18</artifactId>
-    </dependency>
     <dependency>
       <groupId>dnsjava</groupId>
       <artifactId>dnsjava</artifactId>
@@ -1090,9 +1085,9 @@
             </resolverFilter>
             <resolverFilter>
               <include>
-                <!--Needed for Pig-->
+                <!-- Direct non-transitive runtime dependencies -->
                 *:antlr-runtime,*:automaton,*:pig,*:sqoop,*:joda-time,*:jython,*:aircompressor,*:netty-*,*:pentaho-shaded-netty,software.amazon.awssdk:*,*:hbase-mapreduce,*:libthrift,
-                *:hive-service-rpc,*:hive-shims-common
+                *:hive-service-rpc,*:hive-shims-common,org.bouncycastle:*
               </include>
               <transitive>false</transitive>
             </resolverFilter>


### PR DESCRIPTION
This fixes emr770 hadoop shim after the exclusion made in the previous PR:  https://github.com/pentaho/pentaho-hadoop-shims/pull/1874