### PR TITLE
fix[PPP-6766]: temporarily force jackson-databind 2.18.8 in shims that have hive-jdbc 3.x and 4.x

### DIFF
--- a/shims/cdpdc71/driver/pom.xml
+++ b/shims/cdpdc71/driver/pom.xml
@@ -225,6 +225,12 @@
         </exclusion>
       </exclusions>
     </dependency>
+    <!-- Temporary override; delete once hive-jdbc releases a version without these vulnerabilities. -->
+    <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-databind</artifactId>
+      <version>${fasterxml-jackson-databind.version}</version>
+    </dependency>
     <dependency>
       <groupId>org.apache.hadoop</groupId>
       <artifactId>hadoop-client</artifactId>

--- a/shims/dataproc23/driver/pom.xml
+++ b/shims/dataproc23/driver/pom.xml
@@ -352,6 +352,12 @@
         </exclusion>
       </exclusions>
     </dependency>
+    <!-- Temporary override; delete once hive-jdbc releases a version without these vulnerabilities. -->
+    <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-databind</artifactId>
+      <version>${fasterxml-jackson-databind.version}</version>
+    </dependency>
 
     <dependency>
       <groupId>org.apache.hadoop</groupId>

--- a/shims/emr700/driver/pom.xml
+++ b/shims/emr700/driver/pom.xml
@@ -613,6 +613,12 @@
       <artifactId>hive-jdbc</artifactId>
       <version>${org.apache.hive.version}</version>
     </dependency>
+    <!-- Temporary override; delete once hive-jdbc releases a version without these vulnerabilities. -->
+    <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-databind</artifactId>
+      <version>${fasterxml-jackson-databind.version}</version>
+    </dependency>
     <dependency>
       <groupId>org.apache.hive</groupId>
       <artifactId>hive-exec</artifactId>

--- a/shims/emr770/driver/pom.xml
+++ b/shims/emr770/driver/pom.xml
@@ -673,6 +673,12 @@
       <artifactId>hive-jdbc</artifactId>
       <version>${org.apache.hive.version}</version>
     </dependency>
+    <!-- Temporary override; delete once hive-jdbc releases a version without these vulnerabilities. -->
+    <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-databind</artifactId>
+      <version>${fasterxml-jackson-databind.version}</version>
+    </dependency>
     <dependency>
       <groupId>org.apache.hive</groupId>
       <artifactId>hive-exec</artifactId>

--- a/shims/hdi40/driver/pom.xml
+++ b/shims/hdi40/driver/pom.xml
@@ -219,6 +219,12 @@
       </exclusions>
       <version>${org.apache.hive.version}</version>
     </dependency>
+    <!-- Temporary override; delete once hive-jdbc releases a version without these vulnerabilities. -->
+    <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-databind</artifactId>
+      <version>${fasterxml-jackson-databind.version}</version>
+    </dependency>
     <dependency>
       <groupId>org.bouncycastle</groupId>
       <artifactId>bcpkix-jdk18on</artifactId>


### PR DESCRIPTION
We added an explicit `jackson-databind` 2.18.x dependency for the shims that use Hive 3.x and 4.x, because those shims were resolving a vulnerable Jackson version transitively through the Hive dependency stack, and the explicit dependency forces Maven to use the safer version instead.

We will use `jackson-databind` 2.18.x instead of 2.22.x for this temporary fix. We could move to 2.22.x to pick up additional Jackson vulnerability fixes, but that would also introduce a larger compatibility jump in the Hive shim dependency stack. Since this change is only meant to address the current issue, we are staying on 2.18.x rather than taking the broader upgrade. This is a very temporary workaround and not an ideal long-term solution.

The `jackson-databind` vulnerabilities will remain in `dataproc1421` and `emr521` for now because those two shims are tied to Hive 2.x. In those shims, Jackson comes through the older Hive 2.x dependency stack, and fixing it is not a simple, isolated Jackson change. A Hive 2.x JDBC bump would change the full Hive client stack for vendor-specific older platforms, which creates a real compatibility risk with the clusters those shims are meant to support. It also would not get us far enough: the highest Hive 2.x only moves Jackson to roughly 2.12.0, still short of the safer 2.18.x line. So the risk of breaking those legacy shims is higher than the benefit of the partial upgrade.