### PR TITLE
fix[SP-7451]: update pentaho-shaded-netty version to 1.0.2

### DIFF
--- a/shims/apachevanilla/driver/pom.xml
+++ b/shims/apachevanilla/driver/pom.xml
@@ -686,7 +686,7 @@
     <dependency>
       <groupId>org.pentaho.hadoop</groupId>
       <artifactId>pentaho-shaded-netty</artifactId>
-      <version>1.0.1</version>
+      <version>1.0.2</version>
     </dependency>
     <dependency>
       <groupId>org.apache.hbase</groupId>

--- a/shims/apachevanilla/pmr/pom.xml
+++ b/shims/apachevanilla/pmr/pom.xml
@@ -77,7 +77,7 @@
     <dependency>
       <groupId>org.pentaho.hadoop</groupId>
       <artifactId>pentaho-shaded-netty</artifactId>
-      <version>1.0.1</version>
+      <version>1.0.2</version>
       <exclusions>
         <exclusion>
           <groupId>*</groupId>

--- a/shims/cdpdc71/driver/pom.xml
+++ b/shims/cdpdc71/driver/pom.xml
@@ -674,7 +674,7 @@
     <dependency>
       <groupId>org.pentaho.hadoop</groupId>
       <artifactId>pentaho-shaded-netty</artifactId>
-      <version>1.0.1</version>
+      <version>1.0.2</version>
     </dependency>
     <dependency>
       <groupId>org.apache.hbase</groupId>

--- a/shims/cdpdc71/pmr/pom.xml
+++ b/shims/cdpdc71/pmr/pom.xml
@@ -299,7 +299,7 @@
     <dependency>
       <groupId>org.pentaho.hadoop</groupId>
       <artifactId>pentaho-shaded-netty</artifactId>
-      <version>1.0.1</version>
+      <version>1.0.2</version>
     </dependency>
     <dependency>
       <groupId>org.apache.hbase.thirdparty</groupId>

--- a/shims/dataproc1421/driver/pom.xml
+++ b/shims/dataproc1421/driver/pom.xml
@@ -421,7 +421,7 @@
     <dependency>
       <groupId>org.pentaho.hadoop</groupId>
       <artifactId>pentaho-shaded-netty</artifactId>
-      <version>1.0.1</version>
+      <version>1.0.2</version>
     </dependency>
     <dependency>
       <groupId>org.apache.hbase</groupId>

--- a/shims/dataproc1421/pmr/pom.xml
+++ b/shims/dataproc1421/pmr/pom.xml
@@ -73,7 +73,7 @@
     <dependency>
       <groupId>org.pentaho.hadoop</groupId>
       <artifactId>pentaho-shaded-netty</artifactId>
-      <version>1.0.1</version>
+      <version>1.0.2</version>
       <exclusions>
         <exclusion>
           <groupId>*</groupId>

--- a/shims/emr770/driver/pom.xml
+++ b/shims/emr770/driver/pom.xml
@@ -850,13 +850,10 @@
         </exclusion>
       </exclusions>
     </dependency>
-    <!-- ADD: Custom shaded Netty fixing CVE-2025-59419 (SMTP injection vulnerability) -->
-    <!-- This replaces Apache's hbase-shaded-netty:4.1.10 (Netty 4.1.116 - vulnerable) -->
-    <!-- with pentaho-shaded-netty containing Netty 4.1.128.Final (patched) -->
     <dependency>
       <groupId>org.pentaho.hadoop</groupId>
       <artifactId>pentaho-shaded-netty</artifactId>
-      <version>1.0.1</version>
+      <version>1.0.2</version>
     </dependency>
     <dependency>
       <groupId>org.apache.hbase</groupId>

--- a/shims/emr770/pmr/pom.xml
+++ b/shims/emr770/pmr/pom.xml
@@ -244,7 +244,7 @@
     <dependency>
       <groupId>org.pentaho.hadoop</groupId>
       <artifactId>pentaho-shaded-netty</artifactId>
-      <version>1.0.1</version>
+      <version>1.0.2</version>
       <exclusions>
         <exclusion>
           <groupId>*</groupId>

--- a/shims/hdi40/driver/pom.xml
+++ b/shims/hdi40/driver/pom.xml
@@ -476,7 +476,7 @@
     <dependency>
       <groupId>org.pentaho.hadoop</groupId>
       <artifactId>pentaho-shaded-netty</artifactId>
-      <version>1.0.1</version>
+      <version>1.0.2</version>
     </dependency>
     <dependency>
       <groupId>org.apache.hbase</groupId>

--- a/shims/hdi40/pmr/pom.xml
+++ b/shims/hdi40/pmr/pom.xml
@@ -81,7 +81,7 @@
     <dependency>
       <groupId>org.pentaho.hadoop</groupId>
       <artifactId>pentaho-shaded-netty</artifactId>
-      <version>1.0.1</version>
+      <version>1.0.2</version>
       <exclusions>
         <exclusion>
           <groupId>*</groupId>


### PR DESCRIPTION
Not exactly a backport of https://github.com/pentaho/pentaho-hadoop-shims/pull/1886 since the shims change between versions