### PR TITLE
CVE fix: CVE-2018-1313 in org.apache.derby:derby

### DIFF
--- a/shims/dataproc1421/driver/src/main/assembly/zip.xml
+++ b/shims/dataproc1421/driver/src/main/assembly/zip.xml
@@ -156,6 +156,8 @@
                 <exclude>*:velocity-engine-core:*</exclude>
                 <exclude>*:xml-apis-ext:*</exclude>
                 <exclude>*:*slf4j*:*</exclude>
+                <!-- CVE-2018-1313 fix: derby is an unused Hive metastore embedded DB transitive (via hive-exec/hive-service); exclude it as sibling shims apachevanilla and emr770 already do -->
+                <exclude>*:derby:*</exclude>
             </excludes>
         </dependencySet>
         <dependencySet>
@@ -294,6 +296,8 @@
                 <exclude>*:*slf4j*:*</exclude>
                 <!-- CVE-2025-59419 fix: Exclude vulnerable hbase-shaded-netty, replaced by pentaho-shaded-netty -->
                 <exclude>org.apache.hbase.thirdparty:hbase-shaded-netty:*</exclude>
+                <!-- CVE-2018-1313 fix: derby is an unused Hive metastore embedded DB transitive (via hive-exec/hive-service); exclude it as sibling shims apachevanilla and emr770 already do -->
+                <exclude>*:derby:*</exclude>
             </excludes>
         </dependencySet>
     </dependencySets>

--- a/shims/dataproc23/driver/src/main/assembly/zip.xml
+++ b/shims/dataproc23/driver/src/main/assembly/zip.xml
@@ -155,6 +155,8 @@
                 <exclude>*:velocity-engine-core:*</exclude>
                 <exclude>*:xml-apis-ext:*</exclude>
                 <exclude>*:*slf4j*:*</exclude>
+                <!-- CVE-2018-1313 fix: derby is an unused Hive metastore embedded DB transitive (via hive-exec/hive-service); exclude it as sibling shims apachevanilla and emr770 already do -->
+                <exclude>*:derby:*</exclude>
             </excludes>
         </dependencySet>
         <dependencySet>
@@ -296,6 +298,8 @@
                 <exclude>*:*slf4j*:*</exclude>
                 <!-- CVE-2025-59419 fix: Exclude vulnerable hbase-shaded-netty, replaced by pentaho-shaded-netty -->
                 <exclude>org.apache.hbase.thirdparty:hbase-shaded-netty:*</exclude>
+                <!-- CVE-2018-1313 fix: derby is an unused Hive metastore embedded DB transitive (via hive-exec/hive-service); exclude it as sibling shims apachevanilla and emr770 already do -->
+                <exclude>*:derby:*</exclude>
             </excludes>
         </dependencySet>
     </dependencySets>


### PR DESCRIPTION
## CVE fix: CVE-2018-1313 in org.apache.derby:derby

Tracking: Jira PPP-6539 (https://pentaho-eng.atlassian.net/browse/PPP-6539) · build pdia-master@11.1.0.0-331
Advisory: CVE-2018-1313 / GHSA-42xw-p62x-hwcf -- Medium (CVSS 5.3, CWE-284). Apache Derby 10.3.1.4-10.14.1.0: a crafted network packet can make the Derby Network Server boot an attacker-controlled database when the default permissive policy is in effect.
Change: remove the vulnerable `org.apache.derby:derby:10.14.1.0` from the shipped shim `lib/` (it is not the minimal-bump case -- see below).
Fix point(s): assembly descriptors `shims/dataproc23/driver/src/main/assembly/zip.xml` and `shims/dataproc1421/driver/src/main/assembly/zip.xml` (both compile + runtime dependencySets).

### Root cause / scope (derived from the dependency tree, not the ticket)
No pentaho POM declares derby `10.14.1.0`; it enters **only transitively** as the Hive metastore embedded DB:

```
org.apache.hive:hive-exec:3.1.3  (and hive-service:3.1.3)
  -> org.apache.hive:hive-metastore:3.1.3
       -> org.apache.derby:derby:10.14.1.0
```

The Hive metastore's embedded Derby runs server-side on the cluster and is unused by the client-side shim. The `dataproc23` and `dataproc1421` assemblies already exclude the rest of that metastore stack (`datanucleus-core`, `commons-dbcp2`, `avatica`, `calcite-*`) but were missing the `derby` exclude, while the sibling `apachevanilla` and `emr770` shims already exclude `*:derby:*`. This is assembly-descriptor drift, so the fix is to exclude derby (removing the exposure entirely) rather than ship a newer-but-still-unnecessary DB via a version bump. `cdpdc71` carries a non-vulnerable `10.14.3.0-cloudera1` and is left untouched.

### Dependency tree / packaging (before -> after)
Built both driver assemblies (JDK 17, `mvn -pl shims/dataproc23/driver,shims/dataproc1421/driver -am package`, BUILD SUCCESS):

- Before: `dataproc23/lib/derby-10.14.1.0.jar` present (3.2 MB); 438 jars in `lib/`.
- After: derby **absent** from both `pentaho-hadoop-shims-dataproc23` and `pentaho-hadoop-shims-dataproc1421` zips. `dataproc23/lib/` diff shows **only** `derby-10.14.1.0.jar` removed (439 -> 438) -- no other jar affected.

This propagates to `pentaho-big-data-ee-plugin-...-dataproc.zip`, which repackages the shim `lib/`.

### Tests
No unit test applies -- this is an assembly-packaging change. The proof is the assembly build itself: baseline confirmed the vulnerable jar shipped, and the post-fix build confirms it is gone with zero collateral removal. Approach matches the prior json-io CVE-2023-34610 shim-exclude precedent.

### Review
Fixed and reviewed locally via codemedic-local-remediator before push.