### PR TITLE
fix: Bump common-base avro libs to non vulnerable version 1.12.1 [PPP-6304]

### DIFF
--- a/common-base/pom.xml
+++ b/common-base/pom.xml
@@ -30,7 +30,7 @@
     <gateway-shell.version>1.0.0.3.0.0.0-1634</gateway-shell.version>
     <guava.version>32.1.2-jre</guava.version>
     <failureaccess.version>1.0.1</failureaccess.version>
-    <org.apache.avro.version>1.12.0</org.apache.avro.version>
+    <org.apache.avro.version>1.12.1</org.apache.avro.version>
     <awssdk.version>2.28.27</awssdk.version>
     <!-- client and default folders -->
     <gcs.version>hadoop2-1.9.17</gcs.version>


### PR DESCRIPTION
This pull request makes a minor update to the `common-base/pom.xml` file, upgrading the Apache Avro dependency from version 1.12.0 to 1.12.1. This is a routine dependency update to incorporate the latest fixes and improvements.

- Upgraded the `org.apache.avro` dependency from version 1.12.0 to 1.12.1 in `common-base/pom.xml`.

Missed from https://github.com/pentaho/pentaho-hadoop-shims/pull/1920


NOTE: In the context of the CVE that is being worked on, we are only bumping Avro versions from 1.12.0 to 1.12.1.
Not touching other versions of the lib that can be used.
