### PR TITLE
fix: bump dataproc shims Apache Hive version for CVE-2026-55976 [PPP-7168]

### DIFF
--- a/shims/dataproc1421/driver/pom.xml
+++ b/shims/dataproc1421/driver/pom.xml
@@ -296,7 +296,7 @@
     <dependency>
       <groupId>org.apache.hive</groupId>
       <artifactId>hive-exec</artifactId>
-      <version>${org.apache.hive.version}</version>
+      <version>${hive-exec.version}</version>
       <exclusions>
         <exclusion>
           <groupId>*</groupId>
@@ -316,7 +316,7 @@
     <dependency>
       <groupId>org.apache.hive</groupId>
       <artifactId>hive-service</artifactId>
-      <version>${org.apache.hive.version}</version>
+      <version>${hive-service.version}</version>
       <exclusions>
         <exclusion>
           <groupId>*</groupId>
@@ -376,6 +376,11 @@
           <artifactId>zookeeper</artifactId>
         </exclusion>
       </exclusions>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.hive</groupId>
+      <artifactId>hive-serde</artifactId>
+      <version>${hive-serde.version}</version>
     </dependency>
 
     <dependency>

--- a/shims/dataproc1421/pom.xml
+++ b/shims/dataproc1421/pom.xml
@@ -36,7 +36,13 @@
     <pig.version>0.17.0</pig.version>
     <org.apache.oozie.version>4.3.1</org.apache.oozie.version>
     <sqoop.version>1.4.7</sqoop.version>
-    <hive-jdbc.version>2.3.6</hive-jdbc.version>
+    <!-- PPP-7168: [CVE-2026-55976] Shared Hive property kept on 4.2.0 because hive-service/hive-jdbc are not published on 4.2.1.
+         Use fine-grained overrides so only published artifacts are bumped to 4.2.1.
+         hive-serde v4.2.1 is needed for a security fix for SSRF in Avro SerDe schema.  -->
+    <hive-exec.version>4.2.1</hive-exec.version>
+    <hive-service.version>4.2.0</hive-service.version>
+    <hive-jdbc.version>4.2.0</hive-jdbc.version>
+    <hive-serde.version>4.2.1</hive-serde.version>
     <org.apache.avro.version>1.12.1</org.apache.avro.version>
     <hadoop-aws.version>2.9.2</hadoop-aws.version>
 
@@ -46,7 +52,7 @@
     <!-- pmr folder -->
     <org.apache.hbase-prefix-tree.version>2.0.0-alpha4</org.apache.hbase-prefix-tree.version>
     <geronimo-servlet_3.0_spec.version>1.0</geronimo-servlet_3.0_spec.version>
-    <org.apache.hive.version>3.1.3</org.apache.hive.version>
+    <org.apache.hive.version>4.2.0</org.apache.hive.version>
     <parquet.version>1.10.1</parquet.version>
     <org.antlr.version>3.5.2</org.antlr.version>
     <joda-time.version>2.9.9</joda-time.version>

--- a/shims/dataproc23/driver/pom.xml
+++ b/shims/dataproc23/driver/pom.xml
@@ -331,7 +331,7 @@
     <dependency>
       <groupId>org.apache.hive</groupId>
       <artifactId>hive-exec</artifactId>
-      <version>${org.apache.hive.version}</version>
+      <version>${hive-exec.version}</version>
       <exclusions>
         <exclusion>
           <groupId>*</groupId>
@@ -351,7 +351,7 @@
     <dependency>
       <groupId>org.apache.hive</groupId>
       <artifactId>hive-service</artifactId>
-      <version>${org.apache.hive.version}</version>
+      <version>${hive-service.version}</version>
       <exclusions>
         <exclusion>
           <groupId>*</groupId>
@@ -382,6 +382,11 @@
           <artifactId>zookeeper</artifactId>
         </exclusion>
       </exclusions>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.hive</groupId>
+      <artifactId>hive-serde</artifactId>
+      <version>${hive-serde.version}</version>
     </dependency>
     <!-- Temporary override; delete once hive-jdbc releases a version without these vulnerabilities. -->
     <dependency>

--- a/shims/dataproc23/pom.xml
+++ b/shims/dataproc23/pom.xml
@@ -36,14 +36,20 @@
     <pig.version>0.18.0</pig.version>
     <org.apache.oozie.version>5.2.1</org.apache.oozie.version>
     <sqoop.version>1.4.7</sqoop.version>
-    <hive-jdbc.version>3.1.3</hive-jdbc.version>
+    <!-- PPP-7168: [CVE-2026-55976] Shared Hive property kept on 4.2.0 because hive-service/hive-jdbc are not published on 4.2.1.
+         Use fine-grained overrides so only published artifacts are bumped to 4.2.1.
+         hive-serde v4.2.1 is needed for a security fix for SSRF in Avro SerDe schema.  -->
+    <hive-exec.version>4.2.1</hive-exec.version>
+    <hive-service.version>4.2.0</hive-service.version>
+    <hive-jdbc.version>4.2.0</hive-jdbc.version>
+    <hive-serde.version>4.2.1</hive-serde.version>
     <org.apache.avro.version>1.12.1</org.apache.avro.version>
 
     <!-- client and default folders -->
     <hadoop.version>3.3.6</hadoop.version>
 
     <!-- pmr folder -->
-    <org.apache.hive.version>3.1.3</org.apache.hive.version>
+    <org.apache.hive.version>4.2.0</org.apache.hive.version>
     <org.antlr.version>3.5.2</org.antlr.version>
     <joda-time.version>2.9.9</joda-time.version>
 


### PR DESCRIPTION
https://pentaho-eng.atlassian.net/browse/PPP-7168

This pull request updates the Hive dependencies for the `dataproc1421` and `dataproc23` shims to address a security vulnerability (SSRF in Avro SerDe schema, CVE-2026-55976) by introducing fine-grained version overrides. It ensures that only published and secure artifact versions are used, specifically bumping `hive-serde` to 4.2.1, while keeping other Hive components at compatible versions. The changes also update the dependency declarations in the respective Maven POM files to use the new version properties and add the required `hive-serde` dependency.

**Dependency version management and security fixes:**

* Added fine-grained Hive version properties (`hive-exec.version`, `hive-service.version`, `hive-jdbc.version`, `hive-serde.version`) in both `shims/dataproc1421/pom.xml` and `shims/dataproc23/pom.xml`, with `hive-serde` set to 4.2.1 to address CVE-2026-55976, and other Hive components set to the latest published compatible versions. [[1]](diffhunk://#diff-d64385defb89f85e1544e29523a815708310403514dd8c1fb78dc642e2c1fdc0L39-R45) [[2]](diffhunk://#diff-d64385defb89f85e1544e29523a815708310403514dd8c1fb78dc642e2c1fdc0L49-R55) [[3]](diffhunk://#diff-c6269ff190e13504a9d3b17b8c65ca1040b1a09ea9a73102839920dbaa2b8e93L39-R52)

* Updated the `org.apache.hive.version` property in both `shims/dataproc1421/pom.xml` and `shims/dataproc23/pom.xml` to 4.2.0 for consistency and compatibility with the new fine-grained overrides. [[1]](diffhunk://#diff-d64385defb89f85e1544e29523a815708310403514dd8c1fb78dc642e2c1fdc0L49-R55) [[2]](diffhunk://#diff-c6269ff190e13504a9d3b17b8c65ca1040b1a09ea9a73102839920dbaa2b8e93L39-R52)

**Maven dependency declaration updates:**

* Modified `shims/dataproc1421/driver/pom.xml` and `shims/dataproc23/driver/pom.xml` to reference the new fine-grained Hive version properties for `hive-exec` and `hive-service` dependencies instead of the previous shared property. [[1]](diffhunk://#diff-d841d92e0908a8d5e6a2fc92a1b7e2b66db6aeb13788856a19426ad253839456L299-R299) [[2]](diffhunk://#diff-d841d92e0908a8d5e6a2fc92a1b7e2b66db6aeb13788856a19426ad253839456L319-R319) [[3]](diffhunk://#diff-65b627e2e36d689a42a8091bdcd87db0f197894d6e5144ef9d2205bc751c2914L334-R334) [[4]](diffhunk://#diff-65b627e2e36d689a42a8091bdcd87db0f197894d6e5144ef9d2205bc751c2914L354-R354)

* Added the `hive-serde` dependency (version 4.2.1) to both `shims/dataproc1421/driver/pom.xml` and `shims/dataproc23/driver/pom.xml` to ensure the security fix is included. [[1]](diffhunk://#diff-d841d92e0908a8d5e6a2fc92a1b7e2b66db6aeb13788856a19426ad253839456R380-R384) [[2]](diffhunk://#diff-65b627e2e36d689a42a8091bdcd87db0f197894d6e5144ef9d2205bc751c2914R386-R390)