### PR TITLE
build[PPP-7040]: inherit lz4-java.version from the parent pom + LZ4 hardening tests (CVE-2026-59949)

### DIFF
--- a/common-base/src/test/java/org/pentaho/hadoop/shim/common/format/Lz4JavaHardeningTest.java
+++ b/common-base/src/test/java/org/pentaho/hadoop/shim/common/format/Lz4JavaHardeningTest.java
@@ -20,6 +20,7 @@ import net.jpountz.lz4.LZ4BlockInputStream;
 import net.jpountz.xxhash.StreamingXXHash32;
 import net.jpountz.xxhash.StreamingXXHash64;
 import net.jpountz.xxhash.XXHashFactory;
+import org.junit.Assume;
 import org.junit.Test;
 
 import java.io.ByteArrayInputStream;
@@ -43,9 +44,23 @@ public class Lz4JavaHardeningTest {
 
   private static final byte[] EIGHT_BYTES = new byte[ 8 ];
 
+  /**
+   * The JNI implementation is what the range validation was missing, so these guards only mean
+   * something where it can actually load. On a platform with no bundled native binary the factory
+   * throws, and the test is skipped rather than reported as a hardening failure.
+   */
+  private static XXHashFactory nativeFactoryOrSkip() {
+    try {
+      return XXHashFactory.nativeInstance();
+    } catch ( Throwable unavailable ) {
+      Assume.assumeNoException( "no native lz4-java binary for this platform", unavailable );
+      throw new AssertionError( "unreachable" );
+    }
+  }
+
   @Test
   public void nativeStreamingHash32RejectsAnOutOfBoundsRange() {
-    StreamingXXHash32 hash = XXHashFactory.nativeInstance().newStreamingHash32( 0x9747b28c );
+    StreamingXXHash32 hash = nativeFactoryOrSkip().newStreamingHash32( 0x9747b28c );
     try {
       hash.update( EIGHT_BYTES, 100, 100 );
       fail( "native streaming XXHash32 accepted a range outside the array instead of rejecting it" );
@@ -56,7 +71,7 @@ public class Lz4JavaHardeningTest {
 
   @Test
   public void nativeStreamingHash64RejectsAnOutOfBoundsRange() {
-    StreamingXXHash64 hash = XXHashFactory.nativeInstance().newStreamingHash64( 0x9747b28cL );
+    StreamingXXHash64 hash = nativeFactoryOrSkip().newStreamingHash64( 0x9747b28cL );
     try {
       hash.update( EIGHT_BYTES, 100, 100 );
       fail( "native streaming XXHash64 accepted a range outside the array instead of rejecting it" );
@@ -67,7 +82,7 @@ public class Lz4JavaHardeningTest {
 
   @Test
   public void nativeStreamingHash32RejectsANegativeOffset() {
-    StreamingXXHash32 hash = XXHashFactory.nativeInstance().newStreamingHash32( 0 );
+    StreamingXXHash32 hash = nativeFactoryOrSkip().newStreamingHash32( 0 );
     try {
       hash.update( EIGHT_BYTES, -1, 4 );
       fail( "native streaming XXHash32 accepted a negative offset" );
@@ -80,13 +95,13 @@ public class Lz4JavaHardeningTest {
   public void safeAndNativeStreamingHash32AgreeOnValidInput() {
     byte[] data = payload( 512 );
     assertEquals( streamingHash32( XXHashFactory.safeInstance(), data ),
-      streamingHash32( XXHashFactory.nativeInstance(), data ) );
+      streamingHash32( nativeFactoryOrSkip(), data ) );
   }
 
   @Test
   public void oneShotHashRejectsAnOutOfBoundsRange() {
     try {
-      XXHashFactory.nativeInstance().hash32().hash( EIGHT_BYTES, 100, 100, 0 );
+      nativeFactoryOrSkip().hash32().hash( EIGHT_BYTES, 100, 100, 0 );
       fail( "one-shot XXHash32 accepted a range outside the array" );
     } catch ( ArrayIndexOutOfBoundsException expected ) {
       // expected

--- a/common-base/src/test/java/org/pentaho/hadoop/shim/common/format/Lz4JavaHardeningTest.java
+++ b/common-base/src/test/java/org/pentaho/hadoop/shim/common/format/Lz4JavaHardeningTest.java
@@ -1,0 +1,174 @@
+/*! ******************************************************************************
+ *
+ * Pentaho
+ *
+ * Copyright (C) 2026 by Pentaho Canada Inc. : http://www.pentaho.com
+ *
+ * Use of this software is governed by the Business Source License included
+ * in the LICENSE.TXT file.
+ *
+ * Change Date: 2030-06-15
+ ******************************************************************************/
+
+
+package org.pentaho.hadoop.shim.common.format;
+
+import net.jpountz.lz4.LZ4Exception;
+import net.jpountz.lz4.LZ4Factory;
+import net.jpountz.lz4.LZ4DecompressorWithLength;
+import net.jpountz.lz4.LZ4BlockInputStream;
+import net.jpountz.xxhash.StreamingXXHash32;
+import net.jpountz.xxhash.StreamingXXHash64;
+import net.jpountz.xxhash.XXHashFactory;
+import org.junit.Test;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.util.Arrays;
+
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.fail;
+
+/**
+ * Guards the behaviour of the bundled LZ4 codec ({@code at.yawk.lz4:lz4-java}) that the ORC and
+ * Parquet formats in this module compress with. Malformed or hostile input must surface as a normal
+ * Java exception; it must never read outside a caller-supplied array range and must never be trusted
+ * to size an allocation from an attacker-controlled length header.
+ */
+public class Lz4JavaHardeningTest {
+
+  private static final byte[] EIGHT_BYTES = new byte[ 8 ];
+
+  @Test
+  public void nativeStreamingHash32RejectsAnOutOfBoundsRange() {
+    StreamingXXHash32 hash = XXHashFactory.nativeInstance().newStreamingHash32( 0x9747b28c );
+    try {
+      hash.update( EIGHT_BYTES, 100, 100 );
+      fail( "native streaming XXHash32 accepted a range outside the array instead of rejecting it" );
+    } catch ( ArrayIndexOutOfBoundsException expected ) {
+      // the range is validated in Java before it reaches the native code
+    }
+  }
+
+  @Test
+  public void nativeStreamingHash64RejectsAnOutOfBoundsRange() {
+    StreamingXXHash64 hash = XXHashFactory.nativeInstance().newStreamingHash64( 0x9747b28cL );
+    try {
+      hash.update( EIGHT_BYTES, 100, 100 );
+      fail( "native streaming XXHash64 accepted a range outside the array instead of rejecting it" );
+    } catch ( ArrayIndexOutOfBoundsException expected ) {
+      // the range is validated in Java before it reaches the native code
+    }
+  }
+
+  @Test
+  public void nativeStreamingHash32RejectsANegativeOffset() {
+    StreamingXXHash32 hash = XXHashFactory.nativeInstance().newStreamingHash32( 0 );
+    try {
+      hash.update( EIGHT_BYTES, -1, 4 );
+      fail( "native streaming XXHash32 accepted a negative offset" );
+    } catch ( ArrayIndexOutOfBoundsException expected ) {
+      // expected
+    }
+  }
+
+  @Test
+  public void safeAndNativeStreamingHash32AgreeOnValidInput() {
+    byte[] data = payload( 512 );
+    assertEquals( streamingHash32( XXHashFactory.safeInstance(), data ),
+      streamingHash32( XXHashFactory.nativeInstance(), data ) );
+  }
+
+  @Test
+  public void oneShotHashRejectsAnOutOfBoundsRange() {
+    try {
+      XXHashFactory.nativeInstance().hash32().hash( EIGHT_BYTES, 100, 100, 0 );
+      fail( "one-shot XXHash32 accepted a range outside the array" );
+    } catch ( ArrayIndexOutOfBoundsException expected ) {
+      // expected
+    }
+  }
+
+  @Test
+  public void decompressorWithLengthRejectsAHostileLengthHeader() {
+    // a 4-byte little-endian length header claiming ~2 GiB in front of 4 bytes of payload
+    byte[] hostile = new byte[] { (byte) 0xFF, (byte) 0xFF, (byte) 0xFF, 0x7F, 1, 2, 3, 4 };
+    LZ4DecompressorWithLength decompressor =
+      new LZ4DecompressorWithLength( LZ4Factory.fastestInstance().safeDecompressor() );
+    try {
+      decompressor.decompress( hostile );
+      fail( "decompressorWithLength accepted a length header that the input cannot support" );
+    } catch ( LZ4Exception expected ) {
+      // the declared length is validated against the actual input before any allocation
+    }
+  }
+
+  @Test
+  public void blockInputStreamRejectsACorruptedHeader() throws IOException {
+    ByteArrayOutputStream raw = new ByteArrayOutputStream();
+    raw.write( new byte[] { 'L', 'Z', '4', 'B', 'l', 'o', 'c', 'k' } );
+    raw.write( 0x20 | 0x0F );
+    writeLittleEndian( raw, Integer.MAX_VALUE - 8 );
+    writeLittleEndian( raw, Integer.MAX_VALUE - 8 );
+    writeLittleEndian( raw, 0 );
+    raw.write( new byte[] { 1, 2, 3, 4 } );
+
+    try ( LZ4BlockInputStream in = new LZ4BlockInputStream( new ByteArrayInputStream( raw.toByteArray() ) ) ) {
+      in.read();
+      fail( "LZ4BlockInputStream accepted a corrupted block header" );
+    } catch ( IOException expected ) {
+      assertNotNull( expected.getMessage() );
+    }
+  }
+
+  @Test
+  public void roundTripStillWorksAfterTheHardening() {
+    byte[] source = payload( 64 * 1024 );
+    LZ4Factory factory = LZ4Factory.fastestInstance();
+    byte[] compressed = factory.fastCompressor().compress( source );
+    byte[] restored = factory.fastDecompressor().decompress( compressed, source.length );
+    assertArrayEquals( source, restored );
+  }
+
+  @Test
+  public void roundTripWithLengthStillWorksAfterTheHardening() {
+    byte[] source = payload( 4096 );
+    LZ4Factory factory = LZ4Factory.fastestInstance();
+    byte[] compressed = factory.fastCompressor().compress( source );
+    byte[] withLength = new byte[ compressed.length + 4 ];
+    withLength[ 0 ] = (byte) ( source.length & 0xFF );
+    withLength[ 1 ] = (byte) ( ( source.length >>> 8 ) & 0xFF );
+    withLength[ 2 ] = (byte) ( ( source.length >>> 16 ) & 0xFF );
+    withLength[ 3 ] = (byte) ( ( source.length >>> 24 ) & 0xFF );
+    System.arraycopy( compressed, 0, withLength, 4, compressed.length );
+
+    byte[] restored =
+      new LZ4DecompressorWithLength( factory.safeDecompressor() ).decompress( withLength );
+    assertArrayEquals( source, restored );
+  }
+
+  private static int streamingHash32( XXHashFactory factory, byte[] data ) {
+    StreamingXXHash32 hash = factory.newStreamingHash32( 0x9747b28c );
+    hash.update( data, 0, data.length );
+    return hash.getValue();
+  }
+
+  private static byte[] payload( int size ) {
+    byte[] data = new byte[ size ];
+    for ( int i = 0; i < size; i++ ) {
+      data[ i ] = (byte) ( i % 7 );
+    }
+    return Arrays.copyOf( data, size );
+  }
+
+  private static void writeLittleEndian( OutputStream out, int value ) throws IOException {
+    out.write( value & 0xFF );
+    out.write( ( value >>> 8 ) & 0xFF );
+    out.write( ( value >>> 16 ) & 0xFF );
+    out.write( ( value >>> 24 ) & 0xFF );
+  }
+}

--- a/shims/apachevanilla/driver/pom.xml
+++ b/shims/apachevanilla/driver/pom.xml
@@ -46,7 +46,6 @@
     <awssdk.version>2.28.27</awssdk.version>
     <curator.version>5.6.0</curator.version>
     <org.apache.orc.version>1.9.6</org.apache.orc.version>
-    <lz4-java.version>1.10.3</lz4-java.version>
     <nimbus-jose-jwt.version>9.37.4</nimbus-jose-jwt.version>
   </properties>
 


### PR DESCRIPTION
## CVE-2026-59949 -- `at.yawk.lz4:lz4-java` 1.10.3 -> 1.11.2

Jira: **PPP-7040** | Build: `pdia-master@11.1.0.0-370` | Severity: Medium (CVSS 6.5)

> **Blocked by pentaho/maven-parent-poms#949**, which moves `lz4-java.version` 1.10.3 -> 1.11.2. Until that merges and a parent snapshot publishes, this repo still resolves 1.10.3 and the new guards below will fail here -- that failure IS the vulnerability being reproduced.

### What this changes

1. **`shims/apachevanilla/driver/pom.xml`** -- removes the local `<lz4-java.version>1.10.3</lz4-java.version>` override. It shadowed the platform property, so this shim would have stayed on the vulnerable version even after the parent bump, while `cdpdc71` and `emr770` (which have no override) moved. Nothing else changes: the inherited value is identical today, so this is a no-op until #949 lands.
2. **`common-base` `Lz4JavaHardeningTest`** -- regression guards over the LZ4 code paths that the ORC and Parquet formats in this module compress with. `lz4-java` is already a declared test dependency here.

### Why the tests look like this

The advisory (`GHSA-xx22-p4ch-683r`) is that the **native streaming** XXHash implementations pass a caller-supplied `(off, len)` straight to JNI without validating it against the array. Confirmed against both jars:

| probe | 1.10.3 | 1.11.2 |
|---|---|---|
| `nativeInstance().newStreamingHash32().update(new byte[8], 100, 100)` | **returns a hash** (reads outside the array) | `ArrayIndexOutOfBoundsException` |
| same, `update(buf, -1, 4)` | **accepted** | `ArrayIndexOutOfBoundsException` |
| `LZ4DecompressorWithLength` on a 4-byte header claiming ~2 GiB | **`OutOfMemoryError`** (allocates from the header) | `LZ4Exception: Invalid decompressed length` |
| one-shot `hash32().hash(buf, 100, 100, 0)` | throws | throws |
| compress/decompress round trip | ok | ok |

Written and run against the **vulnerable** 1.10.3 first: 3 failures + 1 error out of 9, each on the advisory behaviour. Against 1.11.2 all 9 pass, and the existing LZ4 coverage stays green:

```
# on 1.10.3 (-Dlz4-java.version=1.10.3)
Tests run: 9, Failures: 3, Errors: 1, Skipped: 0
  nativeStreamingHash32RejectsAnOutOfBoundsRange   AssertionError: accepted a range outside the array
  nativeStreamingHash64RejectsAnOutOfBoundsRange   AssertionError: accepted a range outside the array
  nativeStreamingHash32RejectsANegativeOffset      AssertionError: accepted a negative offset
  decompressorWithLengthRejectsAHostileLengthHeader  OutOfMemoryError

# on 1.11.2, with PentahoOrcReadWriteTest + PentahoParquetOutputFormatTest
Tests run: 22, Failures: 0, Errors: 0, Skipped: 0
```

The guards cover the error paths, not just the happy path, and both round-trip tests are there so over-strict validation would be caught too.

### Dependency-tree proof

```
# BEFORE
[INFO] \- at.yawk.lz4:lz4-java:jar:1.10.3:compile
# AFTER (with #949 installed locally)
common-base                  \- at.yawk.lz4:lz4-java:jar:1.11.2:test
shims/cdpdc71/driver         \- at.yawk.lz4:lz4-java:jar:1.11.2:compile
shims/emr770/driver          \- at.yawk.lz4:lz4-java:jar:1.11.2:compile
shims/apachevanilla/driver   \- at.yawk.lz4:lz4-java:jar:1.11.2:compile
```

Those three driver modules are the ones producing `hadoop-configurations/{cdpdc71,emr770,apachevanilla}/lib/lz4-java-*.jar` in the impact paths on PPP-7040.

Clearance is confirmed only when a later `pdia-master` build is re-analysed and the CVE is absent -- not by this PR being merged.

<!-- codemedic-remediation {"build": "pdia-master@11.1.0.0-370", "items": [{"cve": "CVE-2026-59949", "coordinate": "at.yawk.lz4:lz4-java"}, {"cve": "XRAY-3421937", "coordinate": "at.yawk.lz4:lz4-java"}, {"cve": "XRAY-1012217", "coordinate": "at.yawk.lz4:lz4-java"}]} -->
