### PR TITLE
CVE fix: CVE-2022-44730 in org.apache.xmlgraphics:batik (emr770 & apachevanilla shims)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -172,6 +172,105 @@
         <artifactId>commons-io</artifactId>
         <version>${commons-io.version}</version>
       </dependency>
+      <!--
+        CVE-2022-44730 / CVE-2022-44729 (Apache Batik SSRF, fixed in 1.17):
+        the emr770 and apachevanilla shims transitively pull Batik 1.10 via
+        org.apache.oozie:oozie-client -> oozie-fluent-job-api ->
+        guru.nidi:graphviz-java. Force every batik-* artifact to the
+        platform's already-standard, non-vulnerable ${batik.version} (1.17,
+        inherited from pentaho-parent-pom) so the shims still bundle Batik,
+        just at the fixed version, instead of the vulnerable 1.10.
+      -->
+      <dependency>
+        <groupId>org.apache.xmlgraphics</groupId>
+        <artifactId>batik-anim</artifactId>
+        <version>${batik.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.xmlgraphics</groupId>
+        <artifactId>batik-awt-util</artifactId>
+        <version>${batik.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.xmlgraphics</groupId>
+        <artifactId>batik-bridge</artifactId>
+        <version>${batik.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.xmlgraphics</groupId>
+        <artifactId>batik-codec</artifactId>
+        <version>${batik.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.xmlgraphics</groupId>
+        <artifactId>batik-constants</artifactId>
+        <version>${batik.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.xmlgraphics</groupId>
+        <artifactId>batik-css</artifactId>
+        <version>${batik.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.xmlgraphics</groupId>
+        <artifactId>batik-dom</artifactId>
+        <version>${batik.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.xmlgraphics</groupId>
+        <artifactId>batik-ext</artifactId>
+        <version>${batik.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.xmlgraphics</groupId>
+        <artifactId>batik-gvt</artifactId>
+        <version>${batik.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.xmlgraphics</groupId>
+        <artifactId>batik-i18n</artifactId>
+        <version>${batik.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.xmlgraphics</groupId>
+        <artifactId>batik-rasterizer</artifactId>
+        <version>${batik.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.xmlgraphics</groupId>
+        <artifactId>batik-script</artifactId>
+        <version>${batik.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.xmlgraphics</groupId>
+        <artifactId>batik-svg-dom</artifactId>
+        <version>${batik.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.xmlgraphics</groupId>
+        <artifactId>batik-svggen</artifactId>
+        <version>${batik.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.xmlgraphics</groupId>
+        <artifactId>batik-svgrasterizer</artifactId>
+        <version>${batik.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.xmlgraphics</groupId>
+        <artifactId>batik-transcoder</artifactId>
+        <version>${batik.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.xmlgraphics</groupId>
+        <artifactId>batik-util</artifactId>
+        <version>${batik.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.xmlgraphics</groupId>
+        <artifactId>batik-xml</artifactId>
+        <version>${batik.version}</version>
+      </dependency>
     </dependencies>
   </dependencyManagement>
 

--- a/pom.xml
+++ b/pom.xml
@@ -233,6 +233,11 @@
       </dependency>
       <dependency>
         <groupId>org.apache.xmlgraphics</groupId>
+        <artifactId>batik-parser</artifactId>
+        <version>${batik.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.xmlgraphics</groupId>
         <artifactId>batik-rasterizer</artifactId>
         <version>${batik.version}</version>
       </dependency>


### PR DESCRIPTION
## CVE fix: CVE-2022-44730 in org.apache.xmlgraphics:batik-*

Advisory: CVE-2022-44730 / CVE-2022-44729 (Apache XML Graphics Batik SSRF) -- medium. Fixed upstream in Batik **1.17**.
Change: Apache Batik `1.10` -> `1.17` (the platform-standard, already-inherited version).
Fix point: `dependencyManagement` pin of every `batik-*` artifact to the inherited `${batik.version}` (1.17) in the repo root `pom.xml`.

### Root cause
The `emr770` and `apachevanilla` shim assemblies bundled Apache Batik **1.10**, pulled transitively via:

```
org.apache.oozie:oozie-client:5.2.1
  -> oozie-fluent-job-api:5.2.1
    -> guru.nidi:graphviz-java:0.7.0
      -> org.apache.xmlgraphics:batik-rasterizer:1.10  (+ the whole batik 1.10 tree)
```

This repo inherits `${batik.version}=1.17` from `pentaho-parent-pom`, but had **no batik `dependencyManagement`**, so the platform-standard version was never applied to this transitive path. `dataproc23`/`cdpdc71` shims are unaffected (their Hadoop-distro trees don't pull batik). This surfaced in `pentaho-big-data-ee-plugin-*-{emr,apachevanilla}.zip` on `pdia-master`.

### The change
A single `dependencyManagement` block in the root `pom.xml` pinning every `batik-*` artifact to `${batik.version}`. Batik stays bundled in the shims -- now at the non-vulnerable **1.17** instead of 1.10. The assembly `zip.xml` exclude lists are **unchanged** (`batik-bridge`/`batik-transcoder`/`batik-svgrasterizer` remain excluded, exactly as before).

### Dependency tree (before -> after)
`mvn dependency:tree` on both driver modules: every `org.apache.xmlgraphics:batik-*` node was `1.10`, now resolves to `1.17`. Vulnerable 1.10 absent on all paths.

Note: Batik re-modularized between 1.10 and 1.17, so the number of `batik-*` jars in each shim zip is smaller after the bump (1.17's `batik-codec`/`batik-rasterizer` pull fewer fine-grained transitive modules; a new `batik-shared-resources` appears). This is a consequence of the upgrade, not an intentional removal.

### Verification
- Rebuilt both shim assemblies (JDK 21): **BUILD SUCCESS**.
- `unzip -l` of both zips: only `batik-*-1.17.jar` present, **no 1.10** remaining.
- Compatibility researched: the sole batik consumer in the tree, `graphviz-java` 0.7.0, uses batik only as an optional rasterizer via the foundational Transcoder API (stable since Batik 1.6) and is fully compatible with 1.17 -- no dependent upgrade needed. Pentaho's first-party batik callers (`pentaho-kettle`, `pentaho-platform`, `pentaho-reporting`) already run on 1.17 today.

### Review
Fixed and reviewed locally via codemedic-local-remediator before push.