### PR TITLE
fix: Bump missing avro libs to non vulnerable version 1.12.1 [PPP-6304]

### DIFF
--- a/shims/apachevanilla/driver/pom.xml
+++ b/shims/apachevanilla/driver/pom.xml
@@ -28,7 +28,7 @@
     <commons-lang.version>2.6</commons-lang.version>
     <failureaccess.version>1.0.1</failureaccess.version>
     <pentaho-osgi-bundles.version>11.1.0.0-SNAPSHOT</pentaho-osgi-bundles.version>
-    <org.apache.avro.version>1.12.0</org.apache.avro.version>
+    <org.apache.avro.version>1.12.1</org.apache.avro.version>
     <!-- PPP-6324: Override to 1.16.0 (scoped to apachevanilla only) to fix CVE-2026-29062
          jackson-core shaded inside parquet-jackson/parquet-hadoop-bundle is safe (2.19.2) at 1.16.0+ -->
     <parquet.version>1.16.0</parquet.version>

--- a/shims/cdpdc71/driver/pom.xml
+++ b/shims/cdpdc71/driver/pom.xml
@@ -28,7 +28,7 @@
     <commons-lang.version>2.6</commons-lang.version>
     <failureaccess.version>1.0.1</failureaccess.version>
     <pentaho-osgi-bundles.version>11.1.0.0-SNAPSHOT</pentaho-osgi-bundles.version>
-    <org.apache.avro.version>1.12.0</org.apache.avro.version>
+    <org.apache.avro.version>1.12.1</org.apache.avro.version>
     <!--    <org.apache.orc.version>1.5.1.7.1.4.0-203</org.apache.orc.version>-->
     <org.apache.orc.version>1.5.1.7.1.4.0-203</org.apache.orc.version>
     <org.apache.hadoop.version>3.1.1.7.3.1.700-158</org.apache.hadoop.version>

--- a/shims/dataproc1421/pom.xml
+++ b/shims/dataproc1421/pom.xml
@@ -37,7 +37,7 @@
     <org.apache.oozie.version>4.3.1</org.apache.oozie.version>
     <sqoop.version>1.4.7</sqoop.version>
     <hive-jdbc.version>2.3.6</hive-jdbc.version>
-    <org.apache.avro.version>1.12.0</org.apache.avro.version>
+    <org.apache.avro.version>1.12.1</org.apache.avro.version>
     <hadoop-aws.version>2.9.2</hadoop-aws.version>
 
     <!-- client and default folders -->

--- a/shims/dataproc23/pom.xml
+++ b/shims/dataproc23/pom.xml
@@ -37,7 +37,7 @@
     <org.apache.oozie.version>5.2.1</org.apache.oozie.version>
     <sqoop.version>1.4.7</sqoop.version>
     <hive-jdbc.version>3.1.3</hive-jdbc.version>
-    <org.apache.avro.version>1.12.0</org.apache.avro.version>
+    <org.apache.avro.version>1.12.1</org.apache.avro.version>
 
     <!-- client and default folders -->
     <hadoop.version>3.3.6</hadoop.version>

--- a/shims/emr700/driver/pom.xml
+++ b/shims/emr700/driver/pom.xml
@@ -24,7 +24,7 @@
   <packaging>jar</packaging>
 
   <properties>
-    <org.apache.avro.version>1.12.0</org.apache.avro.version>
+    <org.apache.avro.version>1.12.1</org.apache.avro.version>
     <org.apache.hive.version>4.0.1</org.apache.hive.version>
     <org.apache.oozie.version>5.2.1</org.apache.oozie.version>
     <org.apache.hbase.version>2.6.2</org.apache.hbase.version>

--- a/shims/emr770/driver/pom.xml
+++ b/shims/emr770/driver/pom.xml
@@ -26,7 +26,7 @@
   <properties>
     <shim.id>emr770</shim.id>
     <jsr311-api.version>1.1.1</jsr311-api.version>
-    <org.apache.avro.version>1.12.0</org.apache.avro.version>
+    <org.apache.avro.version>1.12.1</org.apache.avro.version>
     <org.apache.hive.version>4.2.0</org.apache.hive.version>
     <org.apache.oozie.version>5.2.1</org.apache.oozie.version>
     <org.apache.hbase.version>2.6.2</org.apache.hbase.version>

--- a/shims/hdi40/driver/pom.xml
+++ b/shims/hdi40/driver/pom.xml
@@ -26,7 +26,7 @@
   <properties>
     <shim.id>hdi40</shim.id>
     <pentaho-osgi-bundles.version>11.1.0.0-SNAPSHOT</pentaho-osgi-bundles.version>
-    <org.apache.avro.version>1.12.0</org.apache.avro.version>
+    <org.apache.avro.version>1.12.1</org.apache.avro.version>
     <!-- setting v1.14.4 so shaded jackson-databind inside parquet-hadoop-bundle's  version approximately matches jackson-databind in driver.jar -->
     <parquet.version>1.14.4</parquet.version>
     <org.apache.hbase.version>2.4.17.7.1.9.0-387</org.apache.hbase.version>


### PR DESCRIPTION
**CVE-2025-33042: Vulnerability in the Apache Avro**

This pull request updates the version of the Apache Avro dependency from `1.12.0` to `1.12.1` across multiple shim modules. This change ensures that all relevant modules use the latest patch version, which may include important bug fixes and security updates.

**Dependency version updates:**

* Updated `org.apache.avro.version` from `1.12.0` to `1.12.1` in the following `pom.xml` files:
  * `shims/apachevanilla/driver/pom.xml`
  * `shims/cdpdc71/driver/pom.xml`
  * `shims/dataproc1421/pom.xml`
  * `shims/dataproc23/pom.xml`
  * `shims/emr700/driver/pom.xml`
  * `shims/emr770/driver/pom.xml`
  * `shims/hdi40/driver/pom.xml`