### PR TITLE
[PPP-7228][PPP-7229][PPP-7230] Manage zstd-jni at 1.5.7-14 (CVE-2026-87795, CVE-2026-87823, CVE-2026-87825)

### DIFF
--- a/common-base/src/test/java/org/pentaho/hadoop/shim/common/format/ZstdCodecBoundsTest.java
+++ b/common-base/src/test/java/org/pentaho/hadoop/shim/common/format/ZstdCodecBoundsTest.java
@@ -136,9 +136,9 @@ public class ZstdCodecBoundsTest {
    */
   @Test
   public void refusesToCloseDictionaryStillLoadedInAContext() {
-    byte[] dict = sampleDictionary();
-    ZstdDictCompress dictCompress = new ZstdDictCompress( dict, 3 );
-    try ( ZstdCompressCtx ctx = new ZstdCompressCtx() ) {
+    // declared first so try-with-resources closes it last, after the context has released it
+    try ( ZstdDictCompress dictCompress = new ZstdDictCompress( sampleDictionary(), 3 );
+          ZstdCompressCtx ctx = new ZstdCompressCtx() ) {
       ctx.loadDict( dictCompress );
       try {
         dictCompress.close();

--- a/common-base/src/test/java/org/pentaho/hadoop/shim/common/format/ZstdCodecBoundsTest.java
+++ b/common-base/src/test/java/org/pentaho/hadoop/shim/common/format/ZstdCodecBoundsTest.java
@@ -1,0 +1,155 @@
+/*! ******************************************************************************
+ *
+ * Pentaho
+ *
+ * Copyright (C) 2026 by Pentaho Canada Inc. : http://www.pentaho.com
+ *
+ * Use of this software is governed by the Business Source License included
+ * in the LICENSE.TXT file.
+ *
+ * Change Date: 2030-06-15
+ ******************************************************************************/
+
+
+package org.pentaho.hadoop.shim.common.format;
+
+import com.github.luben.zstd.Zstd;
+import com.github.luben.zstd.ZstdCompressCtx;
+import com.github.luben.zstd.ZstdDictCompress;
+import org.junit.Test;
+
+import java.nio.ByteBuffer;
+
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+/**
+ * Bounds and lifecycle guards for the zstd-jni native codec that Parquet and ORC use for
+ * ZSTD compression in the shims.
+ *
+ * <p>Each guard pins behaviour that only holds from zstd-jni 1.5.7-14 onward. On earlier
+ * versions the dictionary constructor accepts out-of-range offsets and reads native heap
+ * memory, and the other two cases terminate the JVM outright, so these tests also act as
+ * regression detectors for a downgrade of the managed zstd-jni version.</p>
+ */
+public class ZstdCodecBoundsTest {
+
+  private static byte[] sampleDictionary() {
+    byte[] dict = new byte[ 64 ];
+    for ( int i = 0; i < dict.length; i++ ) {
+      dict[ i ] = (byte) i;
+    }
+    return dict;
+  }
+
+  private static byte[] samplePayload() {
+    byte[] payload = new byte[ 4096 ];
+    for ( int i = 0; i < payload.length; i++ ) {
+      payload[ i ] = (byte) ( i % 31 );
+    }
+    return payload;
+  }
+
+  /** The codec must still work normally -- the guards below must not pass by breaking ZSTD. */
+  @Test
+  public void roundTripsPayloadThroughZstd() {
+    byte[] payload = samplePayload();
+    byte[] compressed = Zstd.compress( payload, 3 );
+    byte[] restored = Zstd.decompress( compressed, payload.length );
+    assertArrayEquals( payload, restored );
+  }
+
+  /** A dictionary built from a fully in-range window is still accepted and usable. */
+  @Test
+  public void acceptsInRangeDictionaryWindow() {
+    byte[] payload = samplePayload();
+    try ( ZstdDictCompress dictCompress = new ZstdDictCompress( sampleDictionary(), 8, 32, 3 );
+          ZstdCompressCtx ctx = new ZstdCompressCtx() ) {
+      ctx.loadDict( dictCompress );
+      byte[] compressed = ctx.compress( payload );
+      assertEquals( payload.length, Zstd.decompressedSize( compressed ) );
+    }
+  }
+
+  /** CVE-2026-87795: length running past the end of the dictionary array must be rejected. */
+  @Test
+  public void rejectsDictionaryLengthPastEndOfArray() {
+    assertRejectedDictionaryWindow( 32, 1024 );
+  }
+
+  /** CVE-2026-87795: a negative offset must be rejected rather than read backwards. */
+  @Test
+  public void rejectsNegativeDictionaryOffset() {
+    assertRejectedDictionaryWindow( -8, 16 );
+  }
+
+  /** CVE-2026-87795: a negative length must be rejected. */
+  @Test
+  public void rejectsNegativeDictionaryLength() {
+    assertRejectedDictionaryWindow( 0, -1 );
+  }
+
+  /** CVE-2026-87795: an offset past the end of the array must be rejected. */
+  @Test
+  public void rejectsDictionaryOffsetPastEndOfArray() {
+    assertRejectedDictionaryWindow( 128, 8 );
+  }
+
+  /** CVE-2026-87795: an offset+length pair that overflows int must be rejected. */
+  @Test
+  public void rejectsOverflowingDictionaryWindow() {
+    assertRejectedDictionaryWindow( Integer.MAX_VALUE, 8 );
+  }
+
+  private static void assertRejectedDictionaryWindow( int offset, int length ) {
+    byte[] dict = sampleDictionary();
+    try ( ZstdDictCompress ignored = new ZstdDictCompress( dict, offset, length, 3 ) ) {
+      fail( "expected an out-of-range dictionary window (offset=" + offset + ", length=" + length
+        + ") to be rejected, but the dictionary was constructed" );
+    } catch ( IllegalArgumentException expected ) {
+      // zstd-jni >= 1.5.7-14 validates the window instead of reading out of bounds
+    }
+  }
+
+  /**
+   * CVE-2026-87823: the direct-ByteBuffer frame-size native must bounds-check with 64-bit
+   * arithmetic. A negative offset near Integer.MIN_VALUE must report an error rather than
+   * read unmapped memory.
+   */
+  @Test
+  public void reportsErrorForNegativeDirectBufferFrameOffset() {
+    byte[] compressed = Zstd.compress( samplePayload(), 3 );
+    ByteBuffer buffer = ByteBuffer.allocateDirect( compressed.length );
+    buffer.put( compressed );
+    buffer.flip();
+
+    long size = Zstd.getDirectByteBufferFrameContentSize( buffer, Integer.MIN_VALUE + 8, compressed.length );
+
+    assertTrue( "expected an error sentinel for a negative frame offset but got " + size, size < 0 );
+  }
+
+  /**
+   * CVE-2026-87825: a dictionary that is still referenced by a compression context must not
+   * be closable, otherwise later compression reads freed native memory.
+   */
+  @Test
+  public void refusesToCloseDictionaryStillLoadedInAContext() {
+    byte[] dict = sampleDictionary();
+    ZstdDictCompress dictCompress = new ZstdDictCompress( dict, 3 );
+    try ( ZstdCompressCtx ctx = new ZstdCompressCtx() ) {
+      ctx.loadDict( dictCompress );
+      try {
+        dictCompress.close();
+        fail( "expected closing a dictionary that is still loaded in a context to be refused" );
+      } catch ( IllegalStateException expected ) {
+        // zstd-jni >= 1.5.7-14 holds the shared lock for as long as the context references it
+      }
+
+      byte[] payload = samplePayload();
+      byte[] compressed = ctx.compress( payload );
+      assertEquals( payload.length, Zstd.decompressedSize( compressed ) );
+    }
+  }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -57,10 +57,16 @@
     <zookeeper.version>3.9.5</zookeeper.version>
     <snakeyaml.version>2.2</snakeyaml.version>
     <dnsjava.version>3.6.0</dnsjava.version>
+    <zstd-jni.version>1.5.7-14</zstd-jni.version>
   </properties>
 
   <dependencyManagement>
     <dependencies>
+      <dependency>
+        <groupId>com.github.luben</groupId>
+        <artifactId>zstd-jni</artifactId>
+        <version>${zstd-jni.version}</version>
+      </dependency>
       <dependency>
         <groupId>pentaho</groupId>
         <artifactId>pentaho-hdfs-vfs</artifactId>


### PR DESCRIPTION
## CVE-2026-87795, CVE-2026-87823, CVE-2026-87825 -- `com.github.luben:zstd-jni`

| | |
|---|---|
| Severity | High -- CVSS 8.2 / 8.2 / 7.7 |
| CWE | CWE-125 (out-of-bounds read), CWE-190 (integer overflow), CWE-416 (use-after-free) |
| Advisory | fixed in **1.5.7-14** |
| Jira | PPP-7230, PPP-7229, PPP-7228 |
| Build | `pdia-master@11.1.0.0-402` |
| Tracking | pentaho/CodeMedic |

### What is wrong

`zstd-jni` before 1.5.7-14 has three native-memory defects:

- **CVE-2026-87795** -- the `ZstdDictCompress` constructor does not validate its offset/length, so an out-of-range window reads native heap memory into the compression dictionary.
- **CVE-2026-87823** -- three direct-`ByteBuffer` frame-size natives bounds-check with 32-bit signed arithmetic, so a negative offset near `Integer.MIN_VALUE` reads unmapped memory.
- **CVE-2026-87825** -- a dictionary is only shared-locked during the load call, so it can be closed while a stream or context still references it, leaving later operations on freed memory.

### Where it comes from

`zstd-jni` is **not declared anywhere first-party** in this repo -- it is transitive-only, via Parquet:

```
<shim>-driver -> org.apache.parquet:parquet-hadoop:1.18.0 -> com.github.luben:zstd-jni:1.5.7-11
dataproc1421 -> common-base -> org.apache.parquet:parquet-hadoop:1.15.2 -> com.github.luben:zstd-jni:1.5.6-6
```

Because every shim reaches it the same way, this pins it **once** in the root `dependencyManagement` rather than per driver.

> **Scope note.** The scan flagged `apachevanilla`, `cdpdc71`, `dataproc23` and `emr770` (all at 1.5.7-11). `dataproc1421` was **not** flagged but is an active/shipped shim resolving **1.5.6-6**, also inside the vulnerable range, so it is fixed here too -- the same catch as the earlier derby and json-io shim fixes.

### Dependency tree -- before / after

| Module | Before | After |
|---|---|---|
| `shims/apachevanilla/driver` | 1.5.7-11 | **1.5.7-14** |
| `shims/cdpdc71/driver` | 1.5.7-11 | **1.5.7-14** |
| `shims/dataproc23/driver` | 1.5.7-11 | **1.5.7-14** |
| `shims/emr770/driver` | 1.5.7-11 | **1.5.7-14** |
| `shims/dataproc1421/driver` | 1.5.6-6 | **1.5.7-14** |
| `common-base` | 1.5.6-6 | **1.5.7-14** |

No vulnerable version remains on any path.

### Why 1.5.7-14 and why it is safe

- 1.5.7-14 is the **lowest** version whose Xray issue list is empty (1.5.6-10, 1.5.7-11, 1.5.7-12 and 1.5.7-13 each still carry all three), and it matches the advisory's own "before 1.5.7-14". Deliberately not the latest (1.5.7-16).
- Jar delta 1.5.7-11 -> 1.5.7-14: **38 classes on both sides, none added, none removed**; identical set of 18 bundled native libraries including `linux/amd64`. A true drop-in.
- No first-party code calls the `com.github.luben` API -- it is reached only as a Parquet/ORC codec behind unchanged interfaces.

### Tests

`common-base/src/test/java/org/pentaho/hadoop/shim/common/format/ZstdCodecBoundsTest.java` adds 9 guards -- one per CVE plus bounds/misuse variants and two positive controls (a plain ZSTD round-trip and an in-range dictionary) so the guards cannot pass by breaking the codec.

These are **non-vacuous, proven against the vulnerable baseline**. Re-pinning to 1.5.7-11 and running the same test class:

```
[ERROR] The forked VM terminated without properly saying goodbye. VM crash or System.exit called?
[ERROR] Crashed tests: ...ZstdCodecBoundsTest
```

The JVM crash *is* the vulnerability (CVE-2026-87823/87825 terminate the JVM; the CVE-2026-87795 cases construct silently). On 1.5.7-14:

```
Tests run: 3,  ... PentahoOrcReadWriteTest
Tests run: 10, ... PentahoParquetOutputFormatTest
Tests run: 9,  ... ZstdCodecBoundsTest
Tests run: 22, Failures: 0, Errors: 0, Skipped: 0
BUILD SUCCESS
```

### Verification

Clearance is confirmed when a later `pdia-master` build is re-analyzed and the three CVEs are absent -- not at merge time.

<!-- codemedic-remediation {"build": "pdia-master@11.1.0.0-402", "items": [{"cve": "CVE-2026-87795", "coordinate": "com.github.luben:zstd-jni"}, {"cve": "XRAY-1075239", "coordinate": "com.github.luben:zstd-jni"}, {"cve": "CVE-2026-87823", "coordinate": "com.github.luben:zstd-jni"}, {"cve": "XRAY-1075242", "coordinate": "com.github.luben:zstd-jni"}, {"cve": "CVE-2026-87825", "coordinate": "com.github.luben:zstd-jni"}, {"cve": "XRAY-1075243", "coordinate": "com.github.luben:zstd-jni"}]} -->
