### PR TITLE
fix(SP-7554) Backport [PPP-6304] Bump missing avro libs to non vulnerable version 1.12.1

### DIFF
--- a/common-base/pom.xml
+++ b/common-base/pom.xml
@@ -19,7 +19,7 @@
     <gateway-shell.version>1.0.0.3.0.0.0-1634</gateway-shell.version>
     <guava.version>32.1.2-jre</guava.version>
     <failureaccess.version>1.0.1</failureaccess.version>
-    <org.apache.avro.version>1.12.0</org.apache.avro.version>
+    <org.apache.avro.version>1.12.1</org.apache.avro.version>
     <awssdk.version>2.28.27</awssdk.version>
     <!-- client and default folders -->
     <gcs.version>hadoop2-1.9.17</gcs.version>
@@ -640,4 +640,3 @@
     </plugins>
   </build>
 </project>
-

--- a/shims/apache/driver/pom.xml
+++ b/shims/apache/driver/pom.xml
@@ -18,7 +18,7 @@
     <!-- default folder -->
     <guava.version>32.1.2-jre</guava.version>
     <failureaccess.version>1.0.1</failureaccess.version>
-    <org.apache.avro.version>1.12.0</org.apache.avro.version>
+    <org.apache.avro.version>1.12.1</org.apache.avro.version>
     <awssdk.version>2.28.27</awssdk.version>
     <!-- client and default folders -->
     <gcs.version>hadoop2-1.9.17</gcs.version>
@@ -551,4 +551,3 @@
     </plugins>
   </build>
 </project>
-

--- a/shims/apachevanilla/driver/pom.xml
+++ b/shims/apachevanilla/driver/pom.xml
@@ -17,7 +17,7 @@
     <commons-lang.version>2.6</commons-lang.version>
     <failureaccess.version>1.0.1</failureaccess.version>
     <pentaho-osgi-bundles.version>11.0.0.0-SNAPSHOT</pentaho-osgi-bundles.version>
-    <org.apache.avro.version>1.12.0</org.apache.avro.version>
+    <org.apache.avro.version>1.12.1</org.apache.avro.version>
     <!-- settting v1.14.4 so shaded jackson-databind inside parquet-hadoop-bundle's  version approximately matches jackson-databind in driver.jar -->
     <parquet.version>1.14.4</parquet.version>
     <org.apache.hbase.version>2.6.2</org.apache.hbase.version>

--- a/shims/dataproc1421/pom.xml
+++ b/shims/dataproc1421/pom.xml
@@ -26,7 +26,7 @@
     <org.apache.oozie.version>4.3.1</org.apache.oozie.version>
     <sqoop.version>1.4.7</sqoop.version>
     <hive-jdbc.version>2.3.6</hive-jdbc.version>
-    <org.apache.avro.version>1.12.0</org.apache.avro.version>
+    <org.apache.avro.version>1.12.1</org.apache.avro.version>
     <hadoop-aws.version>2.9.2</hadoop-aws.version>
 
     <!-- client and default folders -->

--- a/shims/emr700/driver/pom.xml
+++ b/shims/emr700/driver/pom.xml
@@ -13,7 +13,7 @@
   <packaging>jar</packaging>
 
   <properties>
-    <org.apache.avro.version>1.12.0</org.apache.avro.version>
+    <org.apache.avro.version>1.12.1</org.apache.avro.version>
     <org.apache.hive.version>4.0.1</org.apache.hive.version>
     <org.apache.oozie.version>5.2.1</org.apache.oozie.version>
     <org.apache.hbase.version>2.6.2</org.apache.hbase.version>

--- a/shims/emr770/driver/pom.xml
+++ b/shims/emr770/driver/pom.xml
@@ -15,7 +15,7 @@
   <properties>
     <shim.id>emr770</shim.id>
     <jsr311-api.version>1.1.1</jsr311-api.version>
-    <org.apache.avro.version>1.12.0</org.apache.avro.version>
+    <org.apache.avro.version>1.12.1</org.apache.avro.version>
     <org.apache.hive.version>4.1.0</org.apache.hive.version>
     <org.apache.oozie.version>5.2.1</org.apache.oozie.version>
     <org.apache.hbase.version>2.6.2</org.apache.hbase.version>

--- a/shims/hdi40/driver/pom.xml
+++ b/shims/hdi40/driver/pom.xml
@@ -16,7 +16,7 @@
     <shim.id>hdi40</shim.id>
     <commons-lang.version>2.6</commons-lang.version>
     <pentaho-osgi-bundles.version>11.0.0.0-SNAPSHOT</pentaho-osgi-bundles.version>
-    <org.apache.avro.version>1.12.0</org.apache.avro.version>
+    <org.apache.avro.version>1.12.1</org.apache.avro.version>
     <!-- settting v1.14.4 so shaded jackson-databind inside parquet-hadoop-bundle's  version approximately matches jackson-databind in driver.jar -->
     <parquet.version>1.14.4</parquet.version>
     <org.apache.hbase.version>2.4.17.7.1.9.0-387</org.apache.hbase.version>


### PR DESCRIPTION
- cdpdc71 was left unchanged because this branch uses a vendor-pinned Avro version 1.11.1.7.3.1.0-197.
- dataproc23 was omitted because its POM is deleted on this branch.
