### PR TITLE
[PDI-20034] - PDI Logging for Sqoop missing "File System Counters and Job Counters info"

### DIFF
--- a/shims/apachevanilla/driver/src/main/assembly/zip.xml
+++ b/shims/apachevanilla/driver/src/main/assembly/zip.xml
@@ -19,6 +19,13 @@
                 <include>**/*</include>
             </includes>
         </fileSet>
+        <fileSet>
+            <directory>${project.build.directory}/extra-resources</directory>
+            <outputDirectory>/${shim.id}/lib</outputDirectory>
+            <includes>
+                <include>jetty-runner-${jetty-hadoop.version}.jar</include>
+            </includes>
+        </fileSet>
     </fileSets>
     <dependencySets>
         <dependencySet>
@@ -119,6 +126,7 @@
                 <exclude>*:java-util:*</exclude>
                 <exclude>*:java-xmlbuilder:*</exclude>
                 <exclude>*:javassist:*</exclude>
+                <exclude>*:jetty-runner:*</exclude>
                 <exclude>*:javax-websocket-client-impl:*</exclude>
                 <exclude>*:javax-websocket-server-impl:*</exclude>
                 <exclude>*:javax.inject:*</exclude>
@@ -283,6 +291,7 @@
                 <exclude>*:java-util:*</exclude>
                 <exclude>*:java-xmlbuilder:*</exclude>
                 <exclude>*:javassist:*</exclude>
+                <exclude>*:jetty-runner:*</exclude>
                 <exclude>*:javax-websocket-client-impl:*</exclude>
                 <exclude>*:javax-websocket-server-impl:*</exclude>
                 <exclude>*:javax.inject:*</exclude>


### PR DESCRIPTION
This pull request updates the assembly process for the Apache Vanilla shim to better manage the inclusion of the `jetty-runner` JAR. The main changes ensure that the `jetty-runner` JAR is included from a specific location and excluded from dependency sets to avoid duplication or conflicts.

**Assembly packaging improvements:**

* Added a new `<fileSet>` in `zip.xml` to explicitly include `jetty-runner-${jetty-hadoop.version}.jar` from the `extra-resources` directory into the `lib` folder of the shim package.

**Dependency management:**

* Updated both dependency sets in `zip.xml` to exclude any `jetty-runner` dependencies, preventing them from being pulled in via transitive dependencies and ensuring only the intended JAR is packaged. [[1]](diffhunk://#diff-a4044f31da1e1d5fcc365329f54fc471cde662fce8913f07914fb4171f71077fR129) [[2]](diffhunk://#diff-a4044f31da1e1d5fcc365329f54fc471cde662fce8913f07914fb4171f71077fR294)