### PR TITLE
fix[PPP-6766]: Remove parquet-hadoop-bundle from dataproc23 and emr770 shims

### DIFF
--- a/shims/dataproc23/driver/pom.xml
+++ b/shims/dataproc23/driver/pom.xml
@@ -26,6 +26,7 @@
     <shim.id>dataproc23</shim.id>
     <curator.version>5.6.0</curator.version>
     <grpc-netty-shaded.version>1.80.0</grpc-netty-shaded.version>
+    <parquet-pig.version>1.15.2</parquet-pig.version>    <!-- parquet-pig not released at 1.17.1 — keep at 1.15.2 (last available) -->
   </properties>
 
   <dependencies>
@@ -275,11 +276,6 @@
       <version>${org.apache.avro.version}</version>
     </dependency>
     <dependency>
-      <groupId>org.apache.parquet</groupId>
-      <artifactId>parquet-hadoop-bundle</artifactId>
-      <version>${parquet.version}</version>
-    </dependency>
-    <dependency>
       <groupId>org.apache.sqoop</groupId>
       <artifactId>sqoop</artifactId>
       <version>${sqoop.version}</version>
@@ -302,6 +298,17 @@
       </exclusions>
     </dependency>
     <dependency>
+      <groupId>org.apache.parquet</groupId>
+      <artifactId>parquet-pig</artifactId>
+      <version>${parquet-pig.version}</version>
+      <exclusions>
+        <exclusion>
+          <groupId>*</groupId>
+          <artifactId>*</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+    <dependency>
       <groupId>org.apache.oozie</groupId>
       <artifactId>oozie-client</artifactId>
       <version>${org.apache.oozie.version}</version>
@@ -311,6 +318,26 @@
           <artifactId>xmlgraphics-commons</artifactId>
         </exclusion>
       </exclusions>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.parquet</groupId>
+      <artifactId>parquet-hadoop</artifactId>
+      <version>${parquet.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.parquet</groupId>
+      <artifactId>parquet-column</artifactId>
+      <version>${parquet.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.parquet</groupId>
+      <artifactId>parquet-common</artifactId>
+      <version>${parquet.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.parquet</groupId>
+      <artifactId>parquet-encoding</artifactId>
+      <version>${parquet.version}</version>
     </dependency>
     <dependency>
       <groupId>org.apache.hive</groupId>
@@ -357,6 +384,10 @@
       <artifactId>hive-jdbc</artifactId>
       <version>${hive-jdbc.version}</version>
       <exclusions>
+        <exclusion>
+          <groupId>org.apache.parquet</groupId>
+          <artifactId>parquet-hadoop-bundle</artifactId>
+        </exclusion>
         <exclusion>
           <groupId>*</groupId>
           <artifactId>zookeeper</artifactId>

--- a/shims/dataproc23/driver/src/main/assembly/zip.xml
+++ b/shims/dataproc23/driver/src/main/assembly/zip.xml
@@ -267,10 +267,6 @@
                 <exclude>*:ognl:*</exclude>
                 <exclude>*:org.apache.karaf.jaas.config:*</exclude>
                 <exclude>*:parquet-avro:*</exclude>
-                <exclude>*:parquet-column:*</exclude>
-                <exclude>*:parquet-common:*</exclude>
-                <exclude>*:parquet-encoding:*</exclude>
-                <exclude>*:parquet-format-structures:*</exclude>
                 <exclude>*:pentaho-encryption-support:*</exclude>
                 <exclude>*:pentaho-hadoop-shims-common-base:*</exclude>
                 <exclude>*:pentaho-hadoop-shims-common-services-api:*</exclude>

--- a/shims/dataproc23/pom.xml
+++ b/shims/dataproc23/pom.xml
@@ -45,7 +45,6 @@
     <!-- pmr folder -->
     <commons-configuration.version>1.6</commons-configuration.version>
     <org.apache.hive.version>3.1.3</org.apache.hive.version>
-    <!-- PPP-6766: Override to 1.17.1 in the bundle-backed dataproc23 shim to use a safe shaded jackson-databind line. -->
     <parquet.version>1.17.1</parquet.version>
     <org.antlr.version>3.5.2</org.antlr.version>
     <joda-time.version>2.9.9</joda-time.version>

--- a/shims/emr770/driver/pom.xml
+++ b/shims/emr770/driver/pom.xml
@@ -43,6 +43,7 @@
     <xalan.version>2.7.3</xalan.version>
     <hibernate.version>5.6.15.Final</hibernate.version>
     <nimbus-jose-jwt.version>9.37.4</nimbus-jose-jwt.version>
+    <parquet-pig.version>1.15.2</parquet-pig.version>    <!-- parquet-pig not released at 1.17.1 — keep at 1.15.2 (last available) -->
   </properties>
 
   <dependencies>
@@ -649,11 +650,6 @@
       <version>${org.apache.avro.version}</version>
     </dependency>
     <dependency>
-      <groupId>org.apache.parquet</groupId>
-      <artifactId>parquet-hadoop-bundle</artifactId>
-      <version>${parquet.version}</version>
-    </dependency>
-    <dependency>
       <groupId>org.apache.sqoop</groupId>
       <artifactId>sqoop</artifactId>
       <version>${sqoop.version}</version>
@@ -666,6 +662,17 @@
       <groupId>org.apache.pig</groupId>
       <artifactId>pig</artifactId>
       <version>${pig.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.parquet</groupId>
+      <artifactId>parquet-pig</artifactId>
+      <version>${parquet-pig.version}</version>
+      <exclusions>
+        <exclusion>
+          <groupId>*</groupId>
+          <artifactId>*</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>org.apache.oozie</groupId>
@@ -683,6 +690,26 @@
       </exclusions>
     </dependency>
     <dependency>
+      <groupId>org.apache.parquet</groupId>
+      <artifactId>parquet-hadoop</artifactId>
+      <version>${parquet.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.parquet</groupId>
+      <artifactId>parquet-column</artifactId>
+      <version>${parquet.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.parquet</groupId>
+      <artifactId>parquet-common</artifactId>
+      <version>${parquet.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.parquet</groupId>
+      <artifactId>parquet-encoding</artifactId>
+      <version>${parquet.version}</version>
+    </dependency>
+    <dependency>
       <groupId>com.google.protobuf</groupId>
       <artifactId>protobuf-java</artifactId>
       <version>${protobuf-java.version}</version>
@@ -692,6 +719,10 @@
       <artifactId>hive-jdbc</artifactId>
       <version>${org.apache.hive.version}</version>
       <exclusions>
+        <exclusion>
+          <groupId>org.apache.parquet</groupId>
+          <artifactId>parquet-hadoop-bundle</artifactId>
+        </exclusion>
         <exclusion>
           <groupId>com.github.pjfanning</groupId>
           <artifactId>jersey-json</artifactId>

--- a/shims/emr770/driver/src/main/assembly/zip.xml
+++ b/shims/emr770/driver/src/main/assembly/zip.xml
@@ -175,10 +175,6 @@
                 <exclude>*:mssql-jdbc:*</exclude>
                 <exclude>*:org.apache.karaf.jaas.config:*</exclude>
                 <exclude>*:parquet-avro:*</exclude>
-                <exclude>*:parquet-column:*</exclude>
-                <exclude>*:parquet-common:*</exclude>
-                <exclude>*:parquet-encoding:*</exclude>
-                <exclude>*:parquet-format-structures:*</exclude>
                 <exclude>*:pentaho-hadoop-shims-common-base:*</exclude>
                 <exclude>*:pentaho-hadoop-shims-common-services-api:*</exclude>
                 <exclude>*:pentaho-hadoop-shims-emr700:*</exclude>
@@ -359,10 +355,6 @@
                 <exclude>*:mssql-jdbc:*</exclude>
                 <exclude>*:org.apache.karaf.jaas.config:*</exclude>
                 <exclude>*:parquet-avro:*</exclude>
-                <exclude>*:parquet-column:*</exclude>
-                <exclude>*:parquet-common:*</exclude>
-                <exclude>*:parquet-encoding:*</exclude>
-                <exclude>*:parquet-format-structures:*</exclude>
                 <exclude>*:pentaho-hadoop-shims-common-base:*</exclude>
                 <exclude>*:pentaho-hadoop-shims-common-services-api:*</exclude>
                 <exclude>*:pentaho-hadoop-shims-emr700:*</exclude>

--- a/shims/emr770/pom.xml
+++ b/shims/emr770/pom.xml
@@ -23,7 +23,6 @@
 
   <properties>
     <pentaho-hadoop-shims.version>${project.version}</pentaho-hadoop-shims.version>
-    <!-- PPP-6766: Override to 1.17.1 in the bundle-backed emr770 shim to use a safe shaded jackson-databind line. -->
     <parquet.version>1.17.1</parquet.version>
   </properties>
 


### PR DESCRIPTION
Replace `parquet-hadoop-bundle` with explicit Parquet 1.17.1 modules (`parquet-hadoop`, `parquet-column`, `parquet-common`, `parquet-encoding`) in both the `dataproc23` and `emr770` driver POMs, matching the pattern already applied to `apachevanilla` and `cdpdc71` (PPP-6324, PPP-6326).

It built cleanly and inspection of the built assembly zips looks good: bundle jar absent, all individual parquet modules present. Cross-checked that every `org.apache.parquet` class referenced by `pentaho-hadoop-shims-common-base` resolves against the shipped jars (to avoid linkage/classpath regressions from the packaging change).