### PR TITLE
build[PPP-6968]: bump Apache Kerby to 2.1.2 for CVE-2026-57915

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -53,6 +53,7 @@
     <org.apache.orc.version>1.9.6</org.apache.orc.version>
     <hadoop-shaded-protobuf_3_25.version>1.3.0</hadoop-shaded-protobuf_3_25.version>
     <org.apache.hadoop.version>3.4.0</org.apache.hadoop.version>
+    <org.apache.kerby.version>2.1.2</org.apache.kerby.version>
     <shim-bundle-plugin.version>1.1</shim-bundle-plugin.version>
     <zookeeper.version>3.9.5</zookeeper.version>
     <snakeyaml.version>2.2</snakeyaml.version>
@@ -182,6 +183,16 @@
         <artifactId>junit</artifactId>
         <version>${junit.version}</version>
         <scope>test</scope>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.kerby</groupId>
+        <artifactId>kerb-simplekdc</artifactId>
+        <version>${org.apache.kerby.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.kerby</groupId>
+        <artifactId>kerb-core</artifactId>
+        <version>${org.apache.kerby.version}</version>
       </dependency>
       <dependency>
         <groupId>commons-io</groupId>


### PR DESCRIPTION
## CVE-2026-57915 -- `org.apache.kerby:kerb-server` 2.0.3 -> 2.1.2

Tracking: Jira **PPP-6968** | CodeMedic build `pdia-master@11.1.0.0-386` | Xray id `XRAY-1039276`

**High**, CVSS 7.3, CWE-304 / CWE-358. It is possible to bypass the Kerberos pre-authentication check in Apache Kerby by sending a PA-DATA with an unrecognized or unsupported type. Apache (the CNA) names **2.1.2** as the fix; vulnerable range is `< 2.1.2`.

> The CodeMedic dispatch payload said *"no fixed version available"*. That is wrong for this finding -- both the Xray ladder and the advisory agree a fix exists.

| version | Xray issues |
|---|---|
| 2.0.3 (shipped) | 1 -- CVE-2026-57915 High |
| 2.1.0 | 1 |
| 2.1.1 | 1 |
| **2.1.2** | **0** |

`2.1.2` is both the lowest clean rung and the latest release on the line, and all 15 Kerby family artifacts report 0 issues at it.

### The change

One property + two `<dependencyManagement>` entries in the shims root `pom.xml`.

Kerby is **not declared anywhere in the org** (0 hits for `org.apache.kerby` across `pentaho`) -- it is purely transitive, entering through exactly two points:

```
org.apache.hadoop:hadoop-common:3.4.0
├── org.apache.hadoop:hadoop-auth:3.4.0
│   └── org.apache.kerby:kerb-simplekdc:2.0.3   <-- entry 1
│       ├── kerb-client -> kerby-config, kerb-common -> kerb-crypto, kerb-util, token-provider
│       └── kerb-admin  -> kerb-server -> kerb-identity, kerby-xdr
└── org.apache.kerby:kerb-core:2.0.3            <-- entry 2
    └── kerby-pkix -> kerby-asn1, kerby-util
```

Managing those two cascades the **whole 15-artifact family**, so no leaf or driver pom needed touching and no per-shim override was introduced. The shims root is the correct highest *shared* definition point: Kerby is a Hadoop-stack-only concern, so it belongs beside `org.apache.hadoop.version` / `org.apache.hive.version` here rather than in the universal `org.pentaho:pentaho-parent-pom`, which no other repo would use for it.

### Proof the vulnerable version is gone

**Dependency tree, all five built shims, before -> after** (`mvn dependency:tree -Dincludes='org.apache.kerby:*'`):

| shim | before | after |
|---|---|---|
| apachevanilla | kerb-server **2.0.3** (+14 family) | **2.1.2** |
| cdpdc71 | 2.0.3 | **2.1.2** |
| dataproc23 | 2.0.3 | **2.1.2** |
| dataproc1421 | 2.0.3 | **2.1.2** |
| emr770 | 2.0.3 | **2.1.2** |

`2.0.3` is absent from every path in every shim. The ticket listed 4 impact paths; **`dataproc1421` also carried the vulnerable jar** and is fixed by the same change.

**Shipped artifact** -- `mvn -B clean package -pl shims/apachevanilla/driver`, full entry-list diff of the produced zip:

- 394 entries before, 394 after
- exactly **15 lines changed**: `kerb-{admin,client,common,core,crypto,identity,server,simplekdc,util}`, `kerby-{asn1,config,pkix,util,xdr}`, `token-provider`, all `2.0.3` -> `2.1.2`
- **zero** collateral additions or removals

**Tests** -- `mvn -B -pl common-base test`: **884 run, 0 failures, 0 errors, 3 skipped**.

### Why this upgrade is safe (binary compatibility, from the jars)

The consumer here is a **vendor jar**, not our code, so release notes are not evidence -- bytecode is.

1. **Entry-hash diff of all 15 artifacts, 2.0.3 -> 2.1.2: 0 classes removed**, 1 added (`kerby-asn1`).
2. **Full `javap -public` signature diff of all 15 artifacts.** Exactly **two** public members disappear family-wide, both on `kerb-server`'s `PreauthHandler`: `verify(KdcRequest, PaData)` changes return type **`void` -> `boolean`**. That *is* the CVE fix -- the KDC now reports whether pre-authentication actually verified rather than silently passing an unrecognized PA-DATA type. The only changed API is the vulnerable one.
3. **Nothing we ship binds it.** Of 555 jars on the shim classpath, only `hadoop-auth`, `hadoop-common` and `hadoop-client-api` reference `org/apache/kerby/` at all, through just two classes (`KerberosUtil`, `KDiag`). Neither touches the `kerb/server/` package or `PreauthHandler`. The only binders of that KDC SPI are Kerby's own `kerb-server` / `kerb-admin` / `kerb-simplekdc`, which move to 2.1.2 together in this bump.
4. **Descriptor-level check.** Hadoop binds 8 distinct Kerby members, all in `kerb-util` / `kerb-core` (`Keytab.loadKeytab`/`getPrincipals`/`getKeytabEntries`, `KeytabEntry.getKey`/`getKvno`/`getPrincipal`/`getTimestamp`, `EncryptionKey.getKeyType`, `PrincipalName.getName`). All are present with **identical descriptors** in 2.1.2.
5. **No second copy.** `hadoop-client-api-3.4.0.jar` bundles 0 Kerby classes, so there is no shaded copy left behind at 2.0.3.

### For the reviewer -- what is NOT covered

No new unit test is included, and that is deliberate rather than an omission: **no first-party code in the org calls the Kerby API**, so there is no call site a test could exercise and any test added here would assert nothing about this CVE. The residual risk is runtime behaviour *inside* the vendor Hadoop jars on a Kerberized cluster, which no build-time check can reach.

That is the same shape as **PPP-5579**, where a shim `lib/` change passed CI and still broke HDFS against a secured cluster. Please pair this with the usual secured-cluster validation (Apache Vanilla Kerberized / CDP Knox) before merge.

Per CodeMedic policy this PR is **not auto-merged** -- the repo owners decide. Clearance of the CVE is confirmed only by a later build re-analysis, not by this PR.

<!-- codemedic-remediation {"build": "pdia-master@11.1.0.0-386", "items": [{"cve": "CVE-2026-57915", "coordinate": "org.apache.kerby:kerb-server"}, {"cve": "XRAY-1039276", "coordinate": "org.apache.kerby:kerb-server"}]} -->
