### PR TITLE
CVE fix: CVE-2026-45536 in io.netty:netty-transport-native-epoll

### DIFF
--- a/shims/apachevanilla/driver/pom.xml
+++ b/shims/apachevanilla/driver/pom.xml
@@ -662,6 +662,33 @@
         </exclusion>
       </exclusions>
     </dependency>
+    <!-- CVE-2026-45536: pin the main (no-classifier) netty-transport-native-epoll and its
+         BOM-aligned netty-transport-classes-epoll companion to ${netty.version}. They
+         otherwise leak in transitively from the hadoop client stack at an older,
+         vulnerable netty line (< 4.1.135.Final). Remove once that stack ships
+         netty >= 4.1.135. -->
+    <dependency>
+      <groupId>io.netty</groupId>
+      <artifactId>netty-transport-native-epoll</artifactId>
+      <version>${netty.version}</version>
+      <exclusions>
+        <exclusion>
+          <groupId>*</groupId>
+          <artifactId>*</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+    <dependency>
+      <groupId>io.netty</groupId>
+      <artifactId>netty-transport-classes-epoll</artifactId>
+      <version>${netty.version}</version>
+      <exclusions>
+        <exclusion>
+          <groupId>*</groupId>
+          <artifactId>*</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
     <dependency>
       <groupId>org.apache.hadoop</groupId>
       <artifactId>hadoop-mapreduce-client-app</artifactId>

--- a/shims/cdpdc71/driver/pom.xml
+++ b/shims/cdpdc71/driver/pom.xml
@@ -595,6 +595,33 @@
       <version>${netty.version}</version>
       <classifier>linux-x86_64</classifier>
     </dependency>
+    <!-- CVE-2026-45536: pin the main (no-classifier) netty-transport-native-epoll and its
+         BOM-aligned netty-transport-classes-epoll companion to ${netty.version}. They
+         otherwise leak in transitively from the hadoop client stack at an older,
+         vulnerable netty line (< 4.1.135.Final). Remove once that stack ships
+         netty >= 4.1.135. -->
+    <dependency>
+      <groupId>io.netty</groupId>
+      <artifactId>netty-transport-native-epoll</artifactId>
+      <version>${netty.version}</version>
+      <exclusions>
+        <exclusion>
+          <groupId>*</groupId>
+          <artifactId>*</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+    <dependency>
+      <groupId>io.netty</groupId>
+      <artifactId>netty-transport-classes-epoll</artifactId>
+      <version>${netty.version}</version>
+      <exclusions>
+        <exclusion>
+          <groupId>*</groupId>
+          <artifactId>*</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
     <dependency>
       <groupId>org.apache.ranger</groupId>
       <artifactId>ranger-raz-hook-s3</artifactId>

--- a/shims/dataproc1421/driver/pom.xml
+++ b/shims/dataproc1421/driver/pom.xml
@@ -193,6 +193,22 @@
         </exclusion>
       </exclusions>
     </dependency>
+    <!-- CVE-2026-45536: pin the main (no-classifier) netty-transport-native-epoll to
+         ${netty.version}. It otherwise leaks in transitively from the hadoop client
+         stack at an older, vulnerable netty line (< 4.1.135.Final). The BOM-aligned
+         netty-transport-classes-epoll companion is already pinned below. Remove once
+         that stack ships netty >= 4.1.135. -->
+    <dependency>
+      <groupId>io.netty</groupId>
+      <artifactId>netty-transport-native-epoll</artifactId>
+      <version>${netty.version}</version>
+      <exclusions>
+        <exclusion>
+          <groupId>*</groupId>
+          <artifactId>*</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
     <dependency>
       <groupId>org.apache.hadoop</groupId>
       <artifactId>hadoop-yarn-api</artifactId>

--- a/shims/dataproc23/driver/pom.xml
+++ b/shims/dataproc23/driver/pom.xml
@@ -192,6 +192,22 @@
         </exclusion>
       </exclusions>
     </dependency>
+    <!-- CVE-2026-45536: pin the main (no-classifier) netty-transport-native-epoll to
+         ${netty.version}. It otherwise leaks in transitively from the hadoop client
+         stack at an older, vulnerable netty line (< 4.1.135.Final). The BOM-aligned
+         netty-transport-classes-epoll companion is already pinned below. Remove once
+         that stack ships netty >= 4.1.135. -->
+    <dependency>
+      <groupId>io.netty</groupId>
+      <artifactId>netty-transport-native-epoll</artifactId>
+      <version>${netty.version}</version>
+      <exclusions>
+        <exclusion>
+          <groupId>*</groupId>
+          <artifactId>*</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
     <dependency>
       <groupId>org.apache.hadoop</groupId>
       <artifactId>hadoop-yarn-api</artifactId>


### PR DESCRIPTION
## CVE fix: CVE-2026-45536 in io.netty:netty-transport-native-epoll

Tracking: [PPP-6591](https://pentaho-eng.atlassian.net/browse/PPP-6591)
Advisory: CVE-2026-45536 / GHSA-w573-9ffj-6ff9 -- Medium (CWE-200, CWE-772; file-descriptor leak in native `recvFd` via `SCM_RIGHTS` on Epoll/KQueue DomainSocketChannel in `DomainSocketReadMode.FILE_DESCRIPTORS`)
Change: `io.netty:netty-transport-native-epoll` 4.1.100.Final / 4.1.127.Final -> **4.1.135.Final** (`${netty.version}`; a minimal clearing version -- fixed line is 4.1.135(.Final) / 4.2.15(.Final))

### Root cause
Each shim driver already pins the full netty family to `${netty.version}` (= 4.1.135.Final, already safe), but two members were missed and leaked in **transitively** from the hadoop client stack (`hadoop-common`) at an older, vulnerable line:
- the **main (no-classifier)** `netty-transport-native-epoll` (4.1.100.Final in apachevanilla/dataproc, 4.1.127.Final in cdpdc71) -- the CVE-flagged jar; the explicit pin only covered the `linux-x86_64` classifier variant, and
- its BOM-aligned `netty-transport-classes-epoll` (4.1.114.Final in apachevanilla/cdpdc71) -- must be version-aligned with the native artifact (netty is BOM-aligned).

### Fix point(s)
Explicit direct `<dependency>` pins at `${netty.version}` with `*:*` exclusions (matching the repo's existing netty-family convention), in the affected shim driver POMs (paths: `hadoop-configurations/<distro>/lib/`):
- `shims/apachevanilla/driver/pom.xml` -- pin main-epoll + classes-epoll
- `shims/cdpdc71/driver/pom.xml` -- pin main-epoll + classes-epoll
- `shims/dataproc23/driver/pom.xml` -- pin main-epoll (classes-epoll already pinned)
- `shims/dataproc1421/driver/pom.xml` -- pin main-epoll (classes-epoll already pinned)

`dataproc1421` was not in the flagged impact paths but is an active/shipped shim with the identical vulnerable 4.1.100.Final; included so the CVE does not resurface on the next scan. `emr770` was already at 4.1.135.Final (untouched); `emr700`/`emr521`/`hdi40` are dead/commented-out shims.

### Dependency tree (before -> after)
`mvn dependency:tree -Dincludes=io.netty` per driver (`${netty.version}` = 4.1.135.Final):

Before (apachevanilla, representative):
```
+- org.apache.hadoop:hadoop-common:jar:3.4.0:compile
|  \- io.netty:netty-transport-native-epoll:jar:4.1.100.Final:compile   <-- vulnerable
   io.netty:netty-transport-classes-epoll:jar:4.1.114.Final:compile      <-- skewed
+- io.netty:netty-transport-native-epoll:jar:linux-x86_64:4.1.135.Final:compile
```
After (all four drivers):
```
+- io.netty:netty-transport-native-epoll:jar:4.1.135.Final:compile
+- io.netty:netty-transport-classes-epoll:jar:4.1.135.Final:compile
+- io.netty:netty-transport-native-epoll:jar:linux-x86_64:4.1.135.Final:compile
   \- io.netty:netty-transport-native-unix-common:jar:4.1.135.Final:compile
```
No `io.netty` epoll artifact resolves below 4.1.135.Final on any path; `netty-transport-native-unix-common` remains present at 4.1.135.Final; the netty duplicate-declaration warning is resolved.

### Tests
Config/POM-only change to shipped transitive jars; no first-party code exercises netty `DomainSocketReadMode.FILE_DESCRIPTORS`. Per this repo's convention (assembly/driver modules have no unit tests), the RED baseline and green proof are the before/after `dependency:tree` above (JDK 17 for resolution). Same-line 4.1.x patch bump, binary-compatible; aligns the previously-skewed epoll artifacts with the rest of the family (already at 4.1.135.Final), reducing existing skew.

### Review
Fixed and reviewed locally via codemedic-local-remediator before push.