### PR TITLE
[PPP-7061] Exclude jansi from the emr770 shim driver assembly (CVE-2026-8484)

### DIFF
--- a/shims/emr770/driver/src/main/assembly/zip.xml
+++ b/shims/emr770/driver/src/main/assembly/zip.xml
@@ -133,6 +133,7 @@
                 <exclude>*:jackson-mapper-asl:*</exclude>
                 <exclude>*:jakarta.activation:*</exclude>
                 <exclude>*:jakarta.servlet-api:*</exclude>
+                <exclude>*:jansi:*</exclude>
                 <exclude>*:java-util:*</exclude>
                 <exclude>*:java-xmlbuilder:*</exclude>
                 <exclude>*:javassist:*</exclude>
@@ -313,6 +314,7 @@
                 <exclude>*:jackson-mapper-asl:*</exclude>
                 <exclude>*:jakarta.activation:*</exclude>
                 <exclude>*:jakarta.servlet-api:*</exclude>
+                <exclude>*:jansi:*</exclude>
                 <exclude>*:java-util:*</exclude>
                 <exclude>*:java-xmlbuilder:*</exclude>
                 <exclude>*:javassist:*</exclude>


### PR DESCRIPTION
## CVE-2026-8484 -- `org.fusesource.jansi:jansi` in the `emr770` shim driver

Tracking: Jira **PPP-7061** | Build `pdia-master@11.1.0.0-376` | Xray `XRAY-1036986` (Medium, CWE-122)

### There is no fixed version -- so this removes the component instead of bumping it

CERT Polska is the assigning CNA (`sourceIdentifier: cvd@cert.pl`) and its advisory
(https://cert.pl/en/posts/2026/06/CVE-2026-8484/) states verbatim:

> **Vulnerable versions: All through 2.4.3**

`2.4.3` is the **latest** jansi release (2026-03-27) and it predates the advisory
(2026-06-16); there has been no release since. NVD carries no version ranges at all
(`configurations: []`), tags the CVE `unsupported-when-assigned`, and records "All versions
are believed to be vulnerable. This project is unmaintained at the time of CVE assignment."
OSV has no jansi advisory at all.

> [!WARNING]
> Xray reports `jansi:2.4.2` and `2.4.3` as clean. Per the CNA that is a **false negative** --
> its range model stops at 2.4.1. Bumping the version would turn the violation green while
> leaving the vulnerable code in place. This PR deliberately does **not** do that.

### The change

jansi is not declared anywhere first-party. It arrives transitively:

```
pentaho-hadoop-shims-emr770
 +- org.apache.hive:hive-service:4.2.0
 |  +- org.apache.hive:hive-common:4.2.0
 |  |  +- org.fusesource.jansi:jansi:2.4.0   <-- the flagged jar
```

Hive pulls jansi for its CLI/beeline console colouring, which a server-side shim driver
does not use.

**This repo already established the fix.** Of the five shims the parent POM actually builds
(`dataproc23`, `dataproc1421`, `cdpdc71`, `apachevanilla`, `emr770` -- `hdi40` is commented
out), **four already exclude `*:jansi:*` from both dependencySets. `emr770` was the only one
that did not** -- and it is exactly the one Xray flagged. `cdpdc71` even declares
`org.jline:jline-terminal-jansi` explicitly and still excludes the jansi jar from its
shipped zip, so this pattern is already proven in production.

So this is a 2-line omission fix, matching the sibling shims exactly.

### Proof (real builds, before and after)

`emr770/driver` is packaging-only (no `src/test`), so the gate is the shipped artifact.
Both are `mvn -B package -pl shims/emr770/driver` runs ending `BUILD SUCCESS`.

**Before** -- reproduces the Xray impact path from source:
```
221009  emr770/lib/jansi-2.4.0.jar
```

**After:**
```
(no jansi entry)
```

**Collateral check** -- full `unzip -l` file-list diff across all 465 entries:
```
225d224
< emr770/lib/jansi-2.4.0.jar
```

Exactly one entry removed, nothing else changed. `jline-3.30.15.jar` is retained, so jline's
own terminal handling is untouched -- only the vulnerable native-JNI provider jar is dropped.

### Scope -- this does not fully close CVE-2026-8484

The violation has a second, independent surface that this PR does **not** address: the Karaf
`system/` copy of `jansi 2.4.1` shipped in `pentaho-server{,-manual}-{ce,ee}`, which comes
from `pentaho/pentaho-karaf-assembly` (`<jansi.version>` feeding a start-level-8 entry in
`startup.properties`). With no fixed version to move to, that one needs a human product
decision and is escalated separately in pentaho/CodeMedic#113. The CVE clears only when both
surfaces land.

<!-- codemedic-remediation {"build": "pdia-master@11.1.0.0-376", "items": [{"cve": "CVE-2026-8484", "coordinate": "org.fusesource.jansi:jansi"}]} -->
