### PR TITLE
[PPP-6948][PPP-6557] CVE-2026-45292: manage io.opentelemetry at 1.62.0 in four shims

### DIFF
--- a/shims/apachevanilla/pom.xml
+++ b/shims/apachevanilla/pom.xml
@@ -19,6 +19,18 @@
   </parent>
   <artifactId>pentaho-hadoop-shims-apachevanilla-reactor</artifactId>
   <packaging>pom</packaging>
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>io.opentelemetry</groupId>
+        <artifactId>opentelemetry-bom</artifactId>
+        <version>1.62.0</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
+
   <modules>
     <module>pmr</module>
     <module>driver</module>

--- a/shims/dataproc1421/pom.xml
+++ b/shims/dataproc1421/pom.xml
@@ -54,6 +54,18 @@
     <!-- Dependency for Pig -->
     <jython.version>2.5.3</jython.version>
   </properties>
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>io.opentelemetry</groupId>
+        <artifactId>opentelemetry-bom</artifactId>
+        <version>1.62.0</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
+
   <modules>
     <module>pmr</module>
     <module>driver</module>

--- a/shims/dataproc23/pom.xml
+++ b/shims/dataproc23/pom.xml
@@ -48,6 +48,18 @@
     <joda-time.version>2.9.9</joda-time.version>
 
   </properties>
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>io.opentelemetry</groupId>
+        <artifactId>opentelemetry-bom</artifactId>
+        <version>1.62.0</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
+
   <modules>
     <module>pmr</module>
     <module>driver</module>

--- a/shims/emr770/pmr/pom.xml
+++ b/shims/emr770/pmr/pom.xml
@@ -25,7 +25,7 @@
   <properties>
     <org.apache.hbase.version>2.6.2</org.apache.hbase.version>
     <org.apache.hbase.thirdparty.version>4.1.10</org.apache.hbase.thirdparty.version>
-    <io.opentelemetry.version>1.15.0</io.opentelemetry.version>
+    <io.opentelemetry.version>1.62.0</io.opentelemetry.version>
     <io.opentelemetry-semconv.version>1.15.0-alpha</io.opentelemetry-semconv.version>
   </properties>
 

--- a/shims/emr770/pom.xml
+++ b/shims/emr770/pom.xml
@@ -25,6 +25,18 @@
     <pentaho-hadoop-shims.version>${project.version}</pentaho-hadoop-shims.version>
   </properties>
 
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>io.opentelemetry</groupId>
+        <artifactId>opentelemetry-bom</artifactId>
+        <version>1.62.0</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
+
   <modules>
     <module>pmr</module>
     <module>driver</module>


### PR DESCRIPTION
## CVE-2026-45292 / `io.opentelemetry:opentelemetry-api`

- **Advisory:** CVE-2026-45292 (alias GHSA-rcgg-9c38-7xpx), Medium, CVSS 5.3, CWE-770.
  Parsing oversized W3C baggage causes unbounded memory/CPU allocation; because baggage is
  re-injected into every outgoing request, the effect fans out to downstream services.
- **Fixed version:** 1.62.0 (the only fixed release -- no patch backport exists on the
  1.15.x / 1.42.x / 1.52.x lines).
- **Build:** `pdia-master@11.1.0.0-392` -> `pentaho-big-data-ee-plugin` classifier zips.
- Jira: PPP-6948, PPP-6557. CodeMedic tracking: pentaho/CodeMedic#148.

### What changed

Imported `io.opentelemetry:opentelemetry-bom:1.62.0` into the `dependencyManagement` of the
**apachevanilla**, **dataproc23**, **dataproc1421** and **emr770** reactor poms, and bumped
`io.opentelemetry.version` in `shims/emr770/pmr/pom.xml` (that pmr ship-list pins the version
explicitly, so `dependencyManagement` alone would not move it).

Per-shim management matches this repo's existing convention for Hadoop-stack third-party
versions (`org.apache.orc.version`, `org.apache.hive.version`, `lz4-java.version` are all
pinned per shim rather than centrally).

### How OpenTelemetry enters (resolved, not assumed)

| shim | before | enters via |
|---|---|---|
| apachevanilla | api/context 1.15.0 | `org.apache.hbase:hbase-client:2.6.2` |
| dataproc1421 | api/context 1.15.0 | `org.apache.hbase:hbase-client:2.6.2` |
| dataproc23 | api/context 1.15.0 + sdk-* 1.42.1 | `hbase-client:2.6.2`; `gcs-connector` -> `google-cloud-storage:2.44.1` |
| emr770 | api/context/sdk/exporters 1.42.0 | `org.apache.hive:hive-service:4.2.0` |

`dataproc1421` is affected but appears in **no** Xray impact path (the EE plugin publishes only
four classifier zips), so it was picked up from the resolved trees rather than from the ticket.

### `cdpdc71` is deliberately NOT changed

`cdpdc71` resolves `opentelemetry-api:0.12.0` through Cloudera
`hbase-client:2.4.17.7.3.1.0-197`. Disassembling that jar shows 3 classes with 10 distinct
OpenTelemetry call sites, one of which is:

```
io.opentelemetry.api.OpenTelemetry.getGlobalTracer:(Ljava/lang/String;)Lio/opentelemetry/api/trace/Tracer;
```

`getGlobalTracer(String)` is a **static method present in 0.12.0 and removed across the 1.x
line** (replaced by `GlobalOpenTelemetry.getTracer`). Bumping `cdpdc71` would compile and test
clean and then throw `NoSuchMethodError` at runtime inside HBase tracing. Clearing that shim
needs a Cloudera HBase upgrade or a decision to stop shipping HBase tracing -- both product
decisions. Escalated in pentaho/CodeMedic#148.

### Compatibility evidence for the shims that DID change

Full `-protected` API surface of `opentelemetry-api` + `opentelemetry-context` extracted with
`javap` at each deployed version and at 1.62.0, then diffed for **removals**:

| upgrade | non-internal types removed | members removed from surviving types |
|---|---|---|
| 1.52.0 -> 1.62.0 | 0 | 0 |
| 1.42.0 -> 1.62.0 | 1 (`baggage.propagation.Parser$1`) | 1 (`Parser(String)` ctor) |
| 1.15.0 -> 1.62.0 | 2 (`Parser$1`, `PercentEscaper`) | 1 (`Parser(String)` ctor) |

`io.opentelemetry.api.baggage.propagation.Parser` is **package-private** in both the old and new
jars, so its constructor change is invisible to every consumer. The only delta on the 1.x lines
is the CVE fix itself.

First-party OpenTelemetry usage in this repo is two class literals in
`shims/cdpdc71/driver/.../HadoopShim.java` (`Span.class`, `ImplicitContextKeyed.class`) -- both
FQNs unchanged in 1.62.0, and that file is not touched by this PR.

### Proof -- dependency tree

`mvn dependency:tree -Dincludes='io.opentelemetry:*,io.opentelemetry.semconv:*'` on every driver.

Before:

```
apachevanilla  hbase-client:2.6.2 -> opentelemetry-api:1.15.0 -> opentelemetry-context:1.15.0
dataproc1421   hbase-client:2.6.2 -> opentelemetry-api:1.15.0 -> opentelemetry-context:1.15.0
dataproc23     hbase-client:2.6.2 -> opentelemetry-api:1.15.0
               google-cloud-storage:2.44.1 -> opentelemetry-sdk*:1.42.1
emr770         hive-service:4.2.0 -> opentelemetry-api:1.42.0, exporter-otlp/logging:1.42.0,
                                     sdk*/sdk-trace/metrics/logs:1.42.0
cdpdc71        hbase-client:2.4.17.7.3.1.0-197 -> opentelemetry-api:0.12.0   (unchanged, see above)
```

After: every `io.opentelemetry:*` artifact in apachevanilla, dataproc23, dataproc1421 and emr770
resolves at **1.62.0** -- api, context, common, sdk, sdk-trace, sdk-metrics, sdk-logs,
sdk-common, sdk-extension-autoconfigure(-spi), exporter-otlp(-common), exporter-common,
exporter-logging, exporter-sender-okhttp. `BUILD SUCCESS` on all five. **No vulnerable
`opentelemetry-api` remains on any path in the four shims this PR changes.**

### Proof -- shipped artifact

`mvn -B clean package -pl shims/apachevanilla/driver -DskipTests`, full zip entry list diffed
before vs after (`clean` is required here -- a non-clean rebuild can silently keep the old
artifact):

```
332,333c332,334
< apachevanilla/lib/opentelemetry-api-1.15.0.jar
< apachevanilla/lib/opentelemetry-context-1.15.0.jar
---
> apachevanilla/lib/opentelemetry-api-1.62.0.jar
> apachevanilla/lib/opentelemetry-common-1.62.0.jar
> apachevanilla/lib/opentelemetry-context-1.62.0.jar
```

396 -> 397 entries; the only additional entry is `opentelemetry-common`, which upstream split
out of `opentelemetry-context` after 1.15. Nothing else was added, dropped or renamed.

`opentelemetry-semconv-1.15.0-alpha.jar` is unchanged: it is a different coordinate
(later relocated to `io.opentelemetry.semconv`), is not managed by the non-alpha BOM, and is not
in this CVE's scope.

### Testing

These are driver/assembly modules with no unit tests, so the proof shape is the one this repo
uses for packaging changes: re-resolved dependency trees on all five shims plus a full
before/after entry-list diff of the built zip, both shown above. No first-party source changed,
so there is no behaviour to add a unit test for.

### Notes for reviewers

- Not auto-merged; this needs your review.
- The commit subject uses the mandated `[PPP-nnnn]` prefix. If a conventional-commits check is
  red because of it, that is expected and is flagged rather than worked around.
- Clearance is confirmed only when a later `pdia-master` build is re-analyzed and CVE-2026-45292
  is absent -- this PR is not self-certifying.

Generated by the CodeMedic remediator (operator-triggered run).

<!-- codemedic-remediation {"build": "pdia-master@11.1.0.0-392", "items": [{"cve": "CVE-2026-45292", "coordinate": "io.opentelemetry:opentelemetry-api"}, {"cve": "XRAY-983722", "coordinate": "io.opentelemetry:opentelemetry-api"}]} -->