### PR TITLE
build[PPP-6612]: Bump version of micrometer-core dependency to 1.15.12

### DIFF
--- a/shims/emr770/driver/pom.xml
+++ b/shims/emr770/driver/pom.xml
@@ -758,6 +758,11 @@
       <artifactId>grpc-netty-shaded</artifactId>
       <version>1.76.0</version>
     </dependency>
+    <dependency>
+      <groupId>io.micrometer</groupId>
+      <artifactId>micrometer-core</artifactId>
+      <version>1.15.12</version>
+    </dependency>
     <!-- Keep the Bouncy Castle line aligned with the rest of the product until jdk18on is adopted everywhere. -->
     <dependency>
       <groupId>org.bouncycastle</groupId>


### PR DESCRIPTION
### Jira
[PPP-6612](https://hv-eng.atlassian.net/browse/PPP-6612) — CVE-2026-40984 | BigData has a security violation in micrometer-core

### What
Pin `io.micrometer:micrometer-core` to the fixed **1.15.12** in the EMR 7.7 shim driver (`shims/emr770/driver/pom.xml`).

### Why
`hive-service:4.2.0` → `spring-ldap-core:3.3.8` transitively pulls `micrometer-core:1.14.14`, which is inside the vulnerable range of **CVE-2026-40984** (DoS via crafted HTTP requests, CVSS 7.5). The EMR bundle was shipping `micrometer-core-1.14.10/1.14.14.jar` under `pentaho-big-data-plugin/hadoop-configurations/emr770/lib/`.

An explicit, nearer-depth dependency overrides the transitive version. `1.15.12` is a fixed release and aligns with `micrometer-observation:1.15.12` already present on the path, keeping the whole micrometer family (`core`/`commons`/`observation`) on one consistent, non-vulnerable version.

### How tested
- `mvn -pl shims/emr770/driver -am dependency:tree -Dincludes=io.micrometer` → resolves `micrometer-core/commons/observation` all to `1.15.12`.
- `mvn -pl shims/emr770/driver -am package` → BUILD SUCCESS; built bundle contains only `micrometer-core-1.15.12.jar` (no `1.14.x`).


[PPP-6612]: https://hv-eng.atlassian.net/browse/PPP-6612?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ