### PR TITLE
fix(SP-7466) Backport [PDI-20910] [Regression][PDI 10.2.0.6] MapReduce jobs fail on CDH 7.1.9 with YARN Exit 143 after protobuf upgrade in CDP shim

### DIFF
--- a/common-base/src/main/java/org/pentaho/big/data/impl/shim/mapreduce/PentahoMapReduceJobBuilderImpl.java
+++ b/common-base/src/main/java/org/pentaho/big/data/impl/shim/mapreduce/PentahoMapReduceJobBuilderImpl.java
@@ -151,6 +151,8 @@ public class PentahoMapReduceJobBuilderImpl extends MapReduceJobBuilderImpl impl
     "pentaho.authentication.default.mapping.server.credentials.kerberos.keytabLocation";
   private static final String MAPRED_MAP_JAVA_OPTS = "mapreduce.map.java.opts";
   private static final String MAPRED_REDUCE_JAVA_OPTS = "mapreduce.reduce.java.opts";
+  @VisibleForTesting
+  static final String PROTOBUF_GENCODE_FLAG = "-Dcom.google.protobuf.use_unsafe_pre22_gencode=true";
   public static final String VARIABLE_SPACE = "variableSpace";
   private final HadoopShim hadoopShim;
   private final LogChannelInterface log;
@@ -483,6 +485,7 @@ public class PentahoMapReduceJobBuilderImpl extends MapReduceJobBuilderImpl impl
     conf.set( LOG_LEVEL, logLevel.toString() );
     configureVariableSpace( conf );
     super.configure( conf );
+    appendProtobufGencodeFlag( conf );
   }
 
   @Override
@@ -658,10 +661,30 @@ public class PentahoMapReduceJobBuilderImpl extends MapReduceJobBuilderImpl impl
 
     // set a string in the job configuration as the serialized variablespace
     conf.setStrings( VARIABLE_SPACE, xmlVariableSpace );
+  }
 
-    //For allowing protobuf compatibility
-    conf.set( MAPRED_MAP_JAVA_OPTS, "-Dcom.google.protobuf.use_unsafe_pre22_gencode=true" );
-    conf.set( MAPRED_REDUCE_JAVA_OPTS, "-Dcom.google.protobuf.use_unsafe_pre22_gencode=true" );
+  /**
+   * Appends the protobuf gencode compatibility flag to the map and reduce JVM opts in {@code conf}.
+   * <p>
+   * This method is intentionally called <em>after</em> {@code super.configure(conf)} so that the flag is applied after
+   * the user-defined property loop in {@link MapReduceJobBuilderImpl#configure(Configuration)} (which can overwrite
+   * earlier {@code conf.set(...)} values). The logic is additive: if the flag is already present (e.g. set via
+   * mapred-site.xml or provided by the user) it is not duplicated.
+   * </p>
+   *
+   * @param conf the Hadoop {@link Configuration} to update
+   */
+  @VisibleForTesting
+  void appendProtobufGencodeFlag( Configuration conf ) {
+    for ( String optKey : new String[] { MAPRED_MAP_JAVA_OPTS, MAPRED_REDUCE_JAVA_OPTS } ) {
+      String existing = conf.get( optKey );
+      if ( existing == null || existing.trim().isEmpty() ) {
+        conf.set( optKey, PROTOBUF_GENCODE_FLAG );
+      } else if ( !existing.contains( PROTOBUF_GENCODE_FLAG ) ) {
+        conf.set( optKey, existing.trim() + " " + PROTOBUF_GENCODE_FLAG );
+      }
+      // flag already present – leave as-is (idempotent)
+    }
   }
 
   @VisibleForTesting

--- a/common-base/src/test/java/org/pentaho/big/data/impl/shim/mapreduce/PentahoMapReduceJobBuilderImplTest.java
+++ b/common-base/src/test/java/org/pentaho/big/data/impl/shim/mapreduce/PentahoMapReduceJobBuilderImplTest.java
@@ -96,6 +96,7 @@ import static org.mockito.Mockito.when;
 /**
  * Created by bryan on 1/12/16.
  */
+@SuppressWarnings( "deprecation" )
 @FixMethodOrder( MethodSorters.NAME_ASCENDING )
 @RunWith( MockitoJUnitRunner.class )
 public class PentahoMapReduceJobBuilderImplTest {
@@ -938,5 +939,91 @@ public class PentahoMapReduceJobBuilderImplTest {
     verify( conf ).set( PentahoMapReduceJobBuilderImpl.MAPREDUCE_APPLICATION_CLASSPATH,
       PentahoMapReduceJobBuilderImpl.CLASSES + mapreduceClasspath );
     verify( distributedCacheUtil ).configureWithKettleEnvironment( conf, fileSystem, kettleEnvInstallDir );
+  }
+
+  // -------------------------------------------------------------------------
+  // Tests for appendProtobufGencodeFlag / protobuf regression fix
+  // -------------------------------------------------------------------------
+
+  @Test
+  public void testAppendProtobufGencodeFlagWhenNoExistingOpts() {
+    // When no JVM opts are configured, the flag must be set on its own.
+    Configuration configuration = mock( Configuration.class );
+    when( configuration.get( "mapreduce.map.java.opts" ) ).thenReturn( null );
+    when( configuration.get( "mapreduce.reduce.java.opts" ) ).thenReturn( null );
+
+    pentahoMapReduceJobBuilder.appendProtobufGencodeFlag( configuration );
+
+    verify( configuration ).set( "mapreduce.map.java.opts",
+      PentahoMapReduceJobBuilderImpl.PROTOBUF_GENCODE_FLAG );
+    verify( configuration ).set( "mapreduce.reduce.java.opts",
+      PentahoMapReduceJobBuilderImpl.PROTOBUF_GENCODE_FLAG );
+  }
+
+  @Test
+  public void testAppendProtobufGencodeFlagAppendsToExistingOpts() {
+    // When user-defined JVM opts already exist the flag must be appended, not replace them.
+    Configuration configuration = mock( Configuration.class );
+    String existingMapOpts = "-Xmx1024m";
+    String existingReduceOpts = "-Xmx2048m -XX:+UseG1GC";
+    when( configuration.get( "mapreduce.map.java.opts" ) ).thenReturn( existingMapOpts );
+    when( configuration.get( "mapreduce.reduce.java.opts" ) ).thenReturn( existingReduceOpts );
+
+    pentahoMapReduceJobBuilder.appendProtobufGencodeFlag( configuration );
+
+    verify( configuration ).set( "mapreduce.map.java.opts",
+      existingMapOpts + " " + PentahoMapReduceJobBuilderImpl.PROTOBUF_GENCODE_FLAG );
+    verify( configuration ).set( "mapreduce.reduce.java.opts",
+      existingReduceOpts + " " + PentahoMapReduceJobBuilderImpl.PROTOBUF_GENCODE_FLAG );
+  }
+
+  @Test
+  public void testAppendProtobufGencodeFlagIsIdempotentWhenFlagAlreadyPresent() {
+    // When the flag is already present in the opts it must not be duplicated.
+    Configuration configuration = mock( Configuration.class );
+    String optsWithFlag = "-Xmx1024m " + PentahoMapReduceJobBuilderImpl.PROTOBUF_GENCODE_FLAG;
+    when( configuration.get( "mapreduce.map.java.opts" ) ).thenReturn( optsWithFlag );
+    when( configuration.get( "mapreduce.reduce.java.opts" ) ).thenReturn( optsWithFlag );
+
+    pentahoMapReduceJobBuilder.appendProtobufGencodeFlag( configuration );
+
+    // conf.set must NOT be called because the flag is already present.
+    verify( configuration, never() ).set( eq( "mapreduce.map.java.opts" ), anyString() );
+    verify( configuration, never() ).set( eq( "mapreduce.reduce.java.opts" ), anyString() );
+  }
+
+  @Test
+  public void testConfigureAppendsProtobufFlagAfterUserDefinedProps() throws Exception {
+    // End-to-end regression test: user-defined mapreduce.map.java.opts must NOT suppress the protobuf flag.
+    when( hadoopShim.getPentahoMapReduceMapRunnerClass() ).thenReturn( "" );
+    pentahoMapReduceJobBuilder.setLogLevel( LogLevel.BASIC );
+    pentahoMapReduceJobBuilder.setInputPaths( new String[ 0 ] );
+    pentahoMapReduceJobBuilder.setOutputPath( "test" );
+    pentahoMapReduceJobBuilder.setResolvedJarUrl( new URL( "file:///" ) );
+
+    // Simulate user setting custom JVM opts in the MR job step.
+    String userMapOpts = "-Xmx1024m";
+    pentahoMapReduceJobBuilder.set( "mapreduce.map.java.opts", userMapOpts );
+
+    // Use a real map to track conf.set() calls so we can inspect the final value.
+    java.util.Map<String, String> confStore = new java.util.HashMap<>();
+    Configuration configuration = mock( Configuration.class );
+    doAnswer( invocation -> {
+      confStore.put( invocation.getArgument( 0 ), invocation.getArgument( 1 ) );
+      return null;
+    } ).when( configuration ).set( anyString(), anyString() );
+    when( configuration.get( anyString() ) ).thenAnswer(
+      invocation -> confStore.get( invocation.getArgument( 0 ) ) );
+
+    when( hadoopShim.getFileSystem( configuration ) ).thenReturn( mock( FileSystem.class ) );
+    pentahoMapReduceJobBuilder.setMapperInfo( transXml, "testMrInput", "testMrOutput" );
+
+    pentahoMapReduceJobBuilder.configure( configuration );
+
+    String finalMapOpts = confStore.get( "mapreduce.map.java.opts" );
+    assertNotNull( "mapreduce.map.java.opts must be set", finalMapOpts );
+    assertTrue( "user opts must be preserved", finalMapOpts.contains( userMapOpts ) );
+    assertTrue( "protobuf flag must be present even when user opts exist",
+      finalMapOpts.contains( PentahoMapReduceJobBuilderImpl.PROTOBUF_GENCODE_FLAG ) );
   }
 }


### PR DESCRIPTION
This pull request introduces a more robust and flexible way to ensure protobuf compatibility in Hadoop MapReduce jobs by refactoring how the `-Dcom.google.protobuf.use_unsafe_pre22_gencode=true` JVM flag is applied. The flag is now appended to existing JVM options for map and reduce tasks in an idempotent manner, ensuring user-defined options are preserved and the flag is not duplicated. Comprehensive unit tests have been added to verify the new logic.

**Protobuf JVM flag handling improvements:**

* Introduced the `appendProtobufGencodeFlag` method in `PentahoMapReduceJobBuilderImpl` to append the protobuf compatibility flag to both `mapreduce.map.java.opts` and `mapreduce.reduce.java.opts`, ensuring the flag is present, not duplicated, and user-supplied options are preserved. (`PentahoMapReduceJobBuilderImpl.java`) [[1]](diffhunk://#diff-945ca70f8a280fb38a2c09c934f4de95443b35fcd77a0a3ac04b03e90ac87516R154-R155) [[2]](diffhunk://#diff-945ca70f8a280fb38a2c09c934f4de95443b35fcd77a0a3ac04b03e90ac87516R664-R687)
* Refactored the configuration process to call `appendProtobufGencodeFlag` after user-defined properties are set, guaranteeing the flag is always applied last and cannot be overwritten by user configuration. (`PentahoMapReduceJobBuilderImpl.java`)

**Testing enhancements:**

* Added a suite of targeted unit tests for `appendProtobufGencodeFlag`, covering scenarios with absent, present, and already-flagged JVM options, as well as an end-to-end regression test to ensure user-defined options are respected and the flag is always present. (`PentahoMapReduceJobBuilderImplTest.java`)
* Added `@SuppressWarnings("deprecation")` to the test class to address deprecation warnings. (`PentahoMapReduceJobBuilderImplTest.java`)