### PR TITLE
[PDI-20910] [Regression][PDI 10.2.0.6] MapReduce jobs fail on CDH 7.1.9 with YARN Exit 143 after protobuf upgrade in CDP shim

### DIFF
--- a/common-base/src/main/java/org/pentaho/big/data/impl/shim/mapreduce/PentahoMapReduceJobBuilderImpl.java
+++ b/common-base/src/main/java/org/pentaho/big/data/impl/shim/mapreduce/PentahoMapReduceJobBuilderImpl.java
@@ -151,6 +151,8 @@ public class PentahoMapReduceJobBuilderImpl extends MapReduceJobBuilderImpl impl
     "pentaho.authentication.default.mapping.server.credentials.kerberos.keytabLocation";
   private static final String MAPRED_MAP_JAVA_OPTS = "mapreduce.map.java.opts";
   private static final String MAPRED_REDUCE_JAVA_OPTS = "mapreduce.reduce.java.opts";
+  @VisibleForTesting
+  static final String PROTOBUF_GENCODE_FLAG = "-Dcom.google.protobuf.use_unsafe_pre22_gencode=true";
   public static final String VARIABLE_SPACE = "variableSpace";
   private final HadoopShim hadoopShim;
   private final LogChannelInterface log;
@@ -483,6 +485,7 @@ public class PentahoMapReduceJobBuilderImpl extends MapReduceJobBuilderImpl impl
     conf.set( LOG_LEVEL, logLevel.toString() );
     configureVariableSpace( conf );
     super.configure( conf );
+    appendProtobufGencodeFlag( conf );
   }
 
   @Override
@@ -658,10 +661,30 @@ public class PentahoMapReduceJobBuilderImpl extends MapReduceJobBuilderImpl impl
 
     // set a string in the job configuration as the serialized variablespace
     conf.setStrings( VARIABLE_SPACE, xmlVariableSpace );
+  }
 
-    //For allowing protobuf compatibility
-    conf.set( MAPRED_MAP_JAVA_OPTS, "-Dcom.google.protobuf.use_unsafe_pre22_gencode=true" );
-    conf.set( MAPRED_REDUCE_JAVA_OPTS, "-Dcom.google.protobuf.use_unsafe_pre22_gencode=true" );
+  /**
+   * Appends the protobuf gencode compatibility flag to the map and reduce JVM opts in {@code conf}.
+   * <p>
+   * This method is intentionally called <em>after</em> {@code super.configure(conf)} so that the flag is applied after
+   * the user-defined property loop in {@link MapReduceJobBuilderImpl#configure(Configuration)} (which can overwrite
+   * earlier {@code conf.set(...)} values). The logic is additive: if the flag is already present (e.g. set via
+   * mapred-site.xml or provided by the user) it is not duplicated.
+   * </p>
+   *
+   * @param conf the Hadoop {@link Configuration} to update
+   */
+  @VisibleForTesting
+  void appendProtobufGencodeFlag( Configuration conf ) {
+    for ( String optKey : new String[] { MAPRED_MAP_JAVA_OPTS, MAPRED_REDUCE_JAVA_OPTS } ) {
+      String existing = conf.get( optKey );
+      if ( existing == null || existing.trim().isEmpty() ) {
+        conf.set( optKey, PROTOBUF_GENCODE_FLAG );
+      } else if ( !existing.contains( PROTOBUF_GENCODE_FLAG ) ) {
+        conf.set( optKey, existing.trim() + " " + PROTOBUF_GENCODE_FLAG );
+      }
+      // flag already present – leave as-is (idempotent)
+    }
   }
 
   @VisibleForTesting

--- a/common-base/src/test/java/org/pentaho/big/data/impl/shim/mapreduce/PentahoMapReduceJobBuilderImplTest.java
+++ b/common-base/src/test/java/org/pentaho/big/data/impl/shim/mapreduce/PentahoMapReduceJobBuilderImplTest.java
@@ -96,6 +96,7 @@ import static org.mockito.Mockito.when;
 /**
  * Created by bryan on 1/12/16.
  */
+@SuppressWarnings( "deprecation" )
 @FixMethodOrder( MethodSorters.NAME_ASCENDING )
 @RunWith( MockitoJUnitRunner.class )
 public class PentahoMapReduceJobBuilderImplTest {
@@ -938,5 +939,91 @@ public class PentahoMapReduceJobBuilderImplTest {
     verify( conf ).set( PentahoMapReduceJobBuilderImpl.MAPREDUCE_APPLICATION_CLASSPATH,
       PentahoMapReduceJobBuilderImpl.CLASSES + mapreduceClasspath );
     verify( distributedCacheUtil ).configureWithKettleEnvironment( conf, fileSystem, kettleEnvInstallDir );
+  }
+
+  // -------------------------------------------------------------------------
+  // Tests for appendProtobufGencodeFlag / protobuf regression fix
+  // -------------------------------------------------------------------------
+
+  @Test
+  public void testAppendProtobufGencodeFlagWhenNoExistingOpts() {
+    // When no JVM opts are configured, the flag must be set on its own.
+    Configuration configuration = mock( Configuration.class );
+    when( configuration.get( "mapreduce.map.java.opts" ) ).thenReturn( null );
+    when( configuration.get( "mapreduce.reduce.java.opts" ) ).thenReturn( null );
+
+    pentahoMapReduceJobBuilder.appendProtobufGencodeFlag( configuration );
+
+    verify( configuration ).set( "mapreduce.map.java.opts",
+      PentahoMapReduceJobBuilderImpl.PROTOBUF_GENCODE_FLAG );
+    verify( configuration ).set( "mapreduce.reduce.java.opts",
+      PentahoMapReduceJobBuilderImpl.PROTOBUF_GENCODE_FLAG );
+  }
+
+  @Test
+  public void testAppendProtobufGencodeFlagAppendsToExistingOpts() {
+    // When user-defined JVM opts already exist the flag must be appended, not replace them.
+    Configuration configuration = mock( Configuration.class );
+    String existingMapOpts = "-Xmx1024m";
+    String existingReduceOpts = "-Xmx2048m -XX:+UseG1GC";
+    when( configuration.get( "mapreduce.map.java.opts" ) ).thenReturn( existingMapOpts );
+    when( configuration.get( "mapreduce.reduce.java.opts" ) ).thenReturn( existingReduceOpts );
+
+    pentahoMapReduceJobBuilder.appendProtobufGencodeFlag( configuration );
+
+    verify( configuration ).set( "mapreduce.map.java.opts",
+      existingMapOpts + " " + PentahoMapReduceJobBuilderImpl.PROTOBUF_GENCODE_FLAG );
+    verify( configuration ).set( "mapreduce.reduce.java.opts",
+      existingReduceOpts + " " + PentahoMapReduceJobBuilderImpl.PROTOBUF_GENCODE_FLAG );
+  }
+
+  @Test
+  public void testAppendProtobufGencodeFlagIsIdempotentWhenFlagAlreadyPresent() {
+    // When the flag is already present in the opts it must not be duplicated.
+    Configuration configuration = mock( Configuration.class );
+    String optsWithFlag = "-Xmx1024m " + PentahoMapReduceJobBuilderImpl.PROTOBUF_GENCODE_FLAG;
+    when( configuration.get( "mapreduce.map.java.opts" ) ).thenReturn( optsWithFlag );
+    when( configuration.get( "mapreduce.reduce.java.opts" ) ).thenReturn( optsWithFlag );
+
+    pentahoMapReduceJobBuilder.appendProtobufGencodeFlag( configuration );
+
+    // conf.set must NOT be called because the flag is already present.
+    verify( configuration, never() ).set( eq( "mapreduce.map.java.opts" ), anyString() );
+    verify( configuration, never() ).set( eq( "mapreduce.reduce.java.opts" ), anyString() );
+  }
+
+  @Test
+  public void testConfigureAppendsProtobufFlagAfterUserDefinedProps() throws Exception {
+    // End-to-end regression test: user-defined mapreduce.map.java.opts must NOT suppress the protobuf flag.
+    when( hadoopShim.getPentahoMapReduceMapRunnerClass() ).thenReturn( "" );
+    pentahoMapReduceJobBuilder.setLogLevel( LogLevel.BASIC );
+    pentahoMapReduceJobBuilder.setInputPaths( new String[ 0 ] );
+    pentahoMapReduceJobBuilder.setOutputPath( "test" );
+    pentahoMapReduceJobBuilder.setResolvedJarUrl( new URL( "file:///" ) );
+
+    // Simulate user setting custom JVM opts in the MR job step.
+    String userMapOpts = "-Xmx1024m";
+    pentahoMapReduceJobBuilder.set( "mapreduce.map.java.opts", userMapOpts );
+
+    // Use a real map to track conf.set() calls so we can inspect the final value.
+    java.util.Map<String, String> confStore = new java.util.HashMap<>();
+    Configuration configuration = mock( Configuration.class );
+    doAnswer( invocation -> {
+      confStore.put( invocation.getArgument( 0 ), invocation.getArgument( 1 ) );
+      return null;
+    } ).when( configuration ).set( anyString(), anyString() );
+    when( configuration.get( anyString() ) ).thenAnswer(
+      invocation -> confStore.get( invocation.getArgument( 0 ) ) );
+
+    when( hadoopShim.getFileSystem( configuration ) ).thenReturn( mock( FileSystem.class ) );
+    pentahoMapReduceJobBuilder.setMapperInfo( transXml, "testMrInput", "testMrOutput" );
+
+    pentahoMapReduceJobBuilder.configure( configuration );
+
+    String finalMapOpts = confStore.get( "mapreduce.map.java.opts" );
+    assertNotNull( "mapreduce.map.java.opts must be set", finalMapOpts );
+    assertTrue( "user opts must be preserved", finalMapOpts.contains( userMapOpts ) );
+    assertTrue( "protobuf flag must be present even when user opts exist",
+      finalMapOpts.contains( PentahoMapReduceJobBuilderImpl.PROTOBUF_GENCODE_FLAG ) );
   }
 }


### PR DESCRIPTION
Here's the analysis of what led to these changes:

The execution flow for a Pentaho MapReduce job goes through two classes:

PentahoMapReduceJobBuilderImpl.configure() → calls configureVariableSpace(conf), then calls super.configure(conf)

MapReduceJobBuilderImpl.configure() (the super) → at the end, iterates over all user-defined properties and calls conf.set(key, value) for each one.

Here is what happens step by step:

1. Step 1 — configureVariableSpace() hard-codes the flag

Inside configureVariableSpace(Configuration conf), we were doing:

conf.set( MAPRED_MAP_JAVA_OPTS, "-Dcom.google.protobuf.use_unsafe_pre22_gencode=true" );
conf.set( MAPRED_REDUCE_JAVA_OPTS, "-Dcom.google.protobuf.use_unsafe_pre22_gencode=true" );
At this point the conf has these properties set to only the gencode flag — any prior values loaded from site files (e.g. mapred-site.xml) are already wiped out by this hard conf.set. Thanks to @andresperezhv for pointing this issue!

2. Step 2 — super.configure() overwrites with user-defined values

Immediately after, MapReduceJobBuilderImpl.configure() runs its user-defined property loop:

// process user defined values
for ( Map.Entry<String, String> stringStringEntry : userDefined.entrySet() ) {
    String key   = stringStringEntry.getKey();
    String value = stringStringEntry.getValue();
    if ( key != null && !"".equals( key ) && value != null && !"".equals( value ) ) {
        conf.set( key, value );   // <-- plain overwrite, no append
    }
}
If the user has mapreduce.map.java.opts set to something like -Xmx1024m,in the user-defined tab, this loop calls conf.set("mapreduce.map.java.opts", "-Xmx1024m") — completely replacing the value that was set in Step 1.

3. Step 3 — Final state in conf
After both steps complete, conf holds:

mapreduce.map.java.opts    = -Xmx1024m          ← gencode flag is gone
mapreduce.reduce.java.opts = -Xmx1024m          ← gencode flag is gone
The protobuf flag is silently dropped. The Mapper JVM starts without it, hits the UnsupportedOperationException inside the protobuf runtime when trying to reach HDFS via ClientNamenodeProtocolTranslatorPB, hangs in retry loops for 600 seconds, and is finally terminated by YARN with Exit 143 (SIGTERM).