### PR TITLE
fix[PPP-6766]: bump parquet to 1.18.0

### DIFF
--- a/shims/apachevanilla/driver/pom.xml
+++ b/shims/apachevanilla/driver/pom.xml
@@ -29,14 +29,10 @@
     <failureaccess.version>1.0.1</failureaccess.version>
     <pentaho-osgi-bundles.version>11.1.0.0-SNAPSHOT</pentaho-osgi-bundles.version>
     <org.apache.avro.version>1.12.1</org.apache.avro.version>
-    <!-- PPP-6324: Override to 1.16.0 (scoped to apachevanilla only) to fix CVE-2026-29062
-         jackson-core shaded inside parquet-jackson/parquet-hadoop-bundle is safe (2.19.2) at 1.16.0+ -->
-    <parquet.version>1.16.0</parquet.version>
     <org.apache.hbase.version>2.6.2</org.apache.hbase.version>
     <org.apache.oozie.version>5.2.1</org.apache.oozie.version>
     <pig.version>0.17.0</pig.version>
     <hibernate.version>5.6.15.Final</hibernate.version>
-    <parquet-pig.version>1.15.2</parquet-pig.version>    <!-- PPP-6324: parquet-pig not released at 1.16.0 — keep at 1.15.2 (last available) -->
     <sqoop.version>1.4.7</sqoop.version>
     <vendor-driver.version>3.4.0</vendor-driver.version>
     <pentaho-code.version>11.0.0.0</pentaho-code.version>
@@ -909,8 +905,6 @@
       <artifactId>parquet-hadoop</artifactId>
       <version>${parquet.version}</version>
     </dependency>
-    <!-- BACKLOG-49729: Explicit parquet modules needed after removing parquet-hadoop-bundle (PPP-6324);
-         pins versions to 1.16.0 to override mediation from hive-exec/common-base which would resolve 1.15.2 -->
     <dependency>
       <groupId>org.apache.parquet</groupId>
       <artifactId>parquet-column</artifactId>

--- a/shims/cdpdc71/driver/pom.xml
+++ b/shims/cdpdc71/driver/pom.xml
@@ -35,10 +35,6 @@
     <org.apache.hbase.version>2.4.17.7.3.1.0-197</org.apache.hbase.version>
     <org.apache.hbase.thirdparty.version>4.1.10</org.apache.hbase.thirdparty.version>
     <org.apache.hive.version>3.1.3000.7.3.1.0-197</org.apache.hive.version>
-    <!-- PPP-6326: Override to 1.16.0 (scoped to cdpdc71 only) to fix CVE-2025-52999
-         jackson-core shaded inside parquet-jackson/parquet-hadoop-bundle is safe (2.19.2) at 1.16.0+ -->
-    <parquet.version>1.16.0</parquet.version>
-    <parquet-pig.version>1.15.2</parquet-pig.version>    <!-- PPP-6326: parquet-pig not released at 1.16.0 — keep at 1.15.2 (last available) -->
     <org.apache.oozie.version>5.1.0.7.3.1.0-197</org.apache.oozie.version>
     <pig.version>0.16.0.7.1.4.0-203</pig.version>
     <sqoop.version>1.4.7.7.3.1.0-197</sqoop.version>
@@ -1032,9 +1028,6 @@
       <artifactId>parquet-hadoop</artifactId>
       <version>${parquet.version}</version>
     </dependency>
-    <!-- PPP-6326: Explicit parquet modules needed after removing parquet-hadoop-bundle.
-         Without the bundle (fat JAR), these individual JARs must be present at runtime.
-         Version pinned to ${parquet.version} (1.16.0) to override hive-exec mediation (1.15.2). -->
     <dependency>
       <groupId>org.apache.parquet</groupId>
       <artifactId>parquet-column</artifactId>

--- a/shims/dataproc23/driver/pom.xml
+++ b/shims/dataproc23/driver/pom.xml
@@ -26,7 +26,6 @@
     <shim.id>dataproc23</shim.id>
     <curator.version>5.6.0</curator.version>
     <grpc-netty-shaded.version>1.80.0</grpc-netty-shaded.version>
-    <parquet-pig.version>1.15.2</parquet-pig.version>    <!-- parquet-pig not released at 1.17.1 — keep at 1.15.2 (last available) -->
   </properties>
 
   <dependencies>

--- a/shims/dataproc23/pom.xml
+++ b/shims/dataproc23/pom.xml
@@ -45,7 +45,6 @@
     <!-- pmr folder -->
     <commons-configuration.version>1.6</commons-configuration.version>
     <org.apache.hive.version>3.1.3</org.apache.hive.version>
-    <parquet.version>1.17.1</parquet.version>
     <org.antlr.version>3.5.2</org.antlr.version>
     <joda-time.version>2.9.9</joda-time.version>
 

--- a/shims/emr770/driver/pom.xml
+++ b/shims/emr770/driver/pom.xml
@@ -43,7 +43,6 @@
     <xalan.version>2.7.3</xalan.version>
     <hibernate.version>5.6.15.Final</hibernate.version>
     <nimbus-jose-jwt.version>9.37.4</nimbus-jose-jwt.version>
-    <parquet-pig.version>1.15.2</parquet-pig.version>    <!-- parquet-pig not released at 1.17.1 — keep at 1.15.2 (last available) -->
   </properties>
 
   <dependencies>

--- a/shims/emr770/pom.xml
+++ b/shims/emr770/pom.xml
@@ -23,7 +23,6 @@
 
   <properties>
     <pentaho-hadoop-shims.version>${project.version}</pentaho-hadoop-shims.version>
-    <parquet.version>1.17.1</parquet.version>
   </properties>
 
   <modules>

--- a/shims/pom.xml
+++ b/shims/pom.xml
@@ -19,6 +19,8 @@
   <xerces.version>2.8.1</xerces.version>
   <com.yammer.metrics.version>2.2.0</com.yammer.metrics.version>
   <org.safehaus.jug.version>2.0.0</org.safehaus.jug.version>
+  <parquet.version>1.18.0</parquet.version>
+  <parquet-pig.version>1.15.2</parquet-pig.version>  <!-- PPP-6324: parquet-pig not released at 1.18.0 — keep at 1.15.2 (last available) -->
   <com.codahale.metrics.version>3.0.1</com.codahale.metrics.version>
   <com.igormaznitsa.jcp.version>6.1.2</com.igormaznitsa.jcp.version>
   <bundle.export.version>8.0.513.cdh</bundle.export.version>


### PR DESCRIPTION
Because `parquet-jackson` `1.16.0` / `1.17.0` contains vulnerable `jackson-databind` classes (`2.19.x` and `2.21.3`), while `1.18.0` already contains classes from the safe version `2.22.1` of `jackson-databind`