### PR TITLE
CVE fix: CVE-2025-67721 in io.airlift:aircompressor (0.27 -> 2.0.3)

### DIFF
--- a/shim-api/pom.xml
+++ b/shim-api/pom.xml
@@ -34,6 +34,15 @@
         </exclusion>
       </exclusions>
     </dependency>
+    <!-- CVE-2025-67721: pin io.airlift:aircompressor (transitive via orc-core) to the
+         fixed 2.0.3. orc-core ${org.apache.orc.version} still pulls the vulnerable 0.27;
+         this explicit direct pin overrides it here and, via nearest-wins, in downstream
+         consumers of shim-api (e.g. pentaho-war). Remove once orc-core ships aircompressor >= 2.0.3. -->
+    <dependency>
+      <groupId>io.airlift</groupId>
+      <artifactId>aircompressor</artifactId>
+      <version>2.0.3</version>
+    </dependency>
     <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-core</artifactId>

--- a/shims/apachevanilla/driver/pom.xml
+++ b/shims/apachevanilla/driver/pom.xml
@@ -496,7 +496,7 @@
     <dependency>
       <groupId>io.airlift</groupId>
       <artifactId>aircompressor</artifactId>
-      <version>0.27</version>
+      <version>2.0.3</version>
       <exclusions>
         <exclusion>
           <groupId>*</groupId>

--- a/shims/cdpdc71/driver/pom.xml
+++ b/shims/cdpdc71/driver/pom.xml
@@ -482,7 +482,7 @@
     <dependency>
       <groupId>io.airlift</groupId>
       <artifactId>aircompressor</artifactId>
-      <version>0.27</version>
+      <version>2.0.3</version>
     </dependency>
     <dependency>
       <groupId>org.apache.sqoop</groupId>

--- a/shims/dataproc1421/driver/pom.xml
+++ b/shims/dataproc1421/driver/pom.xml
@@ -242,7 +242,7 @@
     <dependency>
       <groupId>io.airlift</groupId>
       <artifactId>aircompressor</artifactId>
-      <version>0.27</version>
+      <version>2.0.3</version>
       <exclusions>
         <exclusion>
           <groupId>*</groupId>

--- a/shims/dataproc23/driver/pom.xml
+++ b/shims/dataproc23/driver/pom.xml
@@ -245,7 +245,7 @@
     <dependency>
       <groupId>io.airlift</groupId>
       <artifactId>aircompressor</artifactId>
-      <version>0.27</version>
+      <version>2.0.3</version>
       <exclusions>
         <exclusion>
           <groupId>*</groupId>

--- a/shims/emr521/driver/pom.xml
+++ b/shims/emr521/driver/pom.xml
@@ -171,7 +171,7 @@
     <dependency>
       <groupId>io.airlift</groupId>
       <artifactId>aircompressor</artifactId>
-      <version>0.27</version>
+      <version>2.0.3</version>
     </dependency>
     <dependency>
       <groupId>org.apache.avro</groupId>

--- a/shims/emr700/driver/pom.xml
+++ b/shims/emr700/driver/pom.xml
@@ -560,7 +560,7 @@
     <dependency>
       <groupId>io.airlift</groupId>
       <artifactId>aircompressor</artifactId>
-      <version>0.27</version>
+      <version>2.0.3</version>
     </dependency>
     <dependency>
       <groupId>org.apache.avro</groupId>

--- a/shims/emr770/driver/pom.xml
+++ b/shims/emr770/driver/pom.xml
@@ -621,7 +621,7 @@
     <dependency>
       <groupId>io.airlift</groupId>
       <artifactId>aircompressor</artifactId>
-      <version>0.27</version>
+      <version>2.0.3</version>
     </dependency>
     <dependency>
       <groupId>org.apache.avro</groupId>

--- a/shims/hdi40/driver/pom.xml
+++ b/shims/hdi40/driver/pom.xml
@@ -269,7 +269,7 @@
     <dependency>
       <groupId>io.airlift</groupId>
       <artifactId>aircompressor</artifactId>
-      <version>0.27</version>
+      <version>2.0.3</version>
       <exclusions>
         <exclusion>
           <groupId>*</groupId>


### PR DESCRIPTION
## CVE fix: CVE-2025-67721 in io.airlift:aircompressor

Advisory: CVE-2025-67721 / GHSA-vx9q-rhv9-3jvg -- **High** (CWE-125/CWE-201)
Jira: PPP-6257

**Change:** `io.airlift:aircompressor` `0.27` -> `2.0.3` (minimal clearing version on this coordinate's line).

The Java Snappy/LZ4 decompressors in aircompressor can leak reused output-buffer contents to the uncompressed output for crafted input. Fixed upstream in **2.0.3** on the `io.airlift:aircompressor` line. (The advisory's other fixed version, `3.4`, applies to the *separate* `io.airlift:aircompressor-v3` coordinate -- not this one, so 2.0.3 is the correct target here.)

This PR fixes **both** shipping surfaces of aircompressor-0.27 in the `pdia-master 11.1.0.0-326` build, both sourced from this repo:

### Surface 1 -- shim drivers (hadoop-configurations/*/lib)
`aircompressor` is a direct dependency of the ORC codec path (`<!-- used by org.apache.orc -->`) declared as a literal version in each shim driver POM. Bumped in all 8 driver POMs that pinned `0.27`:

| Shim driver | In default `all` build profile? | ORC line |
|---|---|---|
| `shims/apachevanilla/driver` | yes (shipped) | 1.9.6 |
| `shims/cdpdc71/driver` | yes (shipped) | 1.5.1.7.1.4.0-203 |
| `shims/dataproc23/driver` | yes (shipped) | |
| `shims/dataproc1421/driver` | yes (shipped) | |
| `shims/emr770/driver` | yes (shipped) | |
| `shims/emr700/driver` | no active profile | |
| `shims/emr521/driver` | no active profile | |
| `shims/hdi40/driver` | module commented out | |

Covers the flagged impact paths `pentaho-big-data-ee-plugin-11.1.0.0-*-{apachevanilla,cdp,dataproc,emr}.zip/.../hadoop-configurations/{apachevanilla,cdpdc71,dataproc23,emr770}/lib/aircompressor-0.27.jar`. The 3 inactive/dead shims were bumped too for repo consistency so the pin cannot re-surface if a profile is reactivated.

### Surface 2 -- shim-api (server WEB-INF/lib, CE + EE)
`shim-api` declares `orc-core` (1.9.6), which pulls `aircompressor:0.27` **transitively**. `pentaho-platform`'s `pentaho-war` depends on `shim-api` (compile), so `aircompressor-0.27.jar` shipped in `pentaho.war/WEB-INF/lib` of:
- `pentaho-server-ce` / `pentaho-server-manual-ce` (unpack the CE `pentaho-war`)
- `pentaho-server-ee` / `pentaho-server-manual-ee` (`pentaho-war-ee` unpacks the CE `pentaho-war` as its base, then layers EE extras)

Fixed by adding an explicit direct `io.airlift:aircompressor:2.0.3` in `shim-api/pom.xml`, which resolves to the fixed version here and, via Maven nearest-wins, in every downstream consumer of `shim-api` (both server WARs). No change is needed in `pentaho-platform`/`pentaho-platform-ee` (neither declares aircompressor/orc-core).

Non-war assemblies were checked and are clean: `pentaho-big-data-ee` `ee-shim-base` already **excludes** `aircompressor`+`orc-core` (so the OSGi/`pmr` assembly does not ship it on 11.1.0.0), and `big-data-plugin` has no aircompressor reference.

### Compatibility (drop-in, no code change)
- `Compressor`/`Decompressor` interfaces are byte-identical between 0.27 and 2.0.3 (same `io.airlift.compress` package -- the rename to `io.airlift.compress.v3` / `aircompressor-v3` only happened at 3.0).
- The no-arg `LzoCompressor/Decompressor`, `Lz4Compressor/Decompressor`, `ZstdCompressor/Decompressor` classes ORC constructs still exist in the same packages with the same signatures.
- 2.0.3 targets Java 8 bytecode (parent `airbase:112`), so it is runtime-safe on the JDK 17 train.

### Dependency tree (before -> after)
```
apachevanilla driver:  orc-core:1.9.6              + aircompressor:0.27  ->  2.0.3   (direct pin)
cdpdc71 driver:        orc-core:1.5.1.7.1.4.0-203  + aircompressor:0.27  ->  2.0.3   (direct pin)
shim-api:              orc-core:1.9.6 -> aircompressor:0.27  ->  aircompressor:2.0.3 (nearest-wins over orc-core transitive)
```
`mvn dependency:tree` on all three: BUILD SUCCESS, no `0.27` remains on any path. Both distinct ORC lines (modern 1.9.x and legacy Cloudera 1.5.x) verified.

### Tests
`aircompressor` has no first-party caller in this repo (it is a runtime dependency of third-party ORC), so there is no unit-test surface to harden. The before/after dependency-tree resolution is the applicable proof for this runtime-jar bump.

### Review
Fixed and reviewed locally via codemedic-local-remediator before push.