### PR TITLE
[PPP-5970] - fix(shims): strip the stale commons-lang3 descriptor from repacked jetty-runner (CVE-2025-48924 false positive)

### DIFF
--- a/shims/apachevanilla/driver/pom.xml
+++ b/shims/apachevanilla/driver/pom.xml
@@ -990,6 +990,7 @@
                   <exclude name="org/slf4j/**"/>
                   <!-- Strip shaded commons-lang3 bundled in jetty-runner; rely on commons-lang3 from the application/shim classpath (required by commons-configuration2). -->
                   <exclude name="org/apache/commons/lang3/**"/>
+                  <exclude name="META-INF/maven/org.apache.commons/commons-lang3/**"/>
                 </zip>
               </target>
             </configuration>

--- a/shims/cdpdc71/driver/pom.xml
+++ b/shims/cdpdc71/driver/pom.xml
@@ -1200,6 +1200,7 @@
                   <exclude name="org/slf4j/**"/>
                   <!-- Strip shaded commons-lang3 bundled in jetty-runner; rely on commons-lang3 from the application/shim classpath (required by commons-configuration2). -->
                   <exclude name="org/apache/commons/lang3/**"/>
+                  <exclude name="META-INF/maven/org.apache.commons/commons-lang3/**"/>
                 </zip>
               </target>
             </configuration>

--- a/shims/dataproc1421/driver/pom.xml
+++ b/shims/dataproc1421/driver/pom.xml
@@ -693,6 +693,7 @@
                   <exclude name="org/slf4j/**"/>
                   <!-- Strip shaded commons-lang3 bundled in jetty-runner; rely on commons-lang3 from the application/shim classpath (required by commons-configuration2). -->
                   <exclude name="org/apache/commons/lang3/**"/>
+                  <exclude name="META-INF/maven/org.apache.commons/commons-lang3/**"/>
                 </zip>
               </target>
             </configuration>

--- a/shims/dataproc23/driver/pom.xml
+++ b/shims/dataproc23/driver/pom.xml
@@ -714,6 +714,7 @@
                   <exclude name="org/slf4j/**"/>
                   <!-- Strip shaded commons-lang3 bundled in jetty-runner; rely on commons-lang3 from the application/shim classpath (required by commons-configuration2). -->
                   <exclude name="org/apache/commons/lang3/**"/>
+                  <exclude name="META-INF/maven/org.apache.commons/commons-lang3/**"/>
                 </zip>
               </target>
             </configuration>

--- a/shims/emr700/driver/pom.xml
+++ b/shims/emr700/driver/pom.xml
@@ -841,6 +841,7 @@
                   <exclude name="org/slf4j/**"/>
                   <!-- Strip shaded commons-lang3 bundled in jetty-runner; rely on commons-lang3 from the application/shim classpath (required by commons-configuration2). -->
                   <exclude name="org/apache/commons/lang3/**"/>
+                  <exclude name="META-INF/maven/org.apache.commons/commons-lang3/**"/>
                 </zip>
               </target>
             </configuration>

--- a/shims/emr770/driver/pom.xml
+++ b/shims/emr770/driver/pom.xml
@@ -1195,6 +1195,7 @@
                   <exclude name="org/slf4j/**"/>
                   <!-- Strip shaded commons-lang3 bundled in jetty-runner; rely on commons-lang3 from the application/shim classpath (required by commons-configuration2). -->
                   <exclude name="org/apache/commons/lang3/**"/>
+                  <exclude name="META-INF/maven/org.apache.commons/commons-lang3/**"/>
                 </zip>
               </target>
             </configuration>


### PR DESCRIPTION
## CVE-2025-48924 -- `org.apache.commons:commons-lang3` (Medium, CWE-674, CVSS 5.3)

Aliases: GHSA-j288-q9x7-2f5v · Advisory: [Uncontrolled Recursion in Apache Commons Lang](https://nvd.nist.gov/vuln/detail/CVE-2025-48924) (`ClassUtils.getClass(...)` can throw `StackOverflowError`; fixed in 3.18.0)

Tracking: Jira PPP-6975 / PPP-6568 / PPP-5970 · Build `pdia-master@11.1.0.0-386` · CodeMedic remediation

### TL;DR -- this is a false positive, and this PR makes the artifact tell the truth

**No dependency version changes.** The vulnerable code is *already* absent from the shipped jar; only a stale Maven descriptor claiming `3.17.0` was left behind, and that descriptor is what the scanner fingerprints.

### What is actually shipping

Since PPP-6540 (2026-07-18) each shim unpacks the vendored `jetty-runner` uber-jar, strips `org/apache/commons/lang3/**`, and repacks it -- relying on the standalone `commons-lang3-3.18.0.jar` shipped in the same `lib/`. That strip works. Verified against the **actually published** `pentaho-hadoop-shims-apachevanilla-11.1.0.0-386.zip` (and `-emr770-`):

| evidence | result |
|---|---|
| `org/apache/commons/lang3/*.class` in the shipped repacked jar | **0** |
| same count in the untouched vendor jar (negative control) | **395** |
| `ClassUtils` (the vulnerable class) | **absent** |
| `META-INF/maven/org.apache.commons/commons-lang3/pom.xml` (`version=3.17.0`) | **still present** |
| standalone `commons-lang3-3.18.0.jar` in the same `lib/` | **present** |

Xray's reported impact path points at that leftover descriptor character-for-character:

```
.../apachevanilla/lib/jetty-runner-9.4.57.v20241219.jar/META-INF/maven/org.apache.commons/commons-lang3/pom.xml
```

An upgrade cannot clear it: jetty-runner **9.4.58** (newest on the 9.4 line, and 9.4 is EOL) still bundles commons-lang3 **3.17.0**.

### The change

One line per shim, next to the existing strip, in all six poms that perform the repack (`apachevanilla`, `cdpdc71`, `dataproc1421`, `dataproc23`, `emr700`, `emr770`):

```xml
<exclude name="META-INF/maven/org.apache.commons/commons-lang3/**"/>
```

All six are patched rather than only the four currently flagged, because this repo has a documented history of per-shim exclude-list drift in both directions -- leaving an identical construct half-fixed re-creates the same false positive on the next scan.

### Proof -- packaging before/after

`mvn -B clean package -pl shims/apachevanilla/driver -DskipTests`, both BUILD SUCCESS (the `taglibs-standard:1.2.5` parent WARN is pre-existing and non-blocking):

| | before | after |
|---|---|---|
| repacked `jetty-runner` size | 12,677,942 B | 12,670,835 B |
| jar entries | 7,101 | **7,098** |
| `lang3` entries | 3 (descriptor only) | **0** |
| shim zip entry list (399 entries) | -- | **identical** |
| `Main-Class: org.eclipse.jetty.runner.Runner` | present | **present** |

Full jar entry diff is exactly the three descriptor entries and nothing else:

```
< META-INF/maven/org.apache.commons/commons-lang3/
< META-INF/maven/org.apache.commons/commons-lang3/pom.properties
< META-INF/maven/org.apache.commons/commons-lang3/pom.xml
```

The runtime classpath is byte-identical, so there is no behavioural surface to regress -- which is also why no new test accompanies this change; the meaningful assertion is the packaging diff above.

> **Reviewer note / gotcha:** a *non-clean* `package` reports BUILD SUCCESS but leaves the descriptor in place. Ant's `<zip>` treats the destfile as up to date when no *source* file changed and cannot see that the exclude list changed. Verify with `clean`.

### Scope

This PR addresses only the `3.17.0` (jetty-runner) path. The group's other member -- `commons-lang3-3.14.0.jar` under `pentaho-solutions/system/app-shell/lib/` -- is **already fixed on `pentaho/pentaho-app-shell` master** (commit `1d0dbe6`, 2026-08-18, moved to `provided` so it is no longer packaged) and is merely unreleased; it needs a PAS `0.1.15` release plus the `pentaho-platform-ee` pin bump, and is escalated separately. The `enterprise-local-license-server` path is vendor Revenera and already above the fix version.

Not auto-merged -- shim owners please review.

<!-- codemedic-remediation {"build": "pdia-master@11.1.0.0-386", "items": [{"cve": "CVE-2025-48924", "coordinate": "org.apache.commons:commons-lang3"}, {"cve": "XRAY-710140", "coordinate": "org.apache.commons:commons-lang3"}]} -->
