### PR TITLE
build(PPP-7120): Centralize pentaho-shaded-netty dependency management

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -62,11 +62,6 @@
   <dependencyManagement>
     <dependencies>
       <dependency>
-        <groupId>org.pentaho.hadoop</groupId>
-        <artifactId>pentaho-shaded-netty</artifactId>
-        <version>${netty.version}-pentaho-1</version>
-      </dependency>
-      <dependency>
         <groupId>pentaho</groupId>
         <artifactId>pentaho-hdfs-vfs</artifactId>
         <version>${pentaho-hdfs-vfs.version}</version>

--- a/pom.xml
+++ b/pom.xml
@@ -62,6 +62,11 @@
   <dependencyManagement>
     <dependencies>
       <dependency>
+        <groupId>org.pentaho.hadoop</groupId>
+        <artifactId>pentaho-shaded-netty</artifactId>
+        <version>${netty.version}-pentaho-1</version>
+      </dependency>
+      <dependency>
         <groupId>pentaho</groupId>
         <artifactId>pentaho-hdfs-vfs</artifactId>
         <version>${pentaho-hdfs-vfs.version}</version>

--- a/shims/apachevanilla/driver/pom.xml
+++ b/shims/apachevanilla/driver/pom.xml
@@ -732,7 +732,6 @@
     <dependency>
       <groupId>org.pentaho.hadoop</groupId>
       <artifactId>pentaho-shaded-netty</artifactId>
-      <version>1.0.2</version>
     </dependency>
     <dependency>
       <groupId>org.apache.hbase</groupId>

--- a/shims/cdpdc71/driver/pom.xml
+++ b/shims/cdpdc71/driver/pom.xml
@@ -749,7 +749,6 @@
     <dependency>
       <groupId>org.pentaho.hadoop</groupId>
       <artifactId>pentaho-shaded-netty</artifactId>
-      <version>1.0.2</version>
     </dependency>
     <dependency>
       <groupId>org.apache.hbase</groupId>

--- a/shims/cdpdc71/pmr/pom.xml
+++ b/shims/cdpdc71/pmr/pom.xml
@@ -327,7 +327,6 @@
     <dependency>
       <groupId>org.pentaho.hadoop</groupId>
       <artifactId>pentaho-shaded-netty</artifactId>
-      <version>1.0.2</version>
     </dependency>
     <dependency>
       <groupId>org.apache.hbase.thirdparty</groupId>

--- a/shims/dataproc1421/driver/pom.xml
+++ b/shims/dataproc1421/driver/pom.xml
@@ -432,7 +432,6 @@
     <dependency>
       <groupId>org.pentaho.hadoop</groupId>
       <artifactId>pentaho-shaded-netty</artifactId>
-      <version>1.0.2</version>
     </dependency>
     <dependency>
       <groupId>org.apache.hbase</groupId>

--- a/shims/dataproc23/driver/pom.xml
+++ b/shims/dataproc23/driver/pom.xml
@@ -449,7 +449,6 @@
     <dependency>
       <groupId>org.pentaho.hadoop</groupId>
       <artifactId>pentaho-shaded-netty</artifactId>
-      <version>1.0.2</version>
     </dependency>
     <dependency>
       <groupId>org.apache.hbase</groupId>

--- a/shims/emr770/driver/pom.xml
+++ b/shims/emr770/driver/pom.xml
@@ -915,7 +915,6 @@
     <dependency>
       <groupId>org.pentaho.hadoop</groupId>
       <artifactId>pentaho-shaded-netty</artifactId>
-      <version>1.0.2</version>
     </dependency>
     <dependency>
       <groupId>org.apache.hbase</groupId>

--- a/shims/emr770/pmr/pom.xml
+++ b/shims/emr770/pmr/pom.xml
@@ -255,7 +255,6 @@
     <dependency>
       <groupId>org.pentaho.hadoop</groupId>
       <artifactId>pentaho-shaded-netty</artifactId>
-      <version>1.0.2</version>
       <exclusions>
         <exclusion>
           <groupId>*</groupId>

--- a/shims/hdi40/driver/pom.xml
+++ b/shims/hdi40/driver/pom.xml
@@ -485,7 +485,6 @@
     <dependency>
       <groupId>org.pentaho.hadoop</groupId>
       <artifactId>pentaho-shaded-netty</artifactId>
-      <version>1.0.2</version>
     </dependency>
     <dependency>
       <groupId>org.apache.hbase</groupId>


### PR DESCRIPTION
## Summary
Centralize `org.pentaho.hadoop:pentaho-shaded-netty` version ownership in the root dependency management and remove direct versions from eight active shim consumers.

## Validation
- `mvn -B -o -nsu validate`

## Dependency
Requires publication of `org.pentaho.hadoop:pentaho-shaded-netty:4.1.137.Final-pentaho-1` from the companion `third-party-libraries` change.