### PR TITLE
fix[PPP-6766]: bump bundle-backed Parquet line to 1.17.1 in dataproc23 and emr770

### DIFF
--- a/shims/dataproc23/pom.xml
+++ b/shims/dataproc23/pom.xml
@@ -45,8 +45,8 @@
     <!-- pmr folder -->
     <commons-configuration.version>1.6</commons-configuration.version>
     <org.apache.hive.version>3.1.3</org.apache.hive.version>
-    <!-- setting v1.14.4 so shaded jackson-databind inside parquet-hadoop-bundle's  version approximately matches jackson-databind in driver.jar -->
-    <parquet.version>1.14.4</parquet.version>
+    <!-- PPP-6766: Override to 1.17.1 in the bundle-backed dataproc23 shim to use a safe shaded jackson-databind line. -->
+    <parquet.version>1.17.1</parquet.version>
     <org.antlr.version>3.5.2</org.antlr.version>
     <joda-time.version>2.9.9</joda-time.version>
 

--- a/shims/emr770/pom.xml
+++ b/shims/emr770/pom.xml
@@ -23,6 +23,8 @@
 
   <properties>
     <pentaho-hadoop-shims.version>${project.version}</pentaho-hadoop-shims.version>
+    <!-- PPP-6766: Override to 1.17.1 in the bundle-backed emr770 shim to use a safe shaded jackson-databind line. -->
+    <parquet.version>1.17.1</parquet.version>
   </properties>
 
   <modules>


### PR DESCRIPTION
## Summary

This PR updates `parquet-hadoop-bundle` to `1.17.1` in `dataproc23` and `emr770`.

## Why this approach

Some other shims split this Parquet bundle into individual modules instead of using `parquet-hadoop-bundle`, which contains a lot of stuff that cannot be filtered through exclusions. Both shims still depend on `parquet-hadoop-bundle` and their assemblies are still built around that bundle, so replacing it with individual Parquet modules would require changing what gets packaged and shipped, which increases regression risk.

This is also a reasonable bump for these two shims specifically, since they are already on modern Hadoop/Hive lines, so Parquet 1.16+ dropping Hadoop 2 support is not a problem, and Parquet 1.17.x requiring Java 11 also aligns with these maintained shim lines.