### PR TITLE
CVE fix: CVE-2025-3588 in org.jsonschema2pojo:jsonschema2pojo-core (exclude, not bump)

### DIFF
--- a/shims/cdpdc71/driver/pom.xml
+++ b/shims/cdpdc71/driver/pom.xml
@@ -48,10 +48,6 @@
     <!-- Libthrift version must match the version used by Cloudera to support http based Hive Connection -->
     <org.apache.thrift.version>0.16.0</org.apache.thrift.version>
     <velocity-engine-core.version>2.4.1</velocity-engine-core.version>
-    <!-- PPP-6534 / CVE-2025-3588: pin jsonschema2pojo-core off the vulnerable 1.0.2. Pulled transitively
-         (runtime) via hive-jdbc -> hive-shims -> hadoop-yarn-server-resourcemanager. Remove once the
-         vendor Hadoop/Hive distribution ships a version without the vulnerable 1.0.2. -->
-    <jsonschema2pojo.version>1.3.3</jsonschema2pojo.version>
   </properties>
 
   <dependencyManagement>
@@ -227,6 +223,19 @@
           <groupId>org.apache.avro</groupId>
           <artifactId>avro-ipc-jetty</artifactId>
         </exclusion>
+        <!-- PPP-6534 / CVE-2025-3588: exclude jsonschema2pojo-core + its only child codemodel.
+             Transitive-only (runtime) via hive-shims -> hadoop-yarn-server-resourcemanager, which is
+             itself already stripped from the shim assembly; the client shim never invokes this codegen
+             library, so excluding it removes the vulnerable jar from the shipped lib/ (and the build tree)
+             without shipping a heavier jsonschema2pojo 1.3.x closure (Jackson 3, etc.). -->
+        <exclusion>
+          <groupId>org.jsonschema2pojo</groupId>
+          <artifactId>jsonschema2pojo-core</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>com.sun.codemodel</groupId>
+          <artifactId>codemodel</artifactId>
+        </exclusion>
       </exclusions>
     </dependency>
     <!-- Temporary override; delete once hive-jdbc releases a version without these vulnerabilities. -->
@@ -234,15 +243,6 @@
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-databind</artifactId>
       <version>${fasterxml-jackson-databind.version}</version>
-    </dependency>
-    <!-- PPP-6534 / CVE-2025-3588: force jsonschema2pojo-core off the vulnerable 1.0.2 (transitive runtime
-         dep via hive-jdbc -> hive-shims -> hadoop-yarn-server-resourcemanager). This explicit direct pin is
-         the regression guard; delete once the vendor Hadoop/Hive distribution ships a fixed version. -->
-    <dependency>
-      <groupId>org.jsonschema2pojo</groupId>
-      <artifactId>jsonschema2pojo-core</artifactId>
-      <version>${jsonschema2pojo.version}</version>
-      <scope>runtime</scope>
     </dependency>
     <dependency>
       <groupId>org.apache.hadoop</groupId>

--- a/shims/cdpdc71/driver/pom.xml
+++ b/shims/cdpdc71/driver/pom.xml
@@ -48,6 +48,10 @@
     <!-- Libthrift version must match the version used by Cloudera to support http based Hive Connection -->
     <org.apache.thrift.version>0.16.0</org.apache.thrift.version>
     <velocity-engine-core.version>2.4.1</velocity-engine-core.version>
+    <!-- PPP-6534 / CVE-2025-3588: pin jsonschema2pojo-core off the vulnerable 1.0.2. Pulled transitively
+         (runtime) via hive-jdbc -> hive-shims -> hadoop-yarn-server-resourcemanager. Remove once the
+         vendor Hadoop/Hive distribution ships a version without the vulnerable 1.0.2. -->
+    <jsonschema2pojo.version>1.3.3</jsonschema2pojo.version>
   </properties>
 
   <dependencyManagement>
@@ -230,6 +234,15 @@
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-databind</artifactId>
       <version>${fasterxml-jackson-databind.version}</version>
+    </dependency>
+    <!-- PPP-6534 / CVE-2025-3588: force jsonschema2pojo-core off the vulnerable 1.0.2 (transitive runtime
+         dep via hive-jdbc -> hive-shims -> hadoop-yarn-server-resourcemanager). This explicit direct pin is
+         the regression guard; delete once the vendor Hadoop/Hive distribution ships a fixed version. -->
+    <dependency>
+      <groupId>org.jsonschema2pojo</groupId>
+      <artifactId>jsonschema2pojo-core</artifactId>
+      <version>${jsonschema2pojo.version}</version>
+      <scope>runtime</scope>
     </dependency>
     <dependency>
       <groupId>org.apache.hadoop</groupId>

--- a/shims/emr770/driver/pom.xml
+++ b/shims/emr770/driver/pom.xml
@@ -32,6 +32,10 @@
     <xalan.version>2.7.3</xalan.version>
     <hibernate.version>5.6.15.Final</hibernate.version>
     <nimbus-jose-jwt.version>9.37.4</nimbus-jose-jwt.version>
+    <!-- PPP-6534 / CVE-2025-3588: pin jsonschema2pojo-core off the vulnerable 1.0.2. Pulled transitively
+         (runtime) via hive-exec -> hadoop-yarn-server-resourcemanager. Remove once the vendor Hadoop/Hive
+         distribution ships a version without the vulnerable 1.0.2. -->
+    <jsonschema2pojo.version>1.3.3</jsonschema2pojo.version>
   </properties>
 
   <dependencies>
@@ -678,6 +682,15 @@
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-databind</artifactId>
       <version>${fasterxml-jackson-databind.version}</version>
+    </dependency>
+    <!-- PPP-6534 / CVE-2025-3588: force jsonschema2pojo-core off the vulnerable 1.0.2 (transitive runtime
+         dep via hive-exec -> hadoop-yarn-server-resourcemanager). This explicit direct pin is the
+         regression guard; delete once the vendor Hadoop/Hive distribution ships a fixed version. -->
+    <dependency>
+      <groupId>org.jsonschema2pojo</groupId>
+      <artifactId>jsonschema2pojo-core</artifactId>
+      <version>${jsonschema2pojo.version}</version>
+      <scope>runtime</scope>
     </dependency>
     <dependency>
       <groupId>org.apache.hive</groupId>

--- a/shims/emr770/driver/pom.xml
+++ b/shims/emr770/driver/pom.xml
@@ -32,10 +32,6 @@
     <xalan.version>2.7.3</xalan.version>
     <hibernate.version>5.6.15.Final</hibernate.version>
     <nimbus-jose-jwt.version>9.37.4</nimbus-jose-jwt.version>
-    <!-- PPP-6534 / CVE-2025-3588: pin jsonschema2pojo-core off the vulnerable 1.0.2. Pulled transitively
-         (runtime) via hive-exec -> hadoop-yarn-server-resourcemanager. Remove once the vendor Hadoop/Hive
-         distribution ships a version without the vulnerable 1.0.2. -->
-    <jsonschema2pojo.version>1.3.3</jsonschema2pojo.version>
   </properties>
 
   <dependencies>
@@ -683,15 +679,6 @@
       <artifactId>jackson-databind</artifactId>
       <version>${fasterxml-jackson-databind.version}</version>
     </dependency>
-    <!-- PPP-6534 / CVE-2025-3588: force jsonschema2pojo-core off the vulnerable 1.0.2 (transitive runtime
-         dep via hive-exec -> hadoop-yarn-server-resourcemanager). This explicit direct pin is the
-         regression guard; delete once the vendor Hadoop/Hive distribution ships a fixed version. -->
-    <dependency>
-      <groupId>org.jsonschema2pojo</groupId>
-      <artifactId>jsonschema2pojo-core</artifactId>
-      <version>${jsonschema2pojo.version}</version>
-      <scope>runtime</scope>
-    </dependency>
     <dependency>
       <groupId>org.apache.hive</groupId>
       <artifactId>hive-exec</artifactId>
@@ -724,6 +711,19 @@
         <exclusion>
           <groupId>org.bouncycastle</groupId>
           <artifactId>bcmail-jdk18on</artifactId>
+        </exclusion>
+        <!-- PPP-6534 / CVE-2025-3588: exclude jsonschema2pojo-core + its only child codemodel.
+             Transitive-only (runtime) via hadoop-yarn-server-resourcemanager, which is itself already
+             stripped from the shim assembly; the client shim never invokes this codegen library, so
+             excluding it removes the vulnerable jar from the shipped lib/ (and the build tree) without
+             shipping a heavier jsonschema2pojo 1.3.x closure (Jackson 3, etc.). -->
+        <exclusion>
+          <groupId>org.jsonschema2pojo</groupId>
+          <artifactId>jsonschema2pojo-core</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>com.sun.codemodel</groupId>
+          <artifactId>codemodel</artifactId>
         </exclusion>
       </exclusions>
     </dependency>


### PR DESCRIPTION
## CVE fix: CVE-2025-3588 in org.jsonschema2pojo:jsonschema2pojo-core

Tracking: PPP-6534 (https://pentaho-eng.atlassian.net/browse/PPP-6534)
Advisory: CVE-2025-3588 / GHSA-66rc-vg9f-48m7 -- Medium (CVSS 5.3, CWE-119/CWE-121)
Build: pdia-master@11.1.0.0-333

> **Approach changed after Frogbot review** (see commit history). The original commit bumped `jsonschema2pojo-core` 1.0.2 -> 1.3.3, but Frogbot flagged that 1.3.x drags in **Jackson 3** (`tools.jackson.core:jackson-databind`/`jackson-core:3.0.2`) which carries its own **High** CVEs (CVE-2026-54513, CVE-2026-54512, CVE-2026-29062), and the `-Daudit` build failed. Trading one Medium CVE for several Highs is a bad deal, so this PR now **excludes** the component instead.

### What ships / why it's safe to remove
`jsonschema2pojo-core:1.0.2` (+ its only child `com.sun.codemodel:codemodel:2.6`) ships in the `cdpdc71` and `emr770` shim `hadoop-configurations/*/lib/` folders as a **transitive-only runtime** dep. No first-party source references it (grep = 0). It is dragged in under `hadoop-yarn-server-resourcemanager` -- which the shim assembly **already strips** -- and the client shim never runs YARN server code, so it is dead weight:

- **cdpdc71:** `hive-jdbc:3.1.3000.7.3.1.0-197` -> `hive-shims` -> `hive-shims-0.23` -> `hadoop-yarn-server-resourcemanager:3.1.1.7.3.1.700-158` -> `jsonschema2pojo-core:1.0.2`
- **emr770:** `hive-exec:4.2.0` -> ... -> `hadoop-yarn-server-resourcemanager:3.4.1` -> `jsonschema2pojo-core:1.0.2`

### Fix
Add pom-level `<exclusion>` for `org.jsonschema2pojo:jsonschema2pojo-core` and `com.sun.codemodel:codemodel` to the introducing hive dependency in each driver POM (`hive-jdbc` for cdpdc71, `hive-exec` for emr770). This matches the existing **PPP-6071 avro exclusion** on the same `hive-jdbc` dependency, and the json-io/derby dead-YARN-tail precedent. Removing the component at the POM level clears it from **both** the shipped artifact and the build-tree scan, and introduces nothing new (no Jackson 3).

### Verification (build + A/B assembly proof)
No unit tests exist in the driver modules (transitive-only, no first-party usage), so verification is `dependency:tree` + a controlled A/B assembly build:

```
dependency:tree (both shims): jsonschema2pojo-core = 0, codemodel = 0, tools.jackson (Jackson 3) = 0

cdpdc71  mvn clean verify  (JDK 17)  BUILD SUCCESS
  baseline zip: cdpdc71/lib/jsonschema2pojo-core-1.0.2.jar + codemodel-2.6.jar present (440 lib jars)
  fixed zip:    neither present (438 lib jars)  -> delta = exactly those 2 jars

emr770   mvn clean verify  (JDK 21)  BUILD SUCCESS
  baseline zip: emr770/lib/jsonschema2pojo-core-1.0.2.jar + codemodel-2.6.jar present (451 lib jars)
  fixed zip:    neither present (449 lib jars)  -> delta = exactly those 2 jars
```

### Review
Fixed and reviewed locally via codemedic-local-remediator before push.