### PR TITLE
build[PPP-7120]: Move dependency management of Netty to maven parent pom

### DIFF
--- a/common-base/pom.xml
+++ b/common-base/pom.xml
@@ -384,7 +384,6 @@
         <dependency>
           <groupId>io.netty</groupId>
           <artifactId>netty-handler</artifactId>
-          <version>${netty.version}</version>
         </dependency>
         <dependency>
           <groupId>org.apache.commons</groupId>
@@ -455,7 +454,6 @@
         <dependency>
           <groupId>io.netty</groupId>
           <artifactId>netty-codec-http</artifactId>
-          <version>${netty.version}</version>
         </dependency>
         <dependency>
           <groupId>org.apache.hadoop</groupId>

--- a/common-dependencies/pom.xml
+++ b/common-dependencies/pom.xml
@@ -141,7 +141,6 @@
     <dependency>
       <groupId>io.netty</groupId>
       <artifactId>netty-handler</artifactId>
-      <version>${netty.version}</version>
     </dependency>
     <dependency>
       <groupId>org.apache.commons</groupId>

--- a/mapreduce/pom.xml
+++ b/mapreduce/pom.xml
@@ -67,12 +67,10 @@
     <dependency>
       <groupId>io.netty</groupId>
       <artifactId>netty-handler</artifactId>
-      <version>${netty.version}</version>
     </dependency>
     <dependency>
       <groupId>io.netty</groupId>
       <artifactId>netty-common</artifactId>
-      <version>${netty.version}</version>
     </dependency>
     <dependency>
       <groupId>com.thoughtworks.xstream</groupId>

--- a/shims/apachevanilla/driver/pom.xml
+++ b/shims/apachevanilla/driver/pom.xml
@@ -581,7 +581,6 @@
     <dependency>
       <groupId>io.netty</groupId>
       <artifactId>netty-buffer</artifactId>
-      <version>${netty.version}</version>
       <exclusions>
         <exclusion>
           <groupId>*</groupId>
@@ -592,7 +591,6 @@
     <dependency>
       <groupId>io.netty</groupId>
       <artifactId>netty-codec</artifactId>
-      <version>${netty.version}</version>
       <exclusions>
         <exclusion>
           <groupId>*</groupId>
@@ -603,7 +601,6 @@
     <dependency>
       <groupId>io.netty</groupId>
       <artifactId>netty-codec-http</artifactId>
-      <version>${netty.version}</version>
       <exclusions>
         <exclusion>
           <groupId>*</groupId>
@@ -614,7 +611,6 @@
     <dependency>
       <groupId>io.netty</groupId>
       <artifactId>netty-codec-http2</artifactId>
-      <version>${netty.version}</version>
       <exclusions>
         <exclusion>
           <groupId>*</groupId>
@@ -625,7 +621,6 @@
     <dependency>
       <groupId>io.netty</groupId>
       <artifactId>netty-codec-smtp</artifactId>
-      <version>${netty.version}</version>
       <exclusions>
         <exclusion>
           <groupId>*</groupId>
@@ -636,7 +631,6 @@
     <dependency>
       <groupId>io.netty</groupId>
       <artifactId>netty-common</artifactId>
-      <version>${netty.version}</version>
       <exclusions>
         <exclusion>
           <groupId>*</groupId>
@@ -647,12 +641,10 @@
     <dependency>
       <groupId>io.netty</groupId>
       <artifactId>netty-handler</artifactId>
-      <version>${netty.version}</version>
     </dependency>
     <dependency>
       <groupId>io.netty</groupId>
       <artifactId>netty-resolver</artifactId>
-      <version>${netty.version}</version>
       <exclusions>
         <exclusion>
           <groupId>*</groupId>
@@ -663,7 +655,6 @@
     <dependency>
       <groupId>io.netty</groupId>
       <artifactId>netty-transport</artifactId>
-      <version>${netty.version}</version>
       <exclusions>
         <exclusion>
           <groupId>*</groupId>
@@ -674,7 +665,6 @@
     <dependency>
       <groupId>io.netty</groupId>
       <artifactId>netty-transport-native-epoll</artifactId>
-      <version>${netty.version}</version>
       <classifier>linux-x86_64</classifier>
       <exclusions>
         <exclusion>

--- a/shims/cdpdc71/driver/pom.xml
+++ b/shims/cdpdc71/driver/pom.xml
@@ -586,47 +586,38 @@
     <dependency>
       <groupId>io.netty</groupId>
       <artifactId>netty-buffer</artifactId>
-      <version>${netty.version}</version>
     </dependency>
     <dependency>
       <groupId>io.netty</groupId>
       <artifactId>netty-codec</artifactId>
-      <version>${netty.version}</version>
     </dependency>
     <dependency>
       <groupId>io.netty</groupId>
       <artifactId>netty-codec-http</artifactId>
-      <version>${netty.version}</version>
     </dependency>
     <dependency>
       <groupId>io.netty</groupId>
       <artifactId>netty-codec-http2</artifactId>
-      <version>${netty.version}</version>
     </dependency>
     <dependency>
       <groupId>io.netty</groupId>
       <artifactId>netty-common</artifactId>
-      <version>${netty.version}</version>
     </dependency>
     <dependency>
       <groupId>io.netty</groupId>
       <artifactId>netty-handler</artifactId>
-      <version>${netty.version}</version>
     </dependency>
     <dependency>
       <groupId>io.netty</groupId>
       <artifactId>netty-resolver</artifactId>
-      <version>${netty.version}</version>
     </dependency>
     <dependency>
       <groupId>io.netty</groupId>
       <artifactId>netty-transport</artifactId>
-      <version>${netty.version}</version>
     </dependency>
     <dependency>
       <groupId>io.netty</groupId>
       <artifactId>netty-codec-smtp</artifactId>
-      <version>${netty.version}</version>
       <exclusions>
         <exclusion>
           <groupId>*</groupId>
@@ -637,7 +628,6 @@
     <dependency>
       <groupId>io.netty</groupId>
       <artifactId>netty-transport-native-epoll</artifactId>
-      <version>${netty.version}</version>
       <classifier>linux-x86_64</classifier>
     </dependency>
     <dependency>

--- a/shims/dataproc1421/driver/pom.xml
+++ b/shims/dataproc1421/driver/pom.xml
@@ -102,7 +102,6 @@
     <dependency>
       <groupId>io.netty</groupId>
       <artifactId>netty-buffer</artifactId>
-      <version>${netty.version}</version>
       <exclusions>
         <exclusion>
           <groupId>*</groupId>
@@ -113,7 +112,6 @@
     <dependency>
       <groupId>io.netty</groupId>
       <artifactId>netty-codec</artifactId>
-      <version>${netty.version}</version>
       <exclusions>
         <exclusion>
           <groupId>*</groupId>
@@ -124,7 +122,6 @@
     <dependency>
       <groupId>io.netty</groupId>
       <artifactId>netty-codec-http</artifactId>
-      <version>${netty.version}</version>
       <exclusions>
         <exclusion>
           <groupId>*</groupId>
@@ -135,7 +132,6 @@
     <dependency>
       <groupId>io.netty</groupId>
       <artifactId>netty-codec-http2</artifactId>
-      <version>${netty.version}</version>
       <exclusions>
         <exclusion>
           <groupId>*</groupId>
@@ -146,7 +142,6 @@
     <dependency>
       <groupId>io.netty</groupId>
       <artifactId>netty-codec-smtp</artifactId>
-      <version>${netty.version}</version>
       <exclusions>
         <exclusion>
           <groupId>*</groupId>
@@ -157,7 +152,6 @@
     <dependency>
       <groupId>io.netty</groupId>
       <artifactId>netty-common</artifactId>
-      <version>${netty.version}</version>
       <exclusions>
         <exclusion>
           <groupId>*</groupId>
@@ -168,12 +162,10 @@
     <dependency>
       <groupId>io.netty</groupId>
       <artifactId>netty-handler</artifactId>
-      <version>${netty.version}</version>
     </dependency>
     <dependency>
       <groupId>io.netty</groupId>
       <artifactId>netty-resolver</artifactId>
-      <version>${netty.version}</version>
       <exclusions>
         <exclusion>
           <groupId>*</groupId>
@@ -184,7 +176,6 @@
     <dependency>
       <groupId>io.netty</groupId>
       <artifactId>netty-transport</artifactId>
-      <version>${netty.version}</version>
       <exclusions>
         <exclusion>
           <groupId>*</groupId>
@@ -195,7 +186,6 @@
     <dependency>
       <groupId>io.netty</groupId>
       <artifactId>netty-transport-native-epoll</artifactId>
-      <version>${netty.version}</version>
       <classifier>linux-x86_64</classifier>
       <exclusions>
         <exclusion>
@@ -652,7 +642,6 @@
     <dependency>
       <groupId>io.netty</groupId>
       <artifactId>netty-transport-classes-epoll</artifactId>
-      <version>${netty.version}</version>
     </dependency>
     <dependency>
       <groupId>org.apache.zookeeper</groupId>

--- a/shims/dataproc23/driver/pom.xml
+++ b/shims/dataproc23/driver/pom.xml
@@ -101,7 +101,6 @@
     <dependency>
       <groupId>io.netty</groupId>
       <artifactId>netty-buffer</artifactId>
-      <version>${netty.version}</version>
       <exclusions>
         <exclusion>
           <groupId>*</groupId>
@@ -112,7 +111,6 @@
     <dependency>
       <groupId>io.netty</groupId>
       <artifactId>netty-codec</artifactId>
-      <version>${netty.version}</version>
       <exclusions>
         <exclusion>
           <groupId>*</groupId>
@@ -123,7 +121,6 @@
     <dependency>
       <groupId>io.netty</groupId>
       <artifactId>netty-codec-http</artifactId>
-      <version>${netty.version}</version>
       <exclusions>
         <exclusion>
           <groupId>*</groupId>
@@ -134,7 +131,6 @@
     <dependency>
       <groupId>io.netty</groupId>
       <artifactId>netty-codec-http2</artifactId>
-      <version>${netty.version}</version>
       <exclusions>
         <exclusion>
           <groupId>*</groupId>
@@ -145,7 +141,6 @@
     <dependency>
       <groupId>io.netty</groupId>
       <artifactId>netty-codec-smtp</artifactId>
-      <version>${netty.version}</version>
       <exclusions>
         <exclusion>
           <groupId>*</groupId>
@@ -156,7 +151,6 @@
     <dependency>
       <groupId>io.netty</groupId>
       <artifactId>netty-common</artifactId>
-      <version>${netty.version}</version>
       <exclusions>
         <exclusion>
           <groupId>*</groupId>
@@ -167,12 +161,10 @@
     <dependency>
       <groupId>io.netty</groupId>
       <artifactId>netty-handler</artifactId>
-      <version>${netty.version}</version>
     </dependency>
     <dependency>
       <groupId>io.netty</groupId>
       <artifactId>netty-resolver</artifactId>
-      <version>${netty.version}</version>
       <exclusions>
         <exclusion>
           <groupId>*</groupId>
@@ -183,7 +175,6 @@
     <dependency>
       <groupId>io.netty</groupId>
       <artifactId>netty-transport</artifactId>
-      <version>${netty.version}</version>
       <exclusions>
         <exclusion>
           <groupId>*</groupId>
@@ -194,7 +185,6 @@
     <dependency>
       <groupId>io.netty</groupId>
       <artifactId>netty-transport-native-epoll</artifactId>
-      <version>${netty.version}</version>
       <classifier>linux-x86_64</classifier>
       <exclusions>
         <exclusion>
@@ -643,7 +633,6 @@
     <dependency>
       <groupId>io.netty</groupId>
       <artifactId>netty-transport-classes-epoll</artifactId>
-      <version>${netty.version}</version>
     </dependency>
     <dependency>
       <groupId>org.apache.zookeeper</groupId>

--- a/shims/emr521/driver/pom.xml
+++ b/shims/emr521/driver/pom.xml
@@ -313,47 +313,38 @@
     <dependency>
       <groupId>io.netty</groupId>
       <artifactId>netty-buffer</artifactId>
-      <version>${netty.version}</version>
     </dependency>
     <dependency>
       <groupId>io.netty</groupId>
       <artifactId>netty-codec</artifactId>
-      <version>${netty.version}</version>
     </dependency>
     <dependency>
       <groupId>io.netty</groupId>
       <artifactId>netty-codec-http</artifactId>
-      <version>${netty.version}</version>
     </dependency>
     <dependency>
       <groupId>io.netty</groupId>
       <artifactId>netty-codec-http2</artifactId>
-      <version>${netty.version}</version>
     </dependency>
     <dependency>
       <groupId>io.netty</groupId>
       <artifactId>netty-common</artifactId>
-      <version>${netty.version}</version>
     </dependency>
     <dependency>
       <groupId>io.netty</groupId>
       <artifactId>netty-handler</artifactId>
-      <version>${netty.version}</version>
     </dependency>
     <dependency>
       <groupId>io.netty</groupId>
       <artifactId>netty-resolver</artifactId>
-      <version>${netty.version}</version>
     </dependency>
     <dependency>
       <groupId>io.netty</groupId>
       <artifactId>netty-transport</artifactId>
-      <version>${netty.version}</version>
     </dependency>
     <dependency>
       <groupId>io.netty</groupId>
       <artifactId>netty-transport-native-epoll</artifactId>
-      <version>${netty.version}</version>
       <classifier>linux-x86_64</classifier>
     </dependency>
 

--- a/shims/emr700/driver/pom.xml
+++ b/shims/emr700/driver/pom.xml
@@ -88,7 +88,6 @@
     <dependency>
       <groupId>io.netty</groupId>
       <artifactId>netty-buffer</artifactId>
-      <version>${netty.version}</version>
       <exclusions>
         <exclusion>
           <groupId>*</groupId>
@@ -100,7 +99,6 @@
     <dependency>
       <groupId>io.netty</groupId>
       <artifactId>netty-codec</artifactId>
-      <version>${netty.version}</version>
       <exclusions>
         <exclusion>
           <groupId>*</groupId>
@@ -111,7 +109,6 @@
     <dependency>
       <groupId>io.netty</groupId>
       <artifactId>netty-codec-dns</artifactId>
-      <version>${netty.version}</version>
       <exclusions>
         <exclusion>
           <groupId>*</groupId>
@@ -122,7 +119,6 @@
     <dependency>
       <groupId>io.netty</groupId>
       <artifactId>netty-codec-haproxy</artifactId>
-      <version>${netty.version}</version>
       <exclusions>
         <exclusion>
           <groupId>*</groupId>
@@ -133,7 +129,6 @@
     <dependency>
       <groupId>io.netty</groupId>
       <artifactId>netty-codec-http2</artifactId>
-      <version>${netty.version}</version>
       <exclusions>
         <exclusion>
           <groupId>*</groupId>
@@ -144,7 +139,6 @@
     <dependency>
       <groupId>io.netty</groupId>
       <artifactId>netty-codec-http</artifactId>
-      <version>${netty.version}</version>
       <exclusions>
         <exclusion>
           <groupId>*</groupId>
@@ -155,7 +149,6 @@
     <dependency>
       <groupId>io.netty</groupId>
       <artifactId>netty-codec-memcache</artifactId>
-      <version>${netty.version}</version>
       <exclusions>
         <exclusion>
           <groupId>*</groupId>
@@ -166,7 +159,6 @@
     <dependency>
       <groupId>io.netty</groupId>
       <artifactId>netty-codec-mqtt</artifactId>
-      <version>${netty.version}</version>
       <exclusions>
         <exclusion>
           <groupId>*</groupId>
@@ -177,7 +169,6 @@
     <dependency>
       <groupId>io.netty</groupId>
       <artifactId>netty-codec-redis</artifactId>
-      <version>${netty.version}</version>
       <exclusions>
         <exclusion>
           <groupId>*</groupId>
@@ -188,7 +179,6 @@
     <dependency>
       <groupId>io.netty</groupId>
       <artifactId>netty-codec-smtp</artifactId>
-      <version>${netty.version}</version>
       <exclusions>
         <exclusion>
           <groupId>*</groupId>
@@ -199,7 +189,6 @@
     <dependency>
       <groupId>io.netty</groupId>
       <artifactId>netty-codec-socks</artifactId>
-      <version>${netty.version}</version>
       <exclusions>
         <exclusion>
           <groupId>*</groupId>
@@ -210,7 +199,6 @@
     <dependency>
       <groupId>io.netty</groupId>
       <artifactId>netty-codec-stomp</artifactId>
-      <version>${netty.version}</version>
       <exclusions>
         <exclusion>
           <groupId>*</groupId>
@@ -221,7 +209,6 @@
     <dependency>
       <groupId>io.netty</groupId>
       <artifactId>netty-codec-xml</artifactId>
-      <version>${netty.version}</version>
       <exclusions>
         <exclusion>
           <groupId>*</groupId>
@@ -233,7 +220,6 @@
     <dependency>
       <groupId>io.netty</groupId>
       <artifactId>netty-common</artifactId>
-      <version>${netty.version}</version>
       <exclusions>
         <exclusion>
           <groupId>*</groupId>
@@ -245,7 +231,6 @@
     <dependency>
       <groupId>io.netty</groupId>
       <artifactId>netty-handler</artifactId>
-      <version>${netty.version}</version>
       <exclusions>
         <exclusion>
           <groupId>*</groupId>
@@ -256,7 +241,6 @@
     <dependency>
       <groupId>io.netty</groupId>
       <artifactId>netty-handler-proxy</artifactId>
-      <version>${netty.version}</version>
       <exclusions>
         <exclusion>
           <groupId>*</groupId>
@@ -267,7 +251,6 @@
     <dependency>
       <groupId>io.netty</groupId>
       <artifactId>netty-handler-ssl-ocsp</artifactId>
-      <version>${netty.version}</version>
       <exclusions>
         <exclusion>
           <groupId>*</groupId>
@@ -279,7 +262,6 @@
     <dependency>
       <groupId>io.netty</groupId>
       <artifactId>netty-resolver</artifactId>
-      <version>${netty.version}</version>
       <exclusions>
         <exclusion>
           <groupId>*</groupId>
@@ -290,7 +272,6 @@
     <dependency>
       <groupId>io.netty</groupId>
       <artifactId>netty-resolver-dns</artifactId>
-      <version>${netty.version}</version>
       <exclusions>
         <exclusion>
           <groupId>*</groupId>
@@ -301,7 +282,6 @@
     <dependency>
       <groupId>io.netty</groupId>
       <artifactId>netty-resolver-dns-classes-macos</artifactId>
-      <version>${netty.version}</version>
       <exclusions>
         <exclusion>
           <groupId>*</groupId>
@@ -312,7 +292,6 @@
     <dependency>
       <groupId>io.netty</groupId>
       <artifactId>netty-resolver-dns-native-macos</artifactId>
-      <version>${netty.version}</version>
       <exclusions>
         <exclusion>
           <groupId>*</groupId>
@@ -324,7 +303,6 @@
     <dependency>
       <groupId>io.netty</groupId>
       <artifactId>netty-transport</artifactId>
-      <version>${netty.version}</version>
       <exclusions>
         <exclusion>
           <groupId>*</groupId>
@@ -335,7 +313,6 @@
     <dependency>
       <groupId>io.netty</groupId>
       <artifactId>netty-transport-classes-epoll</artifactId>
-      <version>${netty.version}</version>
       <exclusions>
         <exclusion>
           <groupId>*</groupId>
@@ -346,7 +323,6 @@
     <dependency>
       <groupId>io.netty</groupId>
       <artifactId>netty-transport-classes-kqueue</artifactId>
-      <version>${netty.version}</version>
       <exclusions>
         <exclusion>
           <groupId>*</groupId>
@@ -357,7 +333,6 @@
     <dependency>
       <groupId>io.netty</groupId>
       <artifactId>netty-transport-native-epoll</artifactId>
-      <version>${netty.version}</version>
       <classifier>linux-aarch_64</classifier>
       <exclusions>
         <exclusion>
@@ -369,7 +344,6 @@
     <dependency>
       <groupId>io.netty</groupId>
       <artifactId>netty-transport-native-epoll</artifactId>
-      <version>${netty.version}</version>
       <classifier>linux-x86_64</classifier>
       <exclusions>
         <exclusion>
@@ -381,7 +355,6 @@
     <dependency>
       <groupId>io.netty</groupId>
       <artifactId>netty-transport-native-epoll</artifactId>
-      <version>${netty.version}</version>
       <exclusions>
         <exclusion>
           <groupId>*</groupId>
@@ -392,7 +365,6 @@
     <dependency>
       <groupId>io.netty</groupId>
       <artifactId>netty-transport-native-kqueue</artifactId>
-      <version>${netty.version}</version>
       <classifier>osx-aarch_64</classifier>
       <exclusions>
         <exclusion>
@@ -404,7 +376,6 @@
     <dependency>
       <groupId>io.netty</groupId>
       <artifactId>netty-transport-native-kqueue</artifactId>
-      <version>${netty.version}</version>
       <classifier>osx-x86_64</classifier>
       <exclusions>
         <exclusion>
@@ -416,7 +387,6 @@
     <dependency>
       <groupId>io.netty</groupId>
       <artifactId>netty-transport-native-kqueue</artifactId>
-      <version>${netty.version}</version>
       <exclusions>
         <exclusion>
           <groupId>*</groupId>
@@ -427,7 +397,6 @@
     <dependency>
       <groupId>io.netty</groupId>
       <artifactId>netty-transport-native-unix-common</artifactId>
-      <version>${netty.version}</version>
       <exclusions>
         <exclusion>
           <groupId>*</groupId>
@@ -438,7 +407,6 @@
     <dependency>
       <groupId>io.netty</groupId>
       <artifactId>netty-transport-rxtx</artifactId>
-      <version>${netty.version}</version>
       <exclusions>
         <exclusion>
           <groupId>*</groupId>
@@ -449,7 +417,6 @@
     <dependency>
       <groupId>io.netty</groupId>
       <artifactId>netty-transport-sctp</artifactId>
-      <version>${netty.version}</version>
       <exclusions>
         <exclusion>
           <groupId>*</groupId>
@@ -460,7 +427,6 @@
     <dependency>
       <groupId>io.netty</groupId>
       <artifactId>netty-transport-udt</artifactId>
-      <version>${netty.version}</version>
       <exclusions>
         <exclusion>
           <groupId>*</groupId>

--- a/shims/emr770/driver/pom.xml
+++ b/shims/emr770/driver/pom.xml
@@ -107,7 +107,6 @@
     <dependency>
       <groupId>io.netty</groupId>
       <artifactId>netty-buffer</artifactId>
-      <version>${netty.version}</version>
       <exclusions>
         <exclusion>
           <groupId>*</groupId>
@@ -119,7 +118,6 @@
     <dependency>
       <groupId>io.netty</groupId>
       <artifactId>netty-codec</artifactId>
-      <version>${netty.version}</version>
       <exclusions>
         <exclusion>
           <groupId>*</groupId>
@@ -130,7 +128,6 @@
     <dependency>
       <groupId>io.netty</groupId>
       <artifactId>netty-codec-dns</artifactId>
-      <version>${netty.version}</version>
       <exclusions>
         <exclusion>
           <groupId>*</groupId>
@@ -141,7 +138,6 @@
     <dependency>
       <groupId>io.netty</groupId>
       <artifactId>netty-codec-haproxy</artifactId>
-      <version>${netty.version}</version>
       <exclusions>
         <exclusion>
           <groupId>*</groupId>
@@ -152,7 +148,6 @@
     <dependency>
       <groupId>io.netty</groupId>
       <artifactId>netty-codec-http2</artifactId>
-      <version>${netty.version}</version>
       <exclusions>
         <exclusion>
           <groupId>*</groupId>
@@ -163,7 +158,6 @@
     <dependency>
       <groupId>io.netty</groupId>
       <artifactId>netty-codec-http</artifactId>
-      <version>${netty.version}</version>
       <exclusions>
         <exclusion>
           <groupId>*</groupId>
@@ -174,7 +168,6 @@
     <dependency>
       <groupId>io.netty</groupId>
       <artifactId>netty-codec-memcache</artifactId>
-      <version>${netty.version}</version>
       <exclusions>
         <exclusion>
           <groupId>*</groupId>
@@ -185,7 +178,6 @@
     <dependency>
       <groupId>io.netty</groupId>
       <artifactId>netty-codec-mqtt</artifactId>
-      <version>${netty.version}</version>
       <exclusions>
         <exclusion>
           <groupId>*</groupId>
@@ -196,7 +188,6 @@
     <dependency>
       <groupId>io.netty</groupId>
       <artifactId>netty-codec-redis</artifactId>
-      <version>${netty.version}</version>
       <exclusions>
         <exclusion>
           <groupId>*</groupId>
@@ -207,7 +198,6 @@
     <dependency>
       <groupId>io.netty</groupId>
       <artifactId>netty-codec-smtp</artifactId>
-      <version>${netty.version}</version>
       <exclusions>
         <exclusion>
           <groupId>*</groupId>
@@ -218,7 +208,6 @@
     <dependency>
       <groupId>io.netty</groupId>
       <artifactId>netty-codec-socks</artifactId>
-      <version>${netty.version}</version>
       <exclusions>
         <exclusion>
           <groupId>*</groupId>
@@ -229,7 +218,6 @@
     <dependency>
       <groupId>io.netty</groupId>
       <artifactId>netty-codec-stomp</artifactId>
-      <version>${netty.version}</version>
       <exclusions>
         <exclusion>
           <groupId>*</groupId>
@@ -240,7 +228,6 @@
     <dependency>
       <groupId>io.netty</groupId>
       <artifactId>netty-codec-xml</artifactId>
-      <version>${netty.version}</version>
       <exclusions>
         <exclusion>
           <groupId>*</groupId>
@@ -252,7 +239,6 @@
     <dependency>
       <groupId>io.netty</groupId>
       <artifactId>netty-common</artifactId>
-      <version>${netty.version}</version>
       <exclusions>
         <exclusion>
           <groupId>*</groupId>
@@ -264,7 +250,6 @@
     <dependency>
       <groupId>io.netty</groupId>
       <artifactId>netty-handler</artifactId>
-      <version>${netty.version}</version>
       <exclusions>
         <exclusion>
           <groupId>*</groupId>
@@ -275,7 +260,6 @@
     <dependency>
       <groupId>io.netty</groupId>
       <artifactId>netty-handler-proxy</artifactId>
-      <version>${netty.version}</version>
       <exclusions>
         <exclusion>
           <groupId>*</groupId>
@@ -286,7 +270,6 @@
     <dependency>
       <groupId>io.netty</groupId>
       <artifactId>netty-handler-ssl-ocsp</artifactId>
-      <version>${netty.version}</version>
       <exclusions>
         <exclusion>
           <groupId>*</groupId>
@@ -298,7 +281,6 @@
     <dependency>
       <groupId>io.netty</groupId>
       <artifactId>netty-resolver</artifactId>
-      <version>${netty.version}</version>
       <exclusions>
         <exclusion>
           <groupId>*</groupId>
@@ -309,7 +291,6 @@
     <dependency>
       <groupId>io.netty</groupId>
       <artifactId>netty-resolver-dns</artifactId>
-      <version>${netty.version}</version>
       <exclusions>
         <exclusion>
           <groupId>*</groupId>
@@ -320,7 +301,6 @@
     <dependency>
       <groupId>io.netty</groupId>
       <artifactId>netty-resolver-dns-classes-macos</artifactId>
-      <version>${netty.version}</version>
       <exclusions>
         <exclusion>
           <groupId>*</groupId>
@@ -331,7 +311,6 @@
     <dependency>
       <groupId>io.netty</groupId>
       <artifactId>netty-resolver-dns-native-macos</artifactId>
-      <version>${netty.version}</version>
       <exclusions>
         <exclusion>
           <groupId>*</groupId>
@@ -343,7 +322,6 @@
     <dependency>
       <groupId>io.netty</groupId>
       <artifactId>netty-transport</artifactId>
-      <version>${netty.version}</version>
       <exclusions>
         <exclusion>
           <groupId>*</groupId>
@@ -354,7 +332,6 @@
     <dependency>
       <groupId>io.netty</groupId>
       <artifactId>netty-transport-classes-epoll</artifactId>
-      <version>${netty.version}</version>
       <exclusions>
         <exclusion>
           <groupId>*</groupId>
@@ -365,7 +342,6 @@
     <dependency>
       <groupId>io.netty</groupId>
       <artifactId>netty-transport-classes-kqueue</artifactId>
-      <version>${netty.version}</version>
       <exclusions>
         <exclusion>
           <groupId>*</groupId>
@@ -376,7 +352,6 @@
     <dependency>
       <groupId>io.netty</groupId>
       <artifactId>netty-transport-native-epoll</artifactId>
-      <version>${netty.version}</version>
       <classifier>linux-aarch_64</classifier>
       <exclusions>
         <exclusion>
@@ -388,7 +363,6 @@
     <dependency>
       <groupId>io.netty</groupId>
       <artifactId>netty-transport-native-epoll</artifactId>
-      <version>${netty.version}</version>
       <classifier>linux-x86_64</classifier>
       <exclusions>
         <exclusion>
@@ -400,7 +374,6 @@
     <dependency>
       <groupId>io.netty</groupId>
       <artifactId>netty-transport-native-epoll</artifactId>
-      <version>${netty.version}</version>
       <exclusions>
         <exclusion>
           <groupId>*</groupId>
@@ -411,7 +384,6 @@
     <dependency>
       <groupId>io.netty</groupId>
       <artifactId>netty-transport-native-kqueue</artifactId>
-      <version>${netty.version}</version>
       <classifier>osx-aarch_64</classifier>
       <exclusions>
         <exclusion>
@@ -423,7 +395,6 @@
     <dependency>
       <groupId>io.netty</groupId>
       <artifactId>netty-transport-native-kqueue</artifactId>
-      <version>${netty.version}</version>
       <classifier>osx-x86_64</classifier>
       <exclusions>
         <exclusion>
@@ -435,7 +406,6 @@
     <dependency>
       <groupId>io.netty</groupId>
       <artifactId>netty-transport-native-kqueue</artifactId>
-      <version>${netty.version}</version>
       <exclusions>
         <exclusion>
           <groupId>*</groupId>
@@ -446,7 +416,6 @@
     <dependency>
       <groupId>io.netty</groupId>
       <artifactId>netty-transport-native-unix-common</artifactId>
-      <version>${netty.version}</version>
       <exclusions>
         <exclusion>
           <groupId>*</groupId>
@@ -457,7 +426,6 @@
     <dependency>
       <groupId>io.netty</groupId>
       <artifactId>netty-transport-rxtx</artifactId>
-      <version>${netty.version}</version>
       <exclusions>
         <exclusion>
           <groupId>*</groupId>
@@ -468,7 +436,6 @@
     <dependency>
       <groupId>io.netty</groupId>
       <artifactId>netty-transport-sctp</artifactId>
-      <version>${netty.version}</version>
       <exclusions>
         <exclusion>
           <groupId>*</groupId>
@@ -479,7 +446,6 @@
     <dependency>
       <groupId>io.netty</groupId>
       <artifactId>netty-transport-udt</artifactId>
-      <version>${netty.version}</version>
       <exclusions>
         <exclusion>
           <groupId>*</groupId>

--- a/shims/hdi40/driver/pom.xml
+++ b/shims/hdi40/driver/pom.xml
@@ -326,7 +326,6 @@
     <dependency>
       <groupId>io.netty</groupId>
       <artifactId>netty-transport-classes-epoll</artifactId>
-      <version>${netty.version}</version>
     </dependency>
     <dependency>
       <groupId>org.apache.hadoop</groupId>
@@ -346,7 +345,6 @@
     <dependency>
       <groupId>io.netty</groupId>
       <artifactId>netty-buffer</artifactId>
-      <version>${netty.version}</version>
       <exclusions>
         <exclusion>
           <groupId>*</groupId>
@@ -357,7 +355,6 @@
     <dependency>
       <groupId>io.netty</groupId>
       <artifactId>netty-codec</artifactId>
-      <version>${netty.version}</version>
       <exclusions>
         <exclusion>
           <groupId>*</groupId>
@@ -368,7 +365,6 @@
     <dependency>
       <groupId>io.netty</groupId>
       <artifactId>netty-codec-http</artifactId>
-      <version>${netty.version}</version>
       <exclusions>
         <exclusion>
           <groupId>*</groupId>
@@ -379,7 +375,6 @@
     <dependency>
       <groupId>io.netty</groupId>
       <artifactId>netty-codec-http2</artifactId>
-      <version>${netty.version}</version>
       <exclusions>
         <exclusion>
           <groupId>*</groupId>
@@ -390,7 +385,6 @@
     <dependency>
       <groupId>io.netty</groupId>
       <artifactId>netty-codec-smtp</artifactId>
-      <version>${netty.version}</version>
       <exclusions>
         <exclusion>
           <groupId>*</groupId>
@@ -401,12 +395,10 @@
     <dependency>
       <groupId>io.netty</groupId>
       <artifactId>netty-common</artifactId>
-      <version>${netty.version}</version>
     </dependency>
     <dependency>
       <groupId>io.netty</groupId>
       <artifactId>netty-handler</artifactId>
-      <version>${netty.version}</version>
       <exclusions>
         <exclusion>
           <groupId>*</groupId>
@@ -417,7 +409,6 @@
     <dependency>
       <groupId>io.netty</groupId>
       <artifactId>netty-resolver</artifactId>
-      <version>${netty.version}</version>
       <exclusions>
         <exclusion>
           <groupId>*</groupId>
@@ -428,7 +419,6 @@
     <dependency>
       <groupId>io.netty</groupId>
       <artifactId>netty-transport</artifactId>
-      <version>${netty.version}</version>
       <exclusions>
         <exclusion>
           <groupId>*</groupId>
@@ -439,7 +429,6 @@
     <dependency>
       <groupId>io.netty</groupId>
       <artifactId>netty-transport-native-epoll</artifactId>
-      <version>${netty.version}</version>
       <classifier>linux-x86_64</classifier>
       <exclusions>
         <exclusion>


### PR DESCRIPTION
## Summary
Remove local Netty versions from Hadoop shim modules and inherit shared parent dependency management, including native transport classifiers.

## Validation
- `mvn -B -nsu -Dmaven.test.skip=true validate`